### PR TITLE
fix(benchmarks): restore broken benchmark dashboard visuals

### DIFF
--- a/benchmarking/benchmark-core/pom.xml
+++ b/benchmarking/benchmark-core/pom.xml
@@ -32,6 +32,8 @@
         <jmh.threads>100</jmh.threads>
         <jmh.time>4s</jmh.time>
         <jmh.warmupTime>1s</jmh.warmupTime>
+        <!-- Benchmark history directory for trend analysis (passed from CI) -->
+        <benchmark.history.dir></benchmark.history.dir>
     </properties>
 
     <dependencyManagement>
@@ -228,6 +230,7 @@
                                 <argument>-Djmh.threads=${jmh.threads}</argument>
                                 <argument>-Djmh.time=${jmh.time}</argument>
                                 <argument>-Djmh.warmupTime=${jmh.warmupTime}</argument>
+                                <argument>-Dbenchmark.history.dir=${benchmark.history.dir}</argument>
                                 <argument>-Djava.util.logging.config.file=benchmark-logging.properties</argument>
                                 <argument>-XX:+UnlockDiagnosticVMOptions</argument>
                                 <argument>-XX:+DebugNonSafepoints</argument>

--- a/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/converter/JmhBenchmarkConverter.java
+++ b/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/converter/JmhBenchmarkConverter.java
@@ -176,9 +176,9 @@ public class JmhBenchmarkConverter implements BenchmarkConverter {
 
     private String formatScore(double score, String unit) {
         if (score >= 1000) {
-            return String.format(Locale.GERMAN, "%.1fK %s", score / 1000, unit);
+            return String.format(Locale.US, "%.1fK %s", score / 1000, unit);
         }
-        return String.format(Locale.GERMAN, "%.1f %s", score, unit);
+        return String.format(Locale.US, "%.1f %s", score, unit);
     }
 
     private int calculatePerformanceScore(double throughput, double latency) {

--- a/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/converter/WrkBenchmarkConverter.java
+++ b/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/converter/WrkBenchmarkConverter.java
@@ -265,16 +265,16 @@ public class WrkBenchmarkConverter implements BenchmarkConverter {
 
     private String formatThroughput(double reqPerSec) {
         if (reqPerSec >= 1000) {
-            return "%.1fK ops/s".formatted(reqPerSec / 1000);
+            return String.format(Locale.US, "%.1fK ops/s", reqPerSec / 1000);
         }
-        return "%.0f ops/s".formatted(reqPerSec);
+        return String.format(Locale.US, "%.0f ops/s", reqPerSec);
     }
 
     private String formatLatency(double ms) {
         if (ms < 1) {
-            return "%.0fμs".formatted(ms * 1000);
+            return String.format(Locale.US, "%.0fμs", ms * 1000);
         }
-        return "%.1fms".formatted(ms);
+        return String.format(Locale.US, "%.1fms", ms);
     }
 
     private int calculatePerformanceScore(double throughput, double latencyMs) {

--- a/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/jfr/JfrVarianceAnalyzer.java
+++ b/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/jfr/JfrVarianceAnalyzer.java
@@ -135,24 +135,24 @@ public class JfrVarianceAnalyzer {
                         LOGGER.info("  Total Operations: %s (Success: %s, Failed: %s)%n",
                                 metrics.totalOperations, metrics.successfulOperations, metrics.failedOperations);
                         LOGGER.info("  Latency (μs) - P50: %s, P95: %s, P99: %s, Max: %s%n",
-                                "%.2f".formatted(metrics.p50Latency / 1000.0),
-                                "%.2f".formatted(metrics.p95Latency / 1000.0),
-                                "%.2f".formatted(metrics.p99Latency / 1000.0),
-                                "%.2f".formatted(metrics.maxLatency / 1000.0));
+                                String.format(Locale.US, "%.2f", metrics.p50Latency / 1000.0),
+                                String.format(Locale.US, "%.2f", metrics.p95Latency / 1000.0),
+                                String.format(Locale.US, "%.2f", metrics.p99Latency / 1000.0),
+                                String.format(Locale.US, "%.2f", metrics.maxLatency / 1000.0));
                         LOGGER.info("  Variance: %s ns² (StdDev: %s μs)%n",
-                                "%.2e".formatted(metrics.variance),
-                                "%.2f".formatted(metrics.standardDeviation / 1000.0));
+                                String.format(Locale.US, "%.2e", metrics.variance),
+                                String.format(Locale.US, "%.2f", metrics.standardDeviation / 1000.0));
                         LOGGER.info("  Coefficient of Variation: %s%%%n",
-                                "%.2f".formatted(metrics.coefficientOfVariation));
+                                String.format(Locale.US, "%.2f", metrics.coefficientOfVariation));
                         LOGGER.info("  Max Concurrent Operations: %s%n", metrics.maxConcurrentOperations);
 
                         if (!metrics.statisticsSnapshots.isEmpty()) {
                             LOGGER.info("  Periodic Statistics:");
                             LOGGER.info("    Average CV over time: %s%%%n",
-                                    "%.2f".formatted(metrics.averageCV));
+                                    String.format(Locale.US, "%.2f", metrics.averageCV));
                             LOGGER.info("    CV Range: %s%% - %s%%%n",
-                                    "%.2f".formatted(metrics.minCV),
-                                    "%.2f".formatted(metrics.maxCV));
+                                    String.format(Locale.US, "%.2f", metrics.minCV),
+                                    String.format(Locale.US, "%.2f", metrics.maxCV));
                         }
 
                         LOGGER.info("");

