### PR TITLE
chore: configure dependency propagation

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -26,3 +26,11 @@ pages:
 github-automation:
   auto-merge-build-versions: true
   auto-merge-build-timeout: 300
+
+consumers:
+  - nifi-extensions:version.oauth-sheriff
+
+dependency-propagation:
+  group-id: de.cuioss.sheriff.oauth
+  artifact-id: oauth-sheriff-core
+  scope: dependency


### PR DESCRIPTION
## Summary
- Add `consumers` and `dependency-propagation` config to `project.yml`
- On release, propagates version to `nifi-extensions` (property `version.oauth-sheriff`)

## Test plan
- [ ] CI build passes (config-only change to project.yml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)