### PR TITLE
fix: benchmark overview displays latency as 2.0ms instead of 2.0K us/op

### DIFF
--- a/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/converter/JmhBenchmarkConverter.java
+++ b/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/converter/JmhBenchmarkConverter.java
@@ -21,6 +21,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import de.cuioss.benchmarking.common.config.BenchmarkType;
 import de.cuioss.benchmarking.common.model.BenchmarkData;
+import de.cuioss.benchmarking.common.report.MetricConversionUtil;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -172,7 +173,7 @@ public class JmhBenchmarkConverter implements BenchmarkConverter {
 
         return BenchmarkData.Overview.builder()
                 .throughput(bestThroughput.map(BenchmarkData.Benchmark::getScore).orElse("N/A"))
-                .latency(bestLatency.map(BenchmarkData.Benchmark::getScore).orElse("N/A"))
+                .latency(latency > 0 ? MetricConversionUtil.formatLatency(latency) : "N/A")
                 .throughputOpsPerSec(throughput)  // Store numeric value used for score calculation
                 .latencyMs(latency)               // Store numeric value used for score calculation
                 .throughputBenchmarkName(bestThroughput.map(BenchmarkData.Benchmark::getName).orElse(""))


### PR DESCRIPTION
## Summary
- Fix latency display in benchmark overview: uses `MetricConversionUtil.formatLatency()` instead of raw `formatScore()` output
- `formatScore()` applies K/M notation to any value >= 1000, producing nonsensical "2.0K us/op" for latency — now correctly shows "2.0ms"
- The `latency` variable (already converted to ms at lines 158-168) is passed directly to `formatLatency()`

## Test plan
- [x] All 181 tests in `benchmarking-common` pass
- [ ] Verify benchmark overview page shows "2.0ms" format after next GitHub Pages deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)