--- a/benchmarking/benchmarking-common/src/main/resources/templates/detailed.html
+++ b/benchmarking/benchmarking-common/src/main/resources/templates/detailed.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Detailed Benchmark Analysis</title>
     <link rel="stylesheet" href="report-styles.css">
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.js"
-            integrity="sha384-iU8HYtnGQ8Cy4zl7gbNMOhsDTTKX02BTXptVP/vqAWIaTfM7isw76iyZCsjL2eVi"
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.js"
+            integrity="sha384-hfkuqrKeWFmnTMWN31VWyoe8xgdTADD11kgxmdpx2uyE6j5Az5uZq6u6AKYYmAOw"
             crossorigin="anonymous"></script>
     <script src="data-loader.js"></script>
 </head>

--- a/benchmarking/benchmarking-common/src/main/resources/templates/index.html
+++ b/benchmarking/benchmarking-common/src/main/resources/templates/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>CUI JWT Benchmarking Results</title>
     <link rel="stylesheet" href="report-styles.css">
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.js"
-            integrity="sha384-iU8HYtnGQ8Cy4zl7gbNMOhsDTTKX02BTXptVP/vqAWIaTfM7isw76iyZCsjL2eVi"
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.js"
+            integrity="sha384-hfkuqrKeWFmnTMWN31VWyoe8xgdTADD11kgxmdpx2uyE6j5Az5uZq6u6AKYYmAOw"
             crossorigin="anonymous"></script>
     <script src="data-loader.js"></script>
 </head>

--- a/benchmarking/benchmarking-common/src/main/resources/templates/trends.html
+++ b/benchmarking/benchmarking-common/src/main/resources/templates/trends.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Performance Trends</title>
     <link rel="stylesheet" href="report-styles.css">
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.js"
-            integrity="sha384-iU8HYtnGQ8Cy4zl7gbNMOhsDTTKX02BTXptVP/vqAWIaTfM7isw76iyZCsjL2eVi"
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.js"
+            integrity="sha384-hfkuqrKeWFmnTMWN31VWyoe8xgdTADD11kgxmdpx2uyE6j5Az5uZq6u6AKYYmAOw"
             crossorigin="anonymous"></script>
     <script src="data-loader.js"></script>
 </head>

