### PR TITLE
fix(ci): skip sonar-build for Dependabot PRs

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -48,6 +48,7 @@ jobs:
 
   sonar-build:
     needs: build
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     steps:
@@ -105,7 +106,7 @@ jobs:
 
   deploy-snapshot:
     needs: sonar-build
-    if: github.ref == 'refs/heads/main'
+    if: always() && github.ref == 'refs/heads/main' && needs.sonar-build.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)


### PR DESCRIPTION
## Summary
- Skip `sonar-build` job when the actor is `dependabot[bot]`, since Dependabot PRs cannot access repository secrets (`SONAR_TOKEN`), causing every dependency update PR to fail at the Sonar analysis step
- Guard `deploy-snapshot` with `always()` + `needs.sonar-build.result == 'success'` so it correctly handles the skipped upstream job while still requiring successful Sonar analysis on main

## Context
All `build(deps)` PRs (#177, #179, #180, #181, and many older ones) fail the `sonar-build` check with:
```
Project not found. Please check the 'SONAR_TOKEN' environment variable
```
This is a GitHub security restriction — Dependabot PRs are intentionally denied access to repository secrets to prevent supply chain attacks. Sonar analysis still runs on the `main` branch push after merge.

## Test plan
- [ ] Verify this PR's own CI passes (sonar-build should run since actor is not dependabot)
- [ ] Verify next Dependabot PR shows sonar-build as skipped (not failed)
- [ ] Verify push to main after merge still runs sonar-build and deploy-snapshot normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)