### PR TITLE
fix: latency percentile chart shows seconds instead of milliseconds

### DIFF
--- a/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/converter/JmhBenchmarkConverter.java
+++ b/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/converter/JmhBenchmarkConverter.java
@@ -103,9 +103,17 @@ public class JmhBenchmarkConverter implements BenchmarkConverter {
             JsonObject scorePercentiles = primaryMetric.getAsJsonObject("scorePercentiles");
             for (Map.Entry<String, JsonElement> entry : scorePercentiles.entrySet()) {
                 double percentileValue = entry.getValue().getAsDouble();
-                // Apply same conversion to percentiles
+                // Apply same unit conversions to percentiles
                 if (THRPT.equals(mode) && "ops/ms".equals(scoreUnit)) {
                     percentileValue = percentileValue * 1000;
+                } else {
+                    // Convert latency percentiles to milliseconds
+                    percentileValue = switch (scoreUnit) {
+                        case "us/op" -> percentileValue / 1000.0;
+                        case "ns/op" -> percentileValue / 1_000_000.0;
+                        case "s/op" -> percentileValue * 1000.0;
+                        default -> percentileValue;
+                    };
                 }
                 percentiles.put(entry.getKey(), percentileValue);
             }


### PR DESCRIPTION
## Summary
- Latency percentiles chart Y-axis displayed "1.85s", "2.42s" instead of "1.85ms", "2.42ms"
- Root cause: JMH percentile values in microseconds (e.g. 1847 us/op) were stored as-is in the JSON, but the chart JS formatter assumes milliseconds — treating 1847 as "1847ms" → "1.85s"
- Fix: convert latency percentiles to milliseconds in `JmhBenchmarkConverter`, matching the existing conversion for the overview latency (lines 158-168)
- Throughput percentile conversion (ops/ms → ops/s) is unchanged

## Test plan
- [x] All 181 tests in `benchmarking-common` pass
- [ ] After next benchmark run, verify chart Y-axis shows "1.85ms" format instead of "1.85s"

🤖 Generated with [Claude Code](https://claude.com/claude-code)