--- a/benchmarking/benchmarking-common/src/test/java/de/cuioss/benchmarking/common/converter/JmhBenchmarkConverterTest.java
+++ b/benchmarking/benchmarking-common/src/test/java/de/cuioss/benchmarking/common/converter/JmhBenchmarkConverterTest.java
@@ -106,8 +106,8 @@ class JmhBenchmarkConverterTest {
         assertEquals("ops/s", healthCheck.getScoreUnit());
 
         // Score should be converted: 9.95 ops/ms = 9,952 ops/s
-        assertEquals("10,0K ops/s", healthCheck.getScore());
-        assertEquals("10,0K ops/s", healthCheck.getThroughput());
+        assertEquals("10.0K ops/s", healthCheck.getScore());
+        assertEquals("10.0K ops/s", healthCheck.getThroughput());
 
         // Test JWT validation benchmark
         BenchmarkData.Benchmark jwtValidation = result.getBenchmarks().get(1);
@@ -120,12 +120,12 @@ class JmhBenchmarkConverterTest {
         assertEquals("ops/s", jwtValidation.getScoreUnit());
 
         // Score should be converted: 8.12 ops/ms = 8,117 ops/s
-        assertEquals("8,1K ops/s", jwtValidation.getScore());
-        assertEquals("8,1K ops/s", jwtValidation.getThroughput());
+        assertEquals("8.1K ops/s", jwtValidation.getScore());
+        assertEquals("8.1K ops/s", jwtValidation.getThroughput());
 
         // Test overview
         BenchmarkData.Overview overview = result.getOverview();
-        assertEquals("10,0K ops/s", overview.getThroughput());
+        assertEquals("10.0K ops/s", overview.getThroughput());
         assertEquals("healthCheckThroughput", overview.getThroughputBenchmarkName());
     }
 
@@ -172,8 +172,8 @@ class JmhBenchmarkConverterTest {
 
         // Latency units should remain unchanged
         assertEquals("ms/op", latencyBenchmark.getScoreUnit());
-        assertEquals("2,1 ms/op", latencyBenchmark.getScore());
-        assertEquals("2,1 ms/op", latencyBenchmark.getLatency());
+        assertEquals("2.1 ms/op", latencyBenchmark.getScore());
+        assertEquals("2.1 ms/op", latencyBenchmark.getLatency());
         assertNull(latencyBenchmark.getThroughput());
     }
 
@@ -207,7 +207,7 @@ class JmhBenchmarkConverterTest {
 
         BenchmarkData.Benchmark benchmark = result.getBenchmarks().getFirst();
         assertEquals("ops/s", benchmark.getScoreUnit());
-        assertEquals("1,0K ops/s", benchmark.getScore());
+        assertEquals("1.0K ops/s", benchmark.getScore());
     }
 
     @Test


### PR DESCRIPTION
## Summary

- **Fix Chart.js SRI hash mismatch**: Pin `chart.js@4.5.1` and update integrity hash in all 3 HTML templates (`index.html`, `trends.html`, `detailed.html`) — charts were completely blocked by the browser
- **Forward `benchmark.history.dir` to micro benchmark JVM**: Add missing property and `-D` argument in `benchmark-core/pom.xml` exec plugin so CI-provided history directory reaches the spawned process — trend data was always "unavailable"
- **Standardize number formatting to `Locale.US`**: Replace `Locale.GERMAN` and default-locale `.formatted()` calls with `String.format(Locale.US, ...)` across `JmhBenchmarkConverter`, `WrkBenchmarkConverter`, and `JfrVarianceAnalyzer` — corrupt history data with comma decimal separators
- **Clear corrupt history data**: Deleted 17 German-locale history JSON files from `cuioss.github.io` (already pushed separately)

## Test plan

- [x] All 181 unit tests pass in `benchmarking-common` (`mvnw clean verify`)
- [x] Zero `Locale.GERMAN` references remain in benchmarking code
- [x] No numeric `.formatted()` calls remain in production code
- [ ] Verify dashboard renders charts after next CI benchmark run
- [ ] Verify trend data populates after two successive benchmark runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)