### PR TITLE
refactor: Remove hardcoded paths from benchmark scripts

### DIFF
--- a/benchmarking/benchmark-integration-wrk/pom.xml
+++ b/benchmarking/benchmark-integration-wrk/pom.xml
@@ -24,6 +24,9 @@
         <!-- Scripts location -->
         <integration.scripts.dir>${project.basedir}/../../cui-jwt-quarkus-parent/cui-jwt-quarkus-integration-tests/scripts</integration.scripts.dir>
 
+        <!-- Docker compose directory for WRK benchmarks -->
+        <integration.compose.dir>${project.basedir}/../../cui-jwt-quarkus-parent/cui-jwt-quarkus-integration-tests</integration.compose.dir>
+
         <!-- Integration test service URLs (host access via published ports) -->
         <integration.service.url>https://localhost:10443</integration.service.url>
         <keycloak.url>https://localhost:1443</keycloak.url>
@@ -180,6 +183,8 @@
                                 <WRK_CONNECTIONS>${wrk.connections}</WRK_CONNECTIONS>
                                 <WRK_DURATION>${wrk.duration}</WRK_DURATION>
                                 <WRK_TIMEOUT>${wrk.timeout}</WRK_TIMEOUT>
+                                <!-- Docker compose directory -->
+                                <COMPOSE_DIR>${integration.compose.dir}</COMPOSE_DIR>
                                 <!-- Service URL and network topology managed by docker-compose.yml -->
                             </environmentVariables>
                         </configuration>
@@ -214,6 +219,8 @@
                                 <WRK_CONNECTIONS>${wrk.connections}</WRK_CONNECTIONS>
                                 <WRK_DURATION>${wrk.duration}</WRK_DURATION>
                                 <WRK_TIMEOUT>${wrk.timeout}</WRK_TIMEOUT>
+                                <!-- Docker compose directory -->
+                                <COMPOSE_DIR>${integration.compose.dir}</COMPOSE_DIR>
                                 <!-- Service URL and network topology managed by docker-compose.yml -->
                             </environmentVariables>
                         </configuration>

--- a/benchmarking/benchmark-integration-wrk/src/main/resources/wrk-scripts/health_live_benchmark.sh
+++ b/benchmarking/benchmark-integration-wrk/src/main/resources/wrk-scripts/health_live_benchmark.sh
@@ -14,9 +14,8 @@ BENCHMARK_NAME="healthLiveCheck"
 # Service URL uses Docker service name (configured in docker-compose.yml)
 SERVICE_URL="https://cui-jwt-integration-tests:8443"
 
-# Get compose file directory (integration-tests directory)
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-COMPOSE_DIR="$SCRIPT_DIR/../../../../../../cui-jwt-quarkus-parent/cui-jwt-quarkus-integration-tests"
+# Get compose file directory from environment variable (passed by Maven)
+: "${COMPOSE_DIR:?ERROR: COMPOSE_DIR environment variable is not set}"
 
 # Record benchmark start time
 BENCHMARK_START_TIME=$(date +%s)

--- a/benchmarking/benchmark-integration-wrk/src/main/resources/wrk-scripts/jwt_benchmark.sh
+++ b/benchmarking/benchmark-integration-wrk/src/main/resources/wrk-scripts/jwt_benchmark.sh
@@ -21,9 +21,11 @@ BENCHMARK_NAME="jwtValidation"
 # Service URL uses Docker service name (configured in docker-compose.yml)
 SERVICE_URL="https://cui-jwt-integration-tests:8443"
 
-# Get script and compose directories
+# Get script directory for fetch_tokens.sh
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-COMPOSE_DIR="$SCRIPT_DIR/../../../../../../cui-jwt-quarkus-parent/cui-jwt-quarkus-integration-tests"
+
+# Get compose file directory from environment variable (passed by Maven)
+: "${COMPOSE_DIR:?ERROR: COMPOSE_DIR environment variable is not set}"
 
 # Record benchmark start time
 BENCHMARK_START_TIME=$(date +%s)


### PR DESCRIPTION
Address Gemini Code Assist review feedback by replacing brittle hardcoded relative paths with environment variable approach.

**Context**: This PR builds on the docker-compose integration (already merged to main) by addressing a maintainability concern raised during code review.

## Changes

- Add `integration.compose.dir` property in pom.xml
- Pass `COMPOSE_DIR` as environment variable to benchmark scripts  
- Update `health_live_benchmark.sh` to use `COMPOSE_DIR` env var
- Update `jwt_benchmark.sh` to use `COMPOSE_DIR` env var

## Benefits

✅ **More maintainable**: Decouples scripts from directory structure  
✅ **More robust**: Fails early with clear error if `COMPOSE_DIR` not set  
✅ **Easier to test**: Can override `COMPOSE_DIR` for different layouts

## Verification

Local benchmark test passed with new environment variable approach:
- Health endpoint: **53,853 req/s** (10s test)
- JWT validation: **18,096 req/s** (10s test)
- All result files generated correctly

## Review Feedback Addressed

This addresses the Gemini Code Assist suggestion from the original PR:
> The hardcoded relative path `../../../../../../...` is fragile and makes the script difficult to maintain. If the directory structure changes, this path will break. A more robust approach is to pass the directory path via an environment variable from the pom.xml.