### PR TITLE
refactor: introduce TokenValidationRequest parameter objects

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -183,7 +183,7 @@ TokenValidator validator = TokenValidator.builder()
     .build();
 
 // Validate token
-AccessTokenContent accessToken = validator.createAccessToken(tokenString);
+AccessTokenContent accessToken = validator.createAccessToken(AccessTokenRequest.of(tokenString));
 ----
 
 == Core Features

--- a/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/oauth/core/benchmark/delegates/BenchmarkDelegate.java
+++ b/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/oauth/core/benchmark/delegates/BenchmarkDelegate.java
@@ -17,6 +17,7 @@ package de.cuioss.sheriff.oauth.core.benchmark.delegates;
 
 import de.cuioss.sheriff.oauth.core.TokenValidator;
 import de.cuioss.sheriff.oauth.core.benchmark.MockTokenRepository;
+import de.cuioss.sheriff.oauth.core.domain.context.AccessTokenRequest;
 import de.cuioss.sheriff.oauth.core.domain.token.AccessTokenContent;
 import de.cuioss.sheriff.oauth.core.exception.TokenValidationException;
 
@@ -45,7 +46,7 @@ public abstract class BenchmarkDelegate {
      * @throws TokenValidationException if validation fails
      */
     protected AccessTokenContent validateToken(String token) throws TokenValidationException {
-        return tokenValidator.createAccessToken(token);
+        return tokenValidator.createAccessToken(AccessTokenRequest.of(token));
     }
 
 }

--- a/doc/specification/testing.adoc
+++ b/doc/specification/testing.adoc
@@ -329,7 +329,7 @@ void shouldRejectAccessTokenWithInvalidSignature(String token) {
 
     // Verify that the tampered token is rejected by throwing TokenValidationException
     assertThrows(TokenValidationException.class, () -> {
-        tokenValidator.createAccessToken(tamperedToken);
+        tokenValidator.createAccessToken(AccessTokenRequest.of(tamperedToken));
     }, "Token with invalid signature should be rejected with TokenValidationException");
 }
 ----
@@ -399,7 +399,7 @@ void shouldRejectAccessTokenWithInvalidSignature(String token) {
 
     // Verify that the tampered token is rejected by throwing TokenValidationException
     TokenValidationException exception = assertThrows(TokenValidationException.class, () -> {
-        tokenValidator.createAccessToken(tamperedToken);
+        tokenValidator.createAccessToken(AccessTokenRequest.of(tamperedToken));
     }, "Token with invalid signature should be rejected with TokenValidationException");
 
     // Verify that the exception contains the correct event type and category

--- a/oauth-sheriff-core/README.adoc
+++ b/oauth-sheriff-core/README.adoc
@@ -34,7 +34,7 @@ TokenValidator tokenValidator = TokenValidator.builder()
 
 // Validate and create token (throws TokenValidationException if invalid)
 try {
-    AccessTokenContent token = tokenValidator.createAccessToken(jwtString);
+    AccessTokenContent token = tokenValidator.createAccessToken(AccessTokenRequest.of(jwtString));
     String subject = token.getSubject();
     List<String> roles = token.getRoles();
 } catch (TokenValidationException e) {

--- a/oauth-sheriff-core/doc/UnitTesting.adoc
+++ b/oauth-sheriff-core/doc/UnitTesting.adoc
@@ -171,7 +171,7 @@ void shouldTestWithAccessToken(TestTokenHolder tokenHolder) {
     AccessTokenContent result = TokenValidator.builder()
             .issuerConfig(tokenHolder.getIssuerConfig())
             .build()
-            .createAccessToken(token);
+            .createAccessToken(AccessTokenRequest.of(token));
 
     // Then
     assertNotNull(result, "Token should be parsed successfully");
@@ -204,7 +204,7 @@ void shouldTestWithMultipleAccessTokens(TestTokenHolder tokenHolder) {
     AccessTokenContent result = TokenValidator.builder()
             .issuerConfig(tokenHolder.getIssuerConfig())
             .build()
-            .createAccessToken(token);
+            .createAccessToken(AccessTokenRequest.of(token));
 
     // Then
     assertNotNull(result, "Token should be parsed successfully");
@@ -227,7 +227,7 @@ void shouldValidateToken() {
     AccessTokenContent result = TokenValidator.builder()
             .issuerConfig(tokenHolder.getIssuerConfig())
             .build()
-            .createAccessToken(token);
+            .createAccessToken(AccessTokenRequest.of(token));
 
     // Assert
     assertNotNull(result);
@@ -263,7 +263,7 @@ void shouldRejectTokenWithMissingClaims() {
 
     // Act/Assert
     TokenValidationException exception = assertThrows(TokenValidationException.class,
-        () -> validator.createAccessToken(token));
+        () -> validator.createAccessToken(AccessTokenRequest.of(token)));
 
     assertEquals(SecurityEventCounter.EventType.MISSING_CLAIM, exception.getEventType());
 }

--- a/oauth-sheriff-core/doc/api-reference.adoc
+++ b/oauth-sheriff-core/doc/api-reference.adoc
@@ -22,9 +22,9 @@ public class TokenValidator {
 
     // Token creation methods (performs validation and returns validated token)
     // These methods throw TokenValidationException if validation fails
-    public AccessTokenContent createAccessToken(String token);
-    public IdTokenContent createIdToken(String token);
-    public RefreshTokenContent createRefreshToken(String token);
+    public AccessTokenContent createAccessToken(AccessTokenRequest request);
+    public IdTokenContent createIdToken(IdTokenRequest request);
+    public RefreshTokenContent createRefreshToken(RefreshTokenRequest request);
 ----
 
 === AccessTokenContent

--- a/oauth-sheriff-core/doc/configuration/multi-issuer-setup.adoc
+++ b/oauth-sheriff-core/doc/configuration/multi-issuer-setup.adoc
@@ -39,7 +39,7 @@ TokenValidator tokenValidator = TokenValidator.builder()
     .build();
 
 // Validator automatically selects correct issuer based on token's "iss" claim
-AccessTokenContent token = tokenValidator.createAccessToken(jwtString);
+AccessTokenContent token = tokenValidator.createAccessToken(AccessTokenRequest.of(jwtString));
 ----
 
 == Issuer Detection
@@ -188,7 +188,7 @@ public class DynamicTokenValidator {
     }
 
     public AccessTokenContent validate(String token) throws TokenValidationException {
-        return validator.createAccessToken(token);
+        return validator.createAccessToken(AccessTokenRequest.of(token));
     }
 }
 ----

--- a/oauth-sheriff-core/doc/usage-guide.adoc
+++ b/oauth-sheriff-core/doc/usage-guide.adoc
@@ -24,7 +24,7 @@ TokenValidator tokenValidator = TokenValidator.builder()
 
 // Validate and create token (throws TokenValidationException if invalid)
 try {
-    AccessTokenContent token = tokenValidator.createAccessToken(jwtString);
+    AccessTokenContent token = tokenValidator.createAccessToken(AccessTokenRequest.of(jwtString));
     String subject = token.getSubject();
     List<String> roles = token.getRoles();
 } catch (TokenValidationException e) {
@@ -51,8 +51,8 @@ TokenValidator tokenValidator = TokenValidator.builder()
     .build();
 
 // Subsequent validations of the same token are cached
-AccessTokenContent token1 = tokenValidator.createAccessToken(jwtString);
-AccessTokenContent token2 = tokenValidator.createAccessToken(jwtString); // From cache
+AccessTokenContent token1 = tokenValidator.createAccessToken(AccessTokenRequest.of(jwtString));
+AccessTokenContent token2 = tokenValidator.createAccessToken(AccessTokenRequest.of(jwtString)); // From cache
 ----
 
 == Multi-Issuer Configuration
@@ -73,7 +73,7 @@ TokenValidator tokenValidator = TokenValidator.builder()
     .build();
 
 // Validator automatically selects correct issuer based on token
-AccessTokenContent token = tokenValidator.createAccessToken(jwtString);
+AccessTokenContent token = tokenValidator.createAccessToken(AccessTokenRequest.of(jwtString));
 ----
 
 == OpenID Connect Discovery
@@ -163,7 +163,7 @@ TokenValidator validator = TokenValidator.builder()
     .build();
 
 // Token claims are automatically mapped
-AccessTokenContent token = validator.createAccessToken(jwtString);
+AccessTokenContent token = validator.createAccessToken(AccessTokenRequest.of(jwtString));
 Set<String> roles = token.getRoles(); // From realm_access/roles
 Set<String> groups = token.getGroups(); // From groups claim
 ----

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/context/AccessTokenRequest.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/context/AccessTokenRequest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.oauth.core.domain.context;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Request object for access token validation, carrying the token string and HTTP headers.
+ * <p>
+ * This record is immutable and thread-safe. The HTTP headers map is defensively copied
+ * at construction time.
+ * <p>
+ * Usage:
+ * <pre>
+ * // Without HTTP headers (test/simple scenarios)
+ * AccessTokenRequest request = AccessTokenRequest.of(tokenString);
+ *
+ * // With HTTP headers (production scenarios with DPoP support)
+ * AccessTokenRequest request = new AccessTokenRequest(tokenString, httpHeaders);
+ * </pre>
+ *
+ * @param tokenString the raw token string, must not be null
+ * @param httpHeaders the HTTP headers from the original request, defensively copied
+ * @since 1.0
+ */
+public record AccessTokenRequest(String tokenString, Map<String, List<String>> httpHeaders)
+        implements TokenValidationRequest {
+
+    /**
+     * Compact constructor that validates inputs and creates defensive copies.
+     *
+     * @param tokenString the raw token string, must not be null
+     * @param httpHeaders the HTTP headers, must not be null (may be empty)
+     */
+    public AccessTokenRequest {
+        Objects.requireNonNull(tokenString, "tokenString must not be null");
+        Objects.requireNonNull(httpHeaders, "httpHeaders must not be null");
+        httpHeaders = Map.copyOf(httpHeaders);
+    }
+
+    /**
+     * Convenience factory for creating a request without HTTP headers.
+     * <p>
+     * Suitable for test scenarios or callers that do not have access to HTTP context.
+     *
+     * @param tokenString the raw token string, must not be null
+     * @return a new AccessTokenRequest with an empty header map
+     */
+    public static AccessTokenRequest of(String tokenString) {
+        return new AccessTokenRequest(tokenString, Map.of());
+    }
+}

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/context/IdTokenRequest.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/context/IdTokenRequest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.oauth.core.domain.context;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Request object for ID token validation, carrying the token string and HTTP headers.
+ * <p>
+ * This record is immutable and thread-safe. The HTTP headers map is defensively copied
+ * at construction time.
+ * <p>
+ * Usage:
+ * <pre>
+ * // Without HTTP headers (typical scenario)
+ * IdTokenRequest request = IdTokenRequest.of(tokenString);
+ *
+ * // With HTTP headers
+ * IdTokenRequest request = new IdTokenRequest(tokenString, httpHeaders);
+ * </pre>
+ *
+ * @param tokenString the raw token string, must not be null
+ * @param httpHeaders the HTTP headers from the original request, defensively copied
+ * @since 1.0
+ */
+public record IdTokenRequest(String tokenString, Map<String, List<String>> httpHeaders)
+        implements TokenValidationRequest {
+
+    /**
+     * Compact constructor that validates inputs and creates defensive copies.
+     *
+     * @param tokenString the raw token string, must not be null
+     * @param httpHeaders the HTTP headers, must not be null (may be empty)
+     */
+    public IdTokenRequest {
+        Objects.requireNonNull(tokenString, "tokenString must not be null");
+        Objects.requireNonNull(httpHeaders, "httpHeaders must not be null");
+        httpHeaders = Map.copyOf(httpHeaders);
+    }
+
+    /**
+     * Convenience factory for creating a request without HTTP headers.
+     * <p>
+     * Suitable for test scenarios or callers that do not have access to HTTP context.
+     *
+     * @param tokenString the raw token string, must not be null
+     * @return a new IdTokenRequest with an empty header map
+     */
+    public static IdTokenRequest of(String tokenString) {
+        return new IdTokenRequest(tokenString, Map.of());
+    }
+}

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/context/RefreshTokenRequest.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/context/RefreshTokenRequest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.oauth.core.domain.context;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Request object for refresh token validation, carrying the token string and HTTP headers.
+ * <p>
+ * This record is immutable and thread-safe. The HTTP headers map is defensively copied
+ * at construction time.
+ * <p>
+ * Usage:
+ * <pre>
+ * // Without HTTP headers (typical scenario)
+ * RefreshTokenRequest request = RefreshTokenRequest.of(tokenString);
+ *
+ * // With HTTP headers
+ * RefreshTokenRequest request = new RefreshTokenRequest(tokenString, httpHeaders);
+ * </pre>
+ *
+ * @param tokenString the raw token string, must not be null
+ * @param httpHeaders the HTTP headers from the original request, defensively copied
+ * @since 1.0
+ */
+public record RefreshTokenRequest(String tokenString, Map<String, List<String>> httpHeaders)
+        implements TokenValidationRequest {
+
+    /**
+     * Compact constructor that validates inputs and creates defensive copies.
+     *
+     * @param tokenString the raw token string, must not be null
+     * @param httpHeaders the HTTP headers, must not be null (may be empty)
+     */
+    public RefreshTokenRequest {
+        Objects.requireNonNull(tokenString, "tokenString must not be null");
+        Objects.requireNonNull(httpHeaders, "httpHeaders must not be null");
+        httpHeaders = Map.copyOf(httpHeaders);
+    }
+
+    /**
+     * Convenience factory for creating a request without HTTP headers.
+     * <p>
+     * Suitable for test scenarios or callers that do not have access to HTTP context.
+     *
+     * @param tokenString the raw token string, must not be null
+     * @return a new RefreshTokenRequest with an empty header map
+     */
+    public static RefreshTokenRequest of(String tokenString) {
+        return new RefreshTokenRequest(tokenString, Map.of());
+    }
+}

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/context/TokenValidationRequest.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/context/TokenValidationRequest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.oauth.core.domain.context;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Sealed interface representing a token validation request carrying the token string
+ * plus HTTP request context (headers) through the validation pipeline.
+ * <p>
+ * This parameter object enables future features that require HTTP context during
+ * token validation, such as:
+ * <ul>
+ *   <li>RFC 9068 {@code typ} header validation (per-issuer configuration)</li>
+ *   <li>RFC 9449 DPoP sender-constrained token validation (requires the {@code DPoP} HTTP header)</li>
+ * </ul>
+ * <p>
+ * Each permit type corresponds to a specific token pipeline, providing type safety
+ * and preventing accidental misuse (e.g., passing an ID token request to the access
+ * token pipeline).
+ * <p>
+ * Implementations are immutable and thread-safe.
+ *
+ * @since 1.0
+ */
+public sealed interface TokenValidationRequest
+        permits AccessTokenRequest, IdTokenRequest, RefreshTokenRequest {
+
+    /**
+     * Returns the raw token string to validate.
+     *
+     * @return the token string, never null
+     */
+    String tokenString();
+
+    /**
+     * Returns the HTTP headers from the original request.
+     * <p>
+     * Header names are expected to be lowercase per RFC 9113 (HTTP/2) and RFC 7230 (HTTP/1.1).
+     * The returned map is an unmodifiable defensive copy.
+     *
+     * @return immutable map of HTTP headers, never null (may be empty)
+     */
+    Map<String, List<String>> httpHeaders();
+}

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/context/package-info.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/context/package-info.java
@@ -22,8 +22,16 @@
  * <p>
  * Key classes:
  * <ul>
- *   <li>{@link de.cuioss.sheriff.oauth.core.domain.context.ValidationContext} - 
+ *   <li>{@link de.cuioss.sheriff.oauth.core.domain.context.ValidationContext} -
  *       Carries cached current time and configuration through the validation pipeline</li>
+ *   <li>{@link de.cuioss.sheriff.oauth.core.domain.context.TokenValidationRequest} -
+ *       Sealed interface for token validation requests carrying token string and HTTP headers</li>
+ *   <li>{@link de.cuioss.sheriff.oauth.core.domain.context.AccessTokenRequest} -
+ *       Request object for access token validation</li>
+ *   <li>{@link de.cuioss.sheriff.oauth.core.domain.context.IdTokenRequest} -
+ *       Request object for ID token validation</li>
+ *   <li>{@link de.cuioss.sheriff.oauth.core.domain.context.RefreshTokenRequest} -
+ *       Request object for refresh token validation</li>
  * </ul>
  *
  * @since 1.0

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/token/BaseTokenContent.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/token/BaseTokenContent.java
@@ -60,6 +60,7 @@ public abstract class BaseTokenContent implements TokenContent {
     private final Map<String, ClaimValue> claims;
 
     @Getter
+    @ToString.Exclude
     private final String rawToken;
 
     @Getter

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/AccessTokenValidationPipeline.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/AccessTokenValidationPipeline.java
@@ -20,6 +20,7 @@ import de.cuioss.sheriff.oauth.core.IssuerConfigResolver;
 import de.cuioss.sheriff.oauth.core.JWTValidationLogMessages;
 import de.cuioss.sheriff.oauth.core.cache.AccessTokenCache;
 import de.cuioss.sheriff.oauth.core.cache.AccessTokenCacheConfig;
+import de.cuioss.sheriff.oauth.core.domain.context.AccessTokenRequest;
 import de.cuioss.sheriff.oauth.core.domain.context.ValidationContext;
 import de.cuioss.sheriff.oauth.core.domain.token.AccessTokenContent;
 import de.cuioss.sheriff.oauth.core.exception.TokenValidationException;
@@ -132,13 +133,13 @@ public class AccessTokenValidationPipeline {
      * If the token is found in cache and is still valid, it is returned immediately
      * without performing expensive cryptographic operations.
      *
-     * @param tokenString the token string to validate (guaranteed non-null, non-blank, within size limits)
+     * @param request the access token validation request (token string guaranteed non-null, non-blank, within size limits)
      * @return the validated access token content
      * @throws TokenValidationException if any validation step fails
      */
-   
-    public AccessTokenContent validate(String tokenString) {
+    public AccessTokenContent validate(AccessTokenRequest request) {
         LOGGER.debug("Validating access token");
+        String tokenString = request.tokenString();
 
         // TokenStringValidator has already checked: null, blank, size
 
@@ -187,7 +188,7 @@ public class AccessTokenValidationPipeline {
         MetricsTicker headerTicker = MetricsTickerFactory.createStartedTicker(MeasurementType.HEADER_VALIDATION, performanceMonitor);
         try {
             TokenHeaderValidator headerValidator = headerValidators.get(issuerConfig.getIssuerIdentifier());
-            headerValidator.validate(decodedJwt);
+            headerValidator.validate(decodedJwt, request);
         } finally {
             headerTicker.stopAndRecord();
         }

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/DecodedJwt.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/DecodedJwt.java
@@ -215,6 +215,9 @@ String rawToken
     /**
      * Overrides toString to properly handle array representation for the parts field.
      * Uses Arrays.toString() for proper array content representation.
+     * <p>
+     * <strong>Security:</strong> The rawToken is redacted to prevent accidental token
+     * leakage in log output. Only the first 10 characters are shown.
      *
      * @return a string representation of this object
      */
@@ -225,8 +228,25 @@ String rawToken
                 ", body=" + body +
                 ", signature=" + signature +
                 ", parts=" + Arrays.toString(parts) +
-                ", rawToken=" + rawToken +
+                ", rawToken=" + redactToken(rawToken) +
                 ']';
+    }
+
+    /**
+     * Redacts a token string to prevent leakage in logs.
+     * Shows only the first 10 characters followed by "...".
+     *
+     * @param token the token to redact
+     * @return the redacted token string
+     */
+    private static String redactToken(String token) {
+        if (token == null) {
+            return "null";
+        }
+        if (token.length() <= 10) {
+            return token;
+        }
+        return token.substring(0, 10) + "...";
     }
 
     /**

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/IdTokenValidationPipeline.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/IdTokenValidationPipeline.java
@@ -18,6 +18,7 @@ package de.cuioss.sheriff.oauth.core.pipeline;
 import de.cuioss.sheriff.oauth.core.IssuerConfig;
 import de.cuioss.sheriff.oauth.core.IssuerConfigResolver;
 import de.cuioss.sheriff.oauth.core.JWTValidationLogMessages;
+import de.cuioss.sheriff.oauth.core.domain.context.IdTokenRequest;
 import de.cuioss.sheriff.oauth.core.domain.context.ValidationContext;
 import de.cuioss.sheriff.oauth.core.domain.token.IdTokenContent;
 import de.cuioss.sheriff.oauth.core.exception.TokenValidationException;
@@ -107,13 +108,13 @@ public class IdTokenValidationPipeline {
      * and claims validation. All validation steps must succeed for the token
      * to be considered valid.
      *
-     * @param tokenString the token string to validate (guaranteed non-null, non-blank, within size limits)
+     * @param request the ID token validation request (token string guaranteed non-null, non-blank, within size limits)
      * @return the validated ID token content
      * @throws TokenValidationException if any validation step fails
      */
-   
-    public IdTokenContent validate(String tokenString) {
+    public IdTokenContent validate(IdTokenRequest request) {
         LOGGER.debug("Validating ID token");
+        String tokenString = request.tokenString();
 
         // TokenStringValidator has already checked: null, blank, size
 
@@ -135,7 +136,7 @@ public class IdTokenValidationPipeline {
 
         // 4. Validate header
         TokenHeaderValidator headerValidator = headerValidators.get(issuerConfig.getIssuerIdentifier());
-        headerValidator.validate(decodedJwt);
+        headerValidator.validate(decodedJwt, request);
 
         // 5. Validate signature
         // Note: signatureValidator is guaranteed to exist because TokenValidator

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/RefreshTokenValidationPipeline.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/RefreshTokenValidationPipeline.java
@@ -16,6 +16,7 @@
 package de.cuioss.sheriff.oauth.core.pipeline;
 
 import de.cuioss.sheriff.oauth.core.domain.claim.ClaimValue;
+import de.cuioss.sheriff.oauth.core.domain.context.RefreshTokenRequest;
 import de.cuioss.sheriff.oauth.core.domain.token.RefreshTokenContent;
 import de.cuioss.sheriff.oauth.core.exception.TokenValidationException;
 import de.cuioss.sheriff.oauth.core.json.MapRepresentation;
@@ -76,12 +77,12 @@ public class RefreshTokenValidationPipeline {
      * claims map is used. Parsing failures are expected and do not cause validation
      * to fail.
      *
-     * @param tokenString the token string to validate (guaranteed non-null, non-blank, within size limits)
+     * @param request the refresh token validation request (token string guaranteed non-null, non-blank, within size limits)
      * @return the validated refresh token content
      */
-   
-    public RefreshTokenContent validate(String tokenString) {
+    public RefreshTokenContent validate(RefreshTokenRequest request) {
         LOGGER.debug("Validating refresh token");
+        String tokenString = request.tokenString();
 
         // TokenStringValidator has already checked: null, blank, size
 

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/validator/TokenHeaderValidator.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/validator/TokenHeaderValidator.java
@@ -17,6 +17,7 @@ package de.cuioss.sheriff.oauth.core.pipeline.validator;
 
 import de.cuioss.sheriff.oauth.core.IssuerConfig;
 import de.cuioss.sheriff.oauth.core.JWTValidationLogMessages;
+import de.cuioss.sheriff.oauth.core.domain.context.TokenValidationRequest;
 import de.cuioss.sheriff.oauth.core.exception.TokenValidationException;
 import de.cuioss.sheriff.oauth.core.json.JwtHeader;
 import de.cuioss.sheriff.oauth.core.pipeline.DecodedJwt;
@@ -67,7 +68,7 @@ public class TokenHeaderValidator {
 
 
     /**
-     * Validates a decoded JWT Token's header.
+     * Validates a decoded JWT Token's header with access to the full validation request context.
      * <p>
      * This validator checks:
      * <ul>
@@ -76,14 +77,18 @@ public class TokenHeaderValidator {
      *   <li>Absence of embedded JWK to prevent CVE-2018-0114 attacks</li>
      * </ul>
      * <p>
+     * The request parameter provides access to HTTP headers, enabling future features such as
+     * RFC 9068 {@code typ} header validation and RFC 9449 DPoP support.
+     * <p>
      * Note: Issuer validation is now performed at the TokenValidator level during
      * issuer configuration resolution, not here.
      * </p>
      *
      * @param decodedJwt the decoded JWT Token to validate
+     * @param request the token validation request providing HTTP context
      * @throws TokenValidationException if the token header is invalid
      */
-    public void validate(DecodedJwt decodedJwt) {
+    public void validate(DecodedJwt decodedJwt, TokenValidationRequest request) {
         LOGGER.trace("Validating token header");
 
         validateAlgorithm(decodedJwt);

--- a/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/ClientConfusionAttackTest.java
+++ b/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/ClientConfusionAttackTest.java
@@ -15,6 +15,7 @@
  */
 package de.cuioss.sheriff.oauth.core;
 
+import de.cuioss.sheriff.oauth.core.domain.context.IdTokenRequest;
 import de.cuioss.sheriff.oauth.core.domain.token.IdTokenContent;
 import de.cuioss.sheriff.oauth.core.exception.TokenValidationException;
 import de.cuioss.sheriff.oauth.core.security.SecurityEventCounter;
@@ -52,7 +53,7 @@ class ClientConfusionAttackTest {
         tokenValidator = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build();
 
         // Verify the token is accepted
-        IdTokenContent result = tokenValidator.createIdToken(token);
+        IdTokenContent result = tokenValidator.createIdToken(IdTokenRequest.of(token));
         assertNotNull(result, "Token with valid azp claim should be accepted");
     }
 
@@ -74,7 +75,7 @@ class ClientConfusionAttackTest {
         tokenValidator = TokenValidator.builder().issuerConfig(issuerConfig).build();
 
         // Verify the token is rejected
-        var exception = assertThrows(TokenValidationException.class, () -> tokenValidator.createIdToken(token),
+        var exception = assertThrows(TokenValidationException.class, () -> tokenValidator.createIdToken(IdTokenRequest.of(token)),
                 "Token with invalid azp claim should be rejected");
         assertEquals(SecurityEventCounter.EventType.AZP_MISMATCH, exception.getEventType(),
                 "Exception should have AZP_MISMATCH event type");
@@ -116,7 +117,7 @@ class ClientConfusionAttackTest {
         tokenValidator = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build();
 
         // Verify the token is accepted
-        IdTokenContent result = tokenValidator.createIdToken(token);
+        IdTokenContent result = tokenValidator.createIdToken(IdTokenRequest.of(token));
         assertNotNull(result, "Token with valid audience should be accepted");
     }
 
@@ -131,7 +132,7 @@ class ClientConfusionAttackTest {
         tokenValidator = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build();
 
         // Verify the token is accepted
-        IdTokenContent result = tokenValidator.createIdToken(token);
+        IdTokenContent result = tokenValidator.createIdToken(IdTokenRequest.of(token));
         assertNotNull(result, "Token with valid azp should be accepted");
     }
 
@@ -147,7 +148,7 @@ class ClientConfusionAttackTest {
         tokenValidator = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build();
 
         // Verify the token is rejected
-        var exception = assertThrows(TokenValidationException.class, () -> tokenValidator.createIdToken(token),
+        var exception = assertThrows(TokenValidationException.class, () -> tokenValidator.createIdToken(IdTokenRequest.of(token)),
                 "Token with missing azp claim should be rejected");
         assertEquals(SecurityEventCounter.EventType.MISSING_CLAIM, exception.getEventType(),
                 "Exception should have MISSING_CLAIM event type");

--- a/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/CustomClaimMapperTest.java
+++ b/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/CustomClaimMapperTest.java
@@ -20,6 +20,7 @@ import de.cuioss.sheriff.oauth.core.domain.claim.ClaimValue;
 import de.cuioss.sheriff.oauth.core.domain.claim.ClaimValueType;
 import de.cuioss.sheriff.oauth.core.domain.claim.mapper.ClaimMapper;
 import de.cuioss.sheriff.oauth.core.domain.claim.mapper.JsonCollectionMapper;
+import de.cuioss.sheriff.oauth.core.domain.context.AccessTokenRequest;
 import de.cuioss.sheriff.oauth.core.domain.token.AccessTokenContent;
 import de.cuioss.sheriff.oauth.core.test.InMemoryJWKSFactory;
 import de.cuioss.sheriff.oauth.core.test.TestTokenHolder;
@@ -78,7 +79,7 @@ class CustomClaimMapperTest {
     @Test
     @DisplayName("Use custom claim mapper for role claim")
     void shouldUseCustomClaimMapperForRoleClaim() {
-        AccessTokenContent tokenContent = tokenValidator.createAccessToken(tokenWithRoles);
+        AccessTokenContent tokenContent = tokenValidator.createAccessToken(AccessTokenRequest.of(tokenWithRoles));
         ClaimValue roleClaim = tokenContent.getClaims().get(ROLE_CLAIM);
 
         assertNotNull(roleClaim, "Role claim should not be null");
@@ -101,7 +102,7 @@ class CustomClaimMapperTest {
                 .issuerConfig(issuerConfigWithoutCustomMapper)
                 .build();
 
-        AccessTokenContent tokenContent = factoryWithoutCustomMapper.createAccessToken(tokenWithRoles);
+        AccessTokenContent tokenContent = factoryWithoutCustomMapper.createAccessToken(AccessTokenRequest.of(tokenWithRoles));
         ClaimValue roleClaim = tokenContent.getClaims().get(ROLE_CLAIM);
 
         assertNotNull(roleClaim, "Role claim should not be null");

--- a/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/OAuth2JWTBestPracticesComplianceTest.java
+++ b/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/OAuth2JWTBestPracticesComplianceTest.java
@@ -17,6 +17,8 @@ package de.cuioss.sheriff.oauth.core;
 
 import de.cuioss.sheriff.oauth.core.domain.claim.ClaimName;
 import de.cuioss.sheriff.oauth.core.domain.claim.ClaimValue;
+import de.cuioss.sheriff.oauth.core.domain.context.AccessTokenRequest;
+import de.cuioss.sheriff.oauth.core.domain.context.IdTokenRequest;
 import de.cuioss.sheriff.oauth.core.domain.context.ValidationContext;
 import de.cuioss.sheriff.oauth.core.domain.token.AccessTokenContent;
 import de.cuioss.sheriff.oauth.core.exception.TokenValidationException;
@@ -93,7 +95,7 @@ class OAuth2JWTBestPracticesComplianceTest {
         void shouldValidateAudienceClaim() {
 
             String token = TestTokenGenerators.accessTokens().next().getRawToken();
-            AccessTokenContent result = tokenValidator.createAccessToken(token);
+            AccessTokenContent result = tokenValidator.createAccessToken(AccessTokenRequest.of(token));
             assertNotNull(result, "Token should be parsed successfully");
             assertTrue(result.getAudience().isPresent(), "Audience claim should be present");
             assertTrue(result.getAudience().get().contains(TestTokenHolder.TEST_AUDIENCE),
@@ -109,7 +111,7 @@ class OAuth2JWTBestPracticesComplianceTest {
             tokenHolder.withAudience(List.of("wrong-audience"));
             String token = tokenHolder.getRawToken();
             TokenValidationException exception = assertThrows(TokenValidationException.class,
-                    () -> tokenValidator.createAccessToken(token),
+                    () -> tokenValidator.createAccessToken(AccessTokenRequest.of(token)),
                     "Token with incorrect audience should be rejected");
 
             // Verify the exception has the correct event type
@@ -127,7 +129,7 @@ class OAuth2JWTBestPracticesComplianceTest {
         void shouldValidateIssuerClaim() {
 
             String token = TestTokenGenerators.accessTokens().next().getRawToken();
-            AccessTokenContent result = tokenValidator.createAccessToken(token);
+            AccessTokenContent result = tokenValidator.createAccessToken(AccessTokenRequest.of(token));
             assertNotNull(result, "Token should be parsed successfully");
             assertEquals(TestTokenHolder.TEST_ISSUER, result.getIssuer(),
                     "Issuer claim should match the expected value");
@@ -145,7 +147,7 @@ class OAuth2JWTBestPracticesComplianceTest {
 
             String token = tokenHolder.getRawToken();
             TokenValidationException exception = assertThrows(TokenValidationException.class,
-                    () -> tokenValidator.createAccessToken(token),
+                    () -> tokenValidator.createAccessToken(AccessTokenRequest.of(token)),
                     "Token with incorrect issuer should be rejected");
 
             // Verify the exception has the correct event type
@@ -164,7 +166,7 @@ class OAuth2JWTBestPracticesComplianceTest {
         void shouldValidateTokenSignature() {
 
             String token = TestTokenGenerators.accessTokens().next().getRawToken();
-            AccessTokenContent result = tokenValidator.createAccessToken(token);
+            AccessTokenContent result = tokenValidator.createAccessToken(AccessTokenRequest.of(token));
             assertNotNull(result, "Token with valid signature should be parsed successfully");
         }
 
@@ -184,7 +186,7 @@ class OAuth2JWTBestPracticesComplianceTest {
             TokenValidator validator = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build();
 
             TokenValidationException exception = assertThrows(TokenValidationException.class,
-                    () -> validator.createAccessToken(tamperedToken),
+                    () -> validator.createAccessToken(AccessTokenRequest.of(tamperedToken)),
                     "Token with invalid signature should be rejected, offending validation: " + tamperedToken);
 
             // Verify the exception has the correct event type
@@ -207,7 +209,7 @@ class OAuth2JWTBestPracticesComplianceTest {
             assertNotEquals(tamperedToken, token, "Token should be tampered");
             TokenValidator validator = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build();
             TokenValidationException exception = assertThrows(TokenValidationException.class,
-                    () -> validator.createIdToken(tamperedToken),
+                    () -> validator.createIdToken(IdTokenRequest.of(tamperedToken)),
                     "Token with invalid signature should be rejected, offending validation: " + tamperedToken);
 
             // Verify the exception has the correct event type
@@ -225,7 +227,7 @@ class OAuth2JWTBestPracticesComplianceTest {
         void shouldValidateTokenExpiration() {
 
             String token = TestTokenGenerators.accessTokens().next().getRawToken();
-            AccessTokenContent result = tokenValidator.createAccessToken(token);
+            AccessTokenContent result = tokenValidator.createAccessToken(AccessTokenRequest.of(token));
             assertNotNull(result, "Token should be parsed successfully");
             assertNotNull(result.getExpirationTime(),
                     "Expiration time claim should be present");
@@ -249,7 +251,7 @@ class OAuth2JWTBestPracticesComplianceTest {
 
             String token = tokenHolder.getRawToken();
             TokenValidationException exception = assertThrows(TokenValidationException.class,
-                    () -> tokenValidator.createAccessToken(token),
+                    () -> tokenValidator.createAccessToken(AccessTokenRequest.of(token)),
                     "Expired token should be rejected");
 
             // Verify the exception has the correct event type
@@ -284,7 +286,7 @@ class OAuth2JWTBestPracticesComplianceTest {
                             .build())
                     .build();
             TokenValidationException exception = assertThrows(TokenValidationException.class,
-                    () -> factory.createAccessToken(largeToken),
+                    () -> factory.createAccessToken(AccessTokenRequest.of(largeToken)),
                     "Token exceeding max size should be rejected");
 
             // Verify the exception has the correct event type

--- a/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/OpenIDConnectComplianceTest.java
+++ b/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/OpenIDConnectComplianceTest.java
@@ -17,6 +17,7 @@ package de.cuioss.sheriff.oauth.core;
 
 import de.cuioss.sheriff.oauth.core.domain.claim.ClaimName;
 import de.cuioss.sheriff.oauth.core.domain.claim.ClaimValue;
+import de.cuioss.sheriff.oauth.core.domain.context.IdTokenRequest;
 import de.cuioss.sheriff.oauth.core.domain.context.ValidationContext;
 import de.cuioss.sheriff.oauth.core.domain.token.IdTokenContent;
 import de.cuioss.sheriff.oauth.core.security.SignatureAlgorithmPreferences;
@@ -84,7 +85,7 @@ class OpenIDConnectComplianceTest {
         void shouldHandleIssuerClaim() {
 
             String token = TestTokenGenerators.idTokens().next().getRawToken();
-            IdTokenContent result = tokenValidator.createIdToken(token);
+            IdTokenContent result = tokenValidator.createIdToken(IdTokenRequest.of(token));
             assertEquals(ISSUER, result.getIssuer());
         }
 
@@ -99,7 +100,7 @@ class OpenIDConnectComplianceTest {
             tokenHolder.withClaim(ClaimName.SUBJECT.getName(), ClaimValue.forPlainString(subject));
 
             String token = tokenHolder.getRawToken();
-            IdTokenContent result = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build().createIdToken(token);
+            IdTokenContent result = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build().createIdToken(IdTokenRequest.of(token));
 
             // Since we explicitly set the subject claim, it should always be present
             // regardless of claimSubOptional configuration
@@ -113,7 +114,7 @@ class OpenIDConnectComplianceTest {
         void shouldHandleAudienceClaim() {
 
             String token = TestTokenGenerators.idTokens().next().getRawToken();
-            IdTokenContent result = tokenValidator.createIdToken(token);
+            IdTokenContent result = tokenValidator.createIdToken(IdTokenRequest.of(token));
             assertEquals(List.of(TestTokenHolder.TEST_AUDIENCE), result.getAudience());
         }
 
@@ -122,7 +123,7 @@ class OpenIDConnectComplianceTest {
         void shouldHandleExpirationTimeClaim() {
 
             String token = TestTokenGenerators.idTokens().next().getRawToken();
-            IdTokenContent result = tokenValidator.createIdToken(token);
+            IdTokenContent result = tokenValidator.createIdToken(IdTokenRequest.of(token));
             assertNotNull(result.getExpirationTime());
             assertFalse(result.isExpired(validationContext));
         }
@@ -132,7 +133,7 @@ class OpenIDConnectComplianceTest {
         void shouldHandleIssuedAtClaim() {
 
             String token = TestTokenGenerators.idTokens().next().getRawToken();
-            IdTokenContent result = tokenValidator.createIdToken(token);
+            IdTokenContent result = tokenValidator.createIdToken(IdTokenRequest.of(token));
             assertNotNull(result.getIssuedAtTime());
         }
 
@@ -147,7 +148,7 @@ class OpenIDConnectComplianceTest {
             tokenHolder.withClaim("auth_time", ClaimValue.forPlainString(String.valueOf(authTime.getEpochSecond())));
 
             String token = tokenHolder.getRawToken();
-            IdTokenContent result = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build().createIdToken(token);
+            IdTokenContent result = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build().createIdToken(IdTokenRequest.of(token));
             assertTrue(result.getClaims().containsKey("auth_time"));
         }
 
@@ -162,7 +163,7 @@ class OpenIDConnectComplianceTest {
             tokenHolder.withClaim("nonce", ClaimValue.forPlainString(nonce));
 
             String token = tokenHolder.getRawToken();
-            IdTokenContent result = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build().createIdToken(token);
+            IdTokenContent result = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build().createIdToken(IdTokenRequest.of(token));
             assertTrue(result.getClaims().containsKey("nonce"));
             assertEquals(nonce, result.getClaims().get("nonce").getOriginalString());
         }
@@ -172,7 +173,7 @@ class OpenIDConnectComplianceTest {
         void shouldHandleAuthorizedPartyClaim() {
 
             String token = TestTokenGenerators.idTokens().next().getRawToken();
-            IdTokenContent result = tokenValidator.createIdToken(token);
+            IdTokenContent result = tokenValidator.createIdToken(IdTokenRequest.of(token));
             assertTrue(result.getClaimOption(ClaimName.AUTHORIZED_PARTY).isPresent());
             assertEquals(TestTokenHolder.TEST_CLIENT_ID, result.getClaimOption(ClaimName.AUTHORIZED_PARTY).get().getOriginalString());
         }
@@ -193,7 +194,7 @@ class OpenIDConnectComplianceTest {
             tokenHolder.withClaim(ClaimName.NAME.getName(), ClaimValue.forPlainString(name));
 
             String token = tokenHolder.getRawToken();
-            IdTokenContent result = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build().createIdToken(token);
+            IdTokenContent result = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build().createIdToken(IdTokenRequest.of(token));
             assertEquals(name, result.getName().orElse(null));
         }
 
@@ -208,7 +209,7 @@ class OpenIDConnectComplianceTest {
             tokenHolder.withClaim(ClaimName.EMAIL.getName(), ClaimValue.forPlainString(email));
 
             String token = tokenHolder.getRawToken();
-            IdTokenContent result = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build().createIdToken(token);
+            IdTokenContent result = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build().createIdToken(IdTokenRequest.of(token));
             assertEquals(email, result.getEmail().orElse(null));
         }
 
@@ -223,7 +224,7 @@ class OpenIDConnectComplianceTest {
             tokenHolder.withClaim(ClaimName.PREFERRED_USERNAME.getName(), ClaimValue.forPlainString(preferredUsername));
 
             String token = tokenHolder.getRawToken();
-            IdTokenContent result = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build().createIdToken(token);
+            IdTokenContent result = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build().createIdToken(IdTokenRequest.of(token));
             assertTrue(result.getClaimOption(ClaimName.PREFERRED_USERNAME).isPresent());
             assertEquals(preferredUsername, result.getClaimOption(ClaimName.PREFERRED_USERNAME).get().getOriginalString());
         }

--- a/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/RFC7519JWTComplianceTest.java
+++ b/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/RFC7519JWTComplianceTest.java
@@ -17,6 +17,7 @@ package de.cuioss.sheriff.oauth.core;
 
 import de.cuioss.sheriff.oauth.core.domain.claim.ClaimName;
 import de.cuioss.sheriff.oauth.core.domain.claim.ClaimValue;
+import de.cuioss.sheriff.oauth.core.domain.context.AccessTokenRequest;
 import de.cuioss.sheriff.oauth.core.domain.context.ValidationContext;
 import de.cuioss.sheriff.oauth.core.domain.token.AccessTokenContent;
 import de.cuioss.sheriff.oauth.core.exception.TokenValidationException;
@@ -69,7 +70,7 @@ class RFC7519JWTComplianceTest {
         void shouldHandleIssuerClaim(TestTokenHolder tokenHolder) {
 
             String token = tokenHolder.getRawToken();
-            AccessTokenContent result = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build().createAccessToken(token);
+            AccessTokenContent result = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build().createAccessToken(AccessTokenRequest.of(token));
             assertNotNull(result, "Token should be parsed successfully");
             assertEquals(TestTokenHolder.TEST_ISSUER, result.getIssuer());
         }
@@ -80,7 +81,7 @@ class RFC7519JWTComplianceTest {
         void shouldHandleSubjectClaim(TestTokenHolder tokenHolder) {
 
             String token = tokenHolder.getRawToken();
-            AccessTokenContent result = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build().createAccessToken(token);
+            AccessTokenContent result = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build().createAccessToken(AccessTokenRequest.of(token));
 
             assertNotNull(result, "Token should be parsed successfully");
 
@@ -95,7 +96,7 @@ class RFC7519JWTComplianceTest {
         void shouldHandleAudienceClaim(TestTokenHolder tokenHolder) {
 
             String token = tokenHolder.getRawToken();
-            AccessTokenContent result = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build().createAccessToken(token);
+            AccessTokenContent result = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build().createAccessToken(AccessTokenRequest.of(token));
             assertNotNull(result, "Token should be parsed successfully");
             assertTrue(result.getAudience().isPresent());
             assertEquals(List.of(TestTokenHolder.TEST_AUDIENCE), result.getAudience().get());
@@ -107,7 +108,7 @@ class RFC7519JWTComplianceTest {
         void shouldHandleExpirationTimeClaim(TestTokenHolder tokenHolder) {
 
             String token = tokenHolder.getRawToken();
-            AccessTokenContent result = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build().createAccessToken(token);
+            AccessTokenContent result = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build().createAccessToken(AccessTokenRequest.of(token));
             assertNotNull(result, "Token should be parsed successfully");
             assertNotNull(result.getExpirationTime());
             assertFalse(result.isExpired(validationContext));
@@ -128,7 +129,7 @@ class RFC7519JWTComplianceTest {
                     ClaimValue.forDateTime(String.valueOf(notBeforeDateTime.toEpochSecond()), notBeforeDateTime));
 
             String token = tokenHolder.getRawToken();
-            AccessTokenContent result = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build().createAccessToken(token);
+            AccessTokenContent result = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build().createAccessToken(AccessTokenRequest.of(token));
             assertNotNull(result, "Token should be parsed successfully");
             assertTrue(result.getNotBefore().isPresent());
         }
@@ -139,7 +140,7 @@ class RFC7519JWTComplianceTest {
 
             TestTokenHolder tokenHolder = TestTokenGenerators.accessTokens().next();
             String token = tokenHolder.getRawToken();
-            AccessTokenContent result = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build().createAccessToken(token);
+            AccessTokenContent result = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build().createAccessToken(AccessTokenRequest.of(token));
             assertNotNull(result, "Token should be parsed successfully");
             assertNotNull(result.getIssuedAtTime());
         }
@@ -157,7 +158,7 @@ class RFC7519JWTComplianceTest {
             tokenHolder.withClaim(ClaimName.TOKEN_ID.getName(), ClaimValue.forPlainString(jwtId));
 
             String token = tokenHolder.getRawToken();
-            AccessTokenContent result = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build().createAccessToken(token);
+            AccessTokenContent result = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build().createAccessToken(AccessTokenRequest.of(token));
             assertNotNull(result, "Token should be parsed successfully");
             assertTrue(result.getClaimOption(ClaimName.TOKEN_ID).isPresent());
             assertEquals(jwtId, result.getClaimOption(ClaimName.TOKEN_ID).get().getOriginalString());
@@ -197,7 +198,7 @@ class RFC7519JWTComplianceTest {
 
             TestTokenHolder tokenHolder = TestTokenGenerators.accessTokens().next();
             String token = tokenHolder.getRawToken();
-            AccessTokenContent result = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build().createAccessToken(token);
+            AccessTokenContent result = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build().createAccessToken(AccessTokenRequest.of(token));
             assertNotNull(result, "Token should be parsed successfully");
             // Note: The TokenContent interface doesn't provide direct access to header claims
             // This is tested indirectly by the fact that the token is successfully validated
@@ -214,7 +215,7 @@ class RFC7519JWTComplianceTest {
 
             TestTokenHolder tokenHolder = TestTokenGenerators.accessTokens().next();
             String token = tokenHolder.getRawToken();
-            AccessTokenContent result = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build().createAccessToken(token);
+            AccessTokenContent result = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build().createAccessToken(AccessTokenRequest.of(token));
             assertNotNull(result);
         }
 
@@ -232,7 +233,7 @@ class RFC7519JWTComplianceTest {
             );
             TokenValidator validator = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build();
             TokenValidationException exception = assertThrows(TokenValidationException.class,
-                    () -> validator.createAccessToken(invalidToken));
+                    () -> validator.createAccessToken(AccessTokenRequest.of(invalidToken)));
 
             assertEquals(SecurityEventCounter.EventType.SIGNATURE_VALIDATION_FAILED, exception.getEventType());
         }
@@ -254,7 +255,7 @@ class RFC7519JWTComplianceTest {
             String token = tokenHolder.getRawToken();
             TokenValidator validator = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build();
             TokenValidationException exception = assertThrows(TokenValidationException.class,
-                    () -> validator.createAccessToken(token));
+                    () -> validator.createAccessToken(AccessTokenRequest.of(token)));
 
             assertEquals(SecurityEventCounter.EventType.TOKEN_EXPIRED, exception.getEventType());
         }
@@ -276,7 +277,7 @@ class RFC7519JWTComplianceTest {
             String token = tokenHolder.getRawToken();
             TokenValidator validator = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build();
             TokenValidationException exception = assertThrows(TokenValidationException.class,
-                    () -> validator.createAccessToken(token));
+                    () -> validator.createAccessToken(AccessTokenRequest.of(token)));
 
             assertEquals(SecurityEventCounter.EventType.TOKEN_NBF_FUTURE, exception.getEventType());
         }
@@ -292,7 +293,7 @@ class RFC7519JWTComplianceTest {
 
             TestTokenHolder tokenHolder = TestTokenGenerators.accessTokens().next();
             String token = tokenHolder.getRawToken();
-            AccessTokenContent result = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build().createAccessToken(token);
+            AccessTokenContent result = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build().createAccessToken(AccessTokenRequest.of(token));
             assertNotNull(result, "Token should be parsed successfully");
 
             // Verify that standard claims are accessible
@@ -320,7 +321,7 @@ class RFC7519JWTComplianceTest {
             tokenHolder.withClaim(customClaimName, ClaimValue.forPlainString(customClaimValue));
 
             String token = tokenHolder.getRawToken();
-            AccessTokenContent result = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build().createAccessToken(token);
+            AccessTokenContent result = TokenValidator.builder().issuerConfig(tokenHolder.getIssuerConfig()).build().createAccessToken(AccessTokenRequest.of(token));
             assertNotNull(result, "Token should be parsed successfully");
 
             // Verify that custom claim is accessible

--- a/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/TokenValidatorConcurrencyTest.java
+++ b/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/TokenValidatorConcurrencyTest.java
@@ -15,6 +15,7 @@
  */
 package de.cuioss.sheriff.oauth.core;
 
+import de.cuioss.sheriff.oauth.core.domain.context.AccessTokenRequest;
 import de.cuioss.sheriff.oauth.core.test.generator.TestTokenGenerators;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
@@ -79,7 +80,7 @@ class TokenValidatorConcurrencyTest {
                     // Perform multiple iterations to increase chance of race condition
                     for (int j = 0; j < ITERATIONS_PER_THREAD; j++) {
                         // This should trigger the resolveIssuerConfig method
-                        tokenValidator.createAccessToken(validJwt);
+                        tokenValidator.createAccessToken(AccessTokenRequest.of(validJwt));
                         successCount.incrementAndGet();
                     }
                 } catch (InterruptedException e) {
@@ -123,7 +124,7 @@ class TokenValidatorConcurrencyTest {
             executor.submit(() -> {
                 try {
                     for (int j = 0; j < 20; j++) {
-                        tokenValidator.createAccessToken(validJwt);
+                        tokenValidator.createAccessToken(AccessTokenRequest.of(validJwt));
                     }
                 } finally {
                     latch.countDown();

--- a/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/TokenValidatorMetricsTest.java
+++ b/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/TokenValidatorMetricsTest.java
@@ -16,6 +16,7 @@
 package de.cuioss.sheriff.oauth.core;
 
 import de.cuioss.sheriff.oauth.core.cache.AccessTokenCacheConfig;
+import de.cuioss.sheriff.oauth.core.domain.context.AccessTokenRequest;
 import de.cuioss.sheriff.oauth.core.domain.token.AccessTokenContent;
 import de.cuioss.sheriff.oauth.core.metrics.MeasurementType;
 import de.cuioss.sheriff.oauth.core.metrics.TokenValidatorMonitor;
@@ -74,7 +75,7 @@ class TokenValidatorMetricsTest {
         TokenValidatorMonitor monitor = tokenValidator.getPerformanceMonitor();
 
         // When
-        AccessTokenContent accessToken = tokenValidator.createAccessToken(tokenString);
+        AccessTokenContent accessToken = tokenValidator.createAccessToken(AccessTokenRequest.of(tokenString));
 
         // Then
         assertNotNull(accessToken);
@@ -122,7 +123,7 @@ class TokenValidatorMetricsTest {
 
         // When - validate multiple times to get stable averages
         for (int i = 0; i < 10; i++) {
-            tokenValidator.createAccessToken(tokenString);
+            tokenValidator.createAccessToken(AccessTokenRequest.of(tokenString));
         }
 
         // Then - calculate sum of individual steps
@@ -169,7 +170,7 @@ class TokenValidatorMetricsTest {
         TokenValidatorMonitor monitor = tokenValidator.getPerformanceMonitor();
 
         // When - validate once
-        tokenValidator.createAccessToken(tokenString);
+        tokenValidator.createAccessToken(AccessTokenRequest.of(tokenString));
 
         // Then - check for very fast operations
         Duration tokenFormatCheck = monitor.getValidationMetrics(MeasurementType.TOKEN_FORMAT_CHECK)
@@ -206,7 +207,7 @@ class TokenValidatorMetricsTest {
         TokenValidatorMonitor monitor = tokenValidator.getPerformanceMonitor();
 
         // When
-        tokenValidator.createAccessToken(tokenString);
+        tokenValidator.createAccessToken(AccessTokenRequest.of(tokenString));
 
         // Then
         Duration jwksOperations = monitor.getValidationMetrics(MeasurementType.JWKS_OPERATIONS)

--- a/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/TokenValidatorMetricsVerificationTest.java
+++ b/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/TokenValidatorMetricsVerificationTest.java
@@ -16,6 +16,7 @@
 package de.cuioss.sheriff.oauth.core;
 
 import de.cuioss.sheriff.oauth.core.cache.AccessTokenCacheConfig;
+import de.cuioss.sheriff.oauth.core.domain.context.AccessTokenRequest;
 import de.cuioss.sheriff.oauth.core.metrics.MeasurementType;
 import de.cuioss.sheriff.oauth.core.metrics.TokenValidatorMonitor;
 import de.cuioss.sheriff.oauth.core.metrics.TokenValidatorMonitorConfig;
@@ -56,7 +57,7 @@ class TokenValidatorMetricsVerificationTest {
         // When - validate multiple times to get meaningful averages
         int iterations = 100;
         for (int i = 0; i < iterations; i++) {
-            tokenValidator.createAccessToken(tokenString);
+            tokenValidator.createAccessToken(AccessTokenRequest.of(tokenString));
         }
 
         // Then - analyze metrics

--- a/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/TokenValidatorPerformanceIntegrationTest.java
+++ b/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/TokenValidatorPerformanceIntegrationTest.java
@@ -15,6 +15,7 @@
  */
 package de.cuioss.sheriff.oauth.core;
 
+import de.cuioss.sheriff.oauth.core.domain.context.AccessTokenRequest;
 import de.cuioss.sheriff.oauth.core.exception.TokenValidationException;
 import de.cuioss.sheriff.oauth.core.metrics.MeasurementType;
 import de.cuioss.sheriff.oauth.core.metrics.TokenValidatorMonitor;
@@ -66,7 +67,7 @@ class TokenValidatorPerformanceIntegrationTest {
 
         // Try to validate an invalid token (empty string) - this should record metrics even for failures
         try {
-            tokenValidator.createAccessToken("");
+            tokenValidator.createAccessToken(AccessTokenRequest.of(""));
             fail("Should have thrown TokenValidationException for empty token");
         } catch (IllegalArgumentException | IllegalStateException | TokenValidationException e) {
             // Expected - token validation should fail for empty string
@@ -81,7 +82,7 @@ class TokenValidatorPerformanceIntegrationTest {
 
         // Try with a malformed token - this should get further in the pipeline
         try {
-            tokenValidator.createAccessToken("not.a.valid.jwt.token");
+            tokenValidator.createAccessToken(AccessTokenRequest.of("not.a.valid.jwt.token"));
             fail("Should have thrown TokenValidationException for malformed token");
         } catch (IllegalArgumentException | IllegalStateException | TokenValidationException e) {
             // Expected - token validation should fail for malformed token

--- a/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/TokenValidatorSecurityEventTest.java
+++ b/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/TokenValidatorSecurityEventTest.java
@@ -17,6 +17,8 @@ package de.cuioss.sheriff.oauth.core;
 
 import de.cuioss.sheriff.oauth.core.domain.claim.ClaimName;
 import de.cuioss.sheriff.oauth.core.domain.claim.ClaimValue;
+import de.cuioss.sheriff.oauth.core.domain.context.AccessTokenRequest;
+import de.cuioss.sheriff.oauth.core.domain.context.RefreshTokenRequest;
 import de.cuioss.sheriff.oauth.core.exception.TokenValidationException;
 import de.cuioss.sheriff.oauth.core.security.SecurityEventCounter;
 import de.cuioss.sheriff.oauth.core.security.SignatureAlgorithmPreferences;
@@ -74,7 +76,7 @@ class TokenValidatorSecurityEventTest {
 
         // Process empty validation - expect exception
         TokenValidationException exception = assertThrows(TokenValidationException.class,
-                () -> tokenValidator.createAccessToken(""),
+                () -> tokenValidator.createAccessToken(AccessTokenRequest.of("")),
                 "Empty token should throw TokenValidationException");
 
         // Verify exception has the correct event type
@@ -86,7 +88,7 @@ class TokenValidatorSecurityEventTest {
 
         // Process another empty validation - expect exception
         exception = assertThrows(TokenValidationException.class,
-                () -> tokenValidator.createRefreshToken("   "),
+                () -> tokenValidator.createRefreshToken(RefreshTokenRequest.of("   ")),
                 "Empty token should throw TokenValidationException");
 
         // Verify exception has the correct event type
@@ -105,7 +107,7 @@ class TokenValidatorSecurityEventTest {
 
         // Process invalid validation - expect exception
         TokenValidationException exception = assertThrows(TokenValidationException.class,
-                () -> tokenValidator.createAccessToken("invalid-validation"),
+                () -> tokenValidator.createAccessToken(AccessTokenRequest.of("invalid-validation")),
                 "Invalid token should throw TokenValidationException");
 
         // Verify exception has the correct event type
@@ -129,7 +131,7 @@ class TokenValidatorSecurityEventTest {
 
         // Process token without issuer - expect exception
         TokenValidationException exception = assertThrows(TokenValidationException.class,
-                () -> tokenValidator.createAccessToken(token),
+                () -> tokenValidator.createAccessToken(AccessTokenRequest.of(token)),
                 "Token without issuer should throw TokenValidationException");
 
         // Verify exception has the correct event type
@@ -154,7 +156,7 @@ class TokenValidatorSecurityEventTest {
 
         // Process token with unknown issuer - expect exception
         TokenValidationException exception = assertThrows(TokenValidationException.class,
-                () -> tokenValidator.createAccessToken(token),
+                () -> tokenValidator.createAccessToken(AccessTokenRequest.of(token)),
                 "Token with unknown issuer should throw TokenValidationException");
 
         // Verify exception has the correct event type
@@ -181,7 +183,7 @@ class TokenValidatorSecurityEventTest {
 
         // Process token with invalid signature - expect exception
         TokenValidationException exception = assertThrows(TokenValidationException.class,
-                () -> tokenValidator.createAccessToken(invalidToken),
+                () -> tokenValidator.createAccessToken(AccessTokenRequest.of(invalidToken)),
                 "Token with invalid signature should throw TokenValidationException");
 
         // Verify exception has the correct event type
@@ -197,8 +199,8 @@ class TokenValidatorSecurityEventTest {
     @DisplayName("Should reset security event counters")
     void shouldResetSecurityEventCounters() {
         // Generate some events - expect exceptions but we don't need to check them here
-        assertThrows(TokenValidationException.class, () -> tokenValidator.createAccessToken(""));
-        assertThrows(TokenValidationException.class, () -> tokenValidator.createAccessToken("invalid-validation"));
+        assertThrows(TokenValidationException.class, () -> tokenValidator.createAccessToken(AccessTokenRequest.of("")));
+        assertThrows(TokenValidationException.class, () -> tokenValidator.createAccessToken(AccessTokenRequest.of("invalid-validation")));
 
         // Verify counts are non-zero
         assertTrue(tokenValidator.getSecurityEventCounter().getCount(SecurityEventCounter.EventType.TOKEN_EMPTY) > 0);

--- a/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/domain/context/AccessTokenRequestTest.java
+++ b/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/domain/context/AccessTokenRequestTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.oauth.core.domain.context;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("AccessTokenRequest")
+class AccessTokenRequestTest {
+
+    private static final String TOKEN = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.test.signature";
+
+    @Test
+    @DisplayName("should create request with token string and empty headers via factory")
+    void shouldCreateWithFactory() {
+        var request = AccessTokenRequest.of(TOKEN);
+        assertEquals(TOKEN, request.tokenString());
+        assertTrue(request.httpHeaders().isEmpty());
+    }
+
+    @Test
+    @DisplayName("should create request with token string and headers")
+    void shouldCreateWithHeaders() {
+        Map<String, List<String>> headers = Map.of("authorization", List.of("Bearer " + TOKEN));
+        var request = new AccessTokenRequest(TOKEN, headers);
+        assertEquals(TOKEN, request.tokenString());
+        assertEquals(1, request.httpHeaders().size());
+        assertEquals(List.of("Bearer " + TOKEN), request.httpHeaders().get("authorization"));
+    }
+
+    @Test
+    @DisplayName("should reject null token string")
+    void shouldRejectNullTokenString() {
+        assertThrows(NullPointerException.class, () -> AccessTokenRequest.of(null));
+    }
+
+    @Test
+    @DisplayName("should reject null headers")
+    void shouldRejectNullHeaders() {
+        assertThrows(NullPointerException.class, () -> new AccessTokenRequest(TOKEN, null));
+    }
+
+    @Test
+    @DisplayName("should defensively copy headers")
+    void shouldDefensivelyCopyHeaders() {
+        Map<String, List<String>> mutableHeaders = new HashMap<>();
+        mutableHeaders.put("authorization", new ArrayList<>(List.of("Bearer token")));
+
+        var request = new AccessTokenRequest(TOKEN, mutableHeaders);
+        mutableHeaders.put("x-new-header", List.of("value"));
+
+        assertFalse(request.httpHeaders().containsKey("x-new-header"));
+    }
+
+    @Test
+    @DisplayName("should return immutable headers")
+    void shouldReturnImmutableHeaders() {
+        var request = new AccessTokenRequest(TOKEN, Map.of("key", List.of("value")));
+        assertThrows(UnsupportedOperationException.class,
+                () -> request.httpHeaders().put("new", List.of("val")));
+    }
+
+    @Test
+    @DisplayName("should implement TokenValidationRequest sealed interface")
+    void shouldImplementSealedInterface() {
+        TokenValidationRequest request = AccessTokenRequest.of(TOKEN);
+        assertInstanceOf(AccessTokenRequest.class, request);
+        assertEquals(TOKEN, request.tokenString());
+    }
+
+    @Test
+    @DisplayName("should support record equality")
+    void shouldSupportEquality() {
+        var request1 = AccessTokenRequest.of(TOKEN);
+        var request2 = AccessTokenRequest.of(TOKEN);
+        assertEquals(request1, request2);
+        assertEquals(request1.hashCode(), request2.hashCode());
+    }
+}

--- a/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/domain/context/IdTokenRequestTest.java
+++ b/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/domain/context/IdTokenRequestTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.oauth.core.domain.context;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("IdTokenRequest")
+class IdTokenRequestTest {
+
+    private static final String TOKEN = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.test.signature";
+
+    @Test
+    @DisplayName("should create request with token string and empty headers via factory")
+    void shouldCreateWithFactory() {
+        var request = IdTokenRequest.of(TOKEN);
+        assertEquals(TOKEN, request.tokenString());
+        assertTrue(request.httpHeaders().isEmpty());
+    }
+
+    @Test
+    @DisplayName("should create request with token string and headers")
+    void shouldCreateWithHeaders() {
+        Map<String, List<String>> headers = Map.of("content-type", List.of("application/json"));
+        var request = new IdTokenRequest(TOKEN, headers);
+        assertEquals(TOKEN, request.tokenString());
+        assertEquals(1, request.httpHeaders().size());
+    }
+
+    @Test
+    @DisplayName("should reject null token string")
+    void shouldRejectNullTokenString() {
+        assertThrows(NullPointerException.class, () -> IdTokenRequest.of(null));
+    }
+
+    @Test
+    @DisplayName("should reject null headers")
+    void shouldRejectNullHeaders() {
+        assertThrows(NullPointerException.class, () -> new IdTokenRequest(TOKEN, null));
+    }
+
+    @Test
+    @DisplayName("should defensively copy headers")
+    void shouldDefensivelyCopyHeaders() {
+        Map<String, List<String>> mutableHeaders = new HashMap<>();
+        mutableHeaders.put("authorization", new ArrayList<>(List.of("Bearer token")));
+
+        var request = new IdTokenRequest(TOKEN, mutableHeaders);
+        mutableHeaders.put("x-new-header", List.of("value"));
+
+        assertFalse(request.httpHeaders().containsKey("x-new-header"));
+    }
+
+    @Test
+    @DisplayName("should return immutable headers")
+    void shouldReturnImmutableHeaders() {
+        var request = new IdTokenRequest(TOKEN, Map.of("key", List.of("value")));
+        assertThrows(UnsupportedOperationException.class,
+                () -> request.httpHeaders().put("new", List.of("val")));
+    }
+
+    @Test
+    @DisplayName("should implement TokenValidationRequest sealed interface")
+    void shouldImplementSealedInterface() {
+        TokenValidationRequest request = IdTokenRequest.of(TOKEN);
+        assertInstanceOf(IdTokenRequest.class, request);
+        assertEquals(TOKEN, request.tokenString());
+    }
+
+    @Test
+    @DisplayName("should support record equality")
+    void shouldSupportEquality() {
+        var request1 = IdTokenRequest.of(TOKEN);
+        var request2 = IdTokenRequest.of(TOKEN);
+        assertEquals(request1, request2);
+        assertEquals(request1.hashCode(), request2.hashCode());
+    }
+}

--- a/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/domain/context/RefreshTokenRequestTest.java
+++ b/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/domain/context/RefreshTokenRequestTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.oauth.core.domain.context;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("RefreshTokenRequest")
+class RefreshTokenRequestTest {
+
+    private static final String TOKEN = "opaque-refresh-token-value";
+
+    @Test
+    @DisplayName("should create request with token string and empty headers via factory")
+    void shouldCreateWithFactory() {
+        var request = RefreshTokenRequest.of(TOKEN);
+        assertEquals(TOKEN, request.tokenString());
+        assertTrue(request.httpHeaders().isEmpty());
+    }
+
+    @Test
+    @DisplayName("should create request with token string and headers")
+    void shouldCreateWithHeaders() {
+        Map<String, List<String>> headers = Map.of("content-type", List.of("application/json"));
+        var request = new RefreshTokenRequest(TOKEN, headers);
+        assertEquals(TOKEN, request.tokenString());
+        assertEquals(1, request.httpHeaders().size());
+    }
+
+    @Test
+    @DisplayName("should reject null token string")
+    void shouldRejectNullTokenString() {
+        assertThrows(NullPointerException.class, () -> RefreshTokenRequest.of(null));
+    }
+
+    @Test
+    @DisplayName("should reject null headers")
+    void shouldRejectNullHeaders() {
+        assertThrows(NullPointerException.class, () -> new RefreshTokenRequest(TOKEN, null));
+    }
+
+    @Test
+    @DisplayName("should defensively copy headers")
+    void shouldDefensivelyCopyHeaders() {
+        Map<String, List<String>> mutableHeaders = new HashMap<>();
+        mutableHeaders.put("authorization", new ArrayList<>(List.of("Bearer token")));
+
+        var request = new RefreshTokenRequest(TOKEN, mutableHeaders);
+        mutableHeaders.put("x-new-header", List.of("value"));
+
+        assertFalse(request.httpHeaders().containsKey("x-new-header"));
+    }
+
+    @Test
+    @DisplayName("should return immutable headers")
+    void shouldReturnImmutableHeaders() {
+        var request = new RefreshTokenRequest(TOKEN, Map.of("key", List.of("value")));
+        assertThrows(UnsupportedOperationException.class,
+                () -> request.httpHeaders().put("new", List.of("val")));
+    }
+
+    @Test
+    @DisplayName("should implement TokenValidationRequest sealed interface")
+    void shouldImplementSealedInterface() {
+        TokenValidationRequest request = RefreshTokenRequest.of(TOKEN);
+        assertInstanceOf(RefreshTokenRequest.class, request);
+        assertEquals(TOKEN, request.tokenString());
+    }
+
+    @Test
+    @DisplayName("should support record equality")
+    void shouldSupportEquality() {
+        var request1 = RefreshTokenRequest.of(TOKEN);
+        var request2 = RefreshTokenRequest.of(TOKEN);
+        assertEquals(request1, request2);
+        assertEquals(request1.hashCode(), request2.hashCode());
+    }
+}

--- a/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/pipeline/IdTokenValidationPipelineTest.java
+++ b/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/pipeline/IdTokenValidationPipelineTest.java
@@ -18,6 +18,7 @@ package de.cuioss.sheriff.oauth.core.pipeline;
 import de.cuioss.sheriff.oauth.core.JWTValidationLogMessages;
 import de.cuioss.sheriff.oauth.core.TokenType;
 import de.cuioss.sheriff.oauth.core.TokenValidator;
+import de.cuioss.sheriff.oauth.core.domain.context.IdTokenRequest;
 import de.cuioss.sheriff.oauth.core.domain.token.IdTokenContent;
 import de.cuioss.sheriff.oauth.core.exception.TokenValidationException;
 import de.cuioss.sheriff.oauth.core.security.SecurityEventCounter;
@@ -62,7 +63,7 @@ class IdTokenValidationPipelineTest {
         String tokenString = tokenHolder.getRawToken();
 
         // When
-        IdTokenContent result = tokenValidator.createIdToken(tokenString);
+        IdTokenContent result = tokenValidator.createIdToken(IdTokenRequest.of(tokenString));
 
         // Then
         assertNotNull(result);
@@ -82,7 +83,7 @@ class IdTokenValidationPipelineTest {
         // When/Then
         TokenValidationException exception = assertThrows(
                 TokenValidationException.class,
-                () -> tokenValidator.createIdToken(tokenString),
+                () -> tokenValidator.createIdToken(IdTokenRequest.of(tokenString)),
                 "Should throw TokenValidationException for missing issuer"
         );
 
@@ -108,7 +109,7 @@ class IdTokenValidationPipelineTest {
         // When/Then
         assertThrows(
                 TokenValidationException.class,
-                () -> tokenValidator.createIdToken(tokenString),
+                () -> tokenValidator.createIdToken(IdTokenRequest.of(tokenString)),
                 "Should consistently throw TokenValidationException for missing issuer"
         );
     }

--- a/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/pipeline/RefreshTokenValidationPipelineTest.java
+++ b/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/pipeline/RefreshTokenValidationPipelineTest.java
@@ -15,6 +15,7 @@
  */
 package de.cuioss.sheriff.oauth.core.pipeline;
 
+import de.cuioss.sheriff.oauth.core.domain.context.RefreshTokenRequest;
 import de.cuioss.sheriff.oauth.core.domain.token.RefreshTokenContent;
 import de.cuioss.sheriff.oauth.core.security.SecurityEventCounter;
 import de.cuioss.sheriff.oauth.core.test.TestTokenHolder;
@@ -53,7 +54,7 @@ class RefreshTokenValidationPipelineTest {
         TestTokenHolder tokenHolder = TestTokenGenerators.refreshTokens().next();
         String tokenString = tokenHolder.getRawToken();
 
-        RefreshTokenContent result = pipeline.validate(tokenString);
+        RefreshTokenContent result = pipeline.validate(RefreshTokenRequest.of(tokenString));
 
         assertNotNull(result);
         assertEquals(tokenString, result.getRawToken());
@@ -66,7 +67,7 @@ class RefreshTokenValidationPipelineTest {
         // Opaque refresh tokens are not JWTs
         String opaqueToken = "opaque_refresh_token_12345";
 
-        RefreshTokenContent result = pipeline.validate(opaqueToken);
+        RefreshTokenContent result = pipeline.validate(RefreshTokenRequest.of(opaqueToken));
 
         assertNotNull(result);
         assertEquals(opaqueToken, result.getRawToken());
@@ -79,7 +80,7 @@ class RefreshTokenValidationPipelineTest {
         // Invalid JWT format should not throw exception for refresh tokens
         String invalidJwt = "not.a.valid.jwt.token";
 
-        RefreshTokenContent result = pipeline.validate(invalidJwt);
+        RefreshTokenContent result = pipeline.validate(RefreshTokenRequest.of(invalidJwt));
 
         assertNotNull(result);
         assertEquals(invalidJwt, result.getRawToken());
@@ -94,7 +95,7 @@ class RefreshTokenValidationPipelineTest {
         String tokenString = tokenHolder.getRawToken();
 
         assertDoesNotThrow(() -> {
-            RefreshTokenContent result = pipeline.validate(tokenString);
+            RefreshTokenContent result = pipeline.validate(RefreshTokenRequest.of(tokenString));
             assertNotNull(result);
         });
     }

--- a/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/pipeline/validator/TokenHeaderValidatorTest.java
+++ b/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/pipeline/validator/TokenHeaderValidatorTest.java
@@ -18,6 +18,7 @@ package de.cuioss.sheriff.oauth.core.pipeline.validator;
 import de.cuioss.sheriff.oauth.core.IssuerConfig;
 import de.cuioss.sheriff.oauth.core.JWTValidationLogMessages;
 import de.cuioss.sheriff.oauth.core.TokenType;
+import de.cuioss.sheriff.oauth.core.domain.context.AccessTokenRequest;
 import de.cuioss.sheriff.oauth.core.exception.TokenValidationException;
 import de.cuioss.sheriff.oauth.core.json.JwtHeader;
 import de.cuioss.sheriff.oauth.core.json.MapRepresentation;
@@ -121,7 +122,7 @@ class TokenHeaderValidatorTest {
             DecodedJwt decodedJwt = JWT_PARSER.decode(token);
 
             // When validating the validation, it should not throw an exception
-            assertDoesNotThrow(() -> validator.validate(decodedJwt));
+            assertDoesNotThrow(() -> validator.validate(decodedJwt, AccessTokenRequest.of("test")));
         }
 
         @Test
@@ -146,7 +147,7 @@ class TokenHeaderValidatorTest {
 
             // When validating the validation, it should throw an exception
             var exception = assertThrows(TokenValidationException.class,
-                    () -> validator.validate(decodedJwt));
+                    () -> validator.validate(decodedJwt, AccessTokenRequest.of("test")));
 
             // Verify the exception has the correct event type
             assertEquals(SecurityEventCounter.EventType.UNSUPPORTED_ALGORITHM, exception.getEventType());
@@ -177,7 +178,7 @@ class TokenHeaderValidatorTest {
 
             // When validating the validation, it should throw an exception
             var exception = assertThrows(TokenValidationException.class,
-                    () -> validator.validate(decodedJwt));
+                    () -> validator.validate(decodedJwt, AccessTokenRequest.of("test")));
 
             // Verify the exception has the correct event type
             assertEquals(SecurityEventCounter.EventType.MISSING_CLAIM, exception.getEventType());
@@ -233,7 +234,7 @@ class TokenHeaderValidatorTest {
 
             // When validating the token, it should throw an exception
             var exception = assertThrows(TokenValidationException.class,
-                    () -> validator.validate(decodedJwt));
+                    () -> validator.validate(decodedJwt, AccessTokenRequest.of("test")));
 
             // Verify the exception has the correct event type
             assertEquals(SecurityEventCounter.EventType.MISSING_CLAIM, exception.getEventType());
@@ -284,7 +285,7 @@ class TokenHeaderValidatorTest {
 
             // When validating the token, it should throw an exception
             var exception = assertThrows(TokenValidationException.class,
-                    () -> validator.validate(decodedJwt));
+                    () -> validator.validate(decodedJwt, AccessTokenRequest.of("test")));
 
             // Verify the exception message includes available header info (only alg)
             assertTrue(exception.getMessage().contains("alg=RS256"));
@@ -327,7 +328,7 @@ class TokenHeaderValidatorTest {
             // When validating the token, it should throw an exception for missing alg first
             // (alg validation comes before kid validation)
             var exception = assertThrows(TokenValidationException.class,
-                    () -> validator.validate(decodedJwt));
+                    () -> validator.validate(decodedJwt, AccessTokenRequest.of("test")));
 
             // Verify the exception is for missing alg (not kid, since alg is checked first)
             assertEquals(SecurityEventCounter.EventType.MISSING_CLAIM, exception.getEventType());
@@ -389,7 +390,7 @@ class TokenHeaderValidatorTest {
 
             // When validating the token, it should throw an exception
             var exception = assertThrows(TokenValidationException.class,
-                    () -> validator.validate(decodedJwt));
+                    () -> validator.validate(decodedJwt, AccessTokenRequest.of("test")));
 
             // Verify the exception has the correct event type
             assertEquals(SecurityEventCounter.EventType.UNSUPPORTED_ALGORITHM, exception.getEventType());
@@ -440,7 +441,7 @@ class TokenHeaderValidatorTest {
             );
 
             // When validating the token, it should not throw an exception for embedded JWK
-            assertDoesNotThrow(() -> validator.validate(decodedJwt));
+            assertDoesNotThrow(() -> validator.validate(decodedJwt, AccessTokenRequest.of("test")));
         }
     }
 

--- a/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/security/EmbeddedJwkAttackTest.java
+++ b/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/security/EmbeddedJwkAttackTest.java
@@ -19,6 +19,7 @@ import de.cuioss.sheriff.oauth.core.IssuerConfig;
 import de.cuioss.sheriff.oauth.core.ParserConfig;
 import de.cuioss.sheriff.oauth.core.TokenType;
 import de.cuioss.sheriff.oauth.core.TokenValidator;
+import de.cuioss.sheriff.oauth.core.domain.context.AccessTokenRequest;
 import de.cuioss.sheriff.oauth.core.exception.TokenValidationException;
 import de.cuioss.sheriff.oauth.core.test.InMemoryJWKSFactory;
 import de.cuioss.sheriff.oauth.core.test.TestTokenHolder;
@@ -82,7 +83,7 @@ class EmbeddedJwkAttackTest {
         String tamperedToken = tamperedHeader + "." + parts[1] + "." + parts[2];
 
         assertThrows(TokenValidationException.class,
-                () -> tokenValidator.createAccessToken(tamperedToken),
+                () -> tokenValidator.createAccessToken(AccessTokenRequest.of(tamperedToken)),
                 "Should reject token with embedded JWK header");
 
         assertTrue(tokenValidator.getSecurityEventCounter().getCount(SecurityEventCounter.EventType.SIGNATURE_VALIDATION_FAILED) >= 0,

--- a/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/security/JkuX5uAttackTest.java
+++ b/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/security/JkuX5uAttackTest.java
@@ -19,6 +19,7 @@ import de.cuioss.sheriff.oauth.core.IssuerConfig;
 import de.cuioss.sheriff.oauth.core.ParserConfig;
 import de.cuioss.sheriff.oauth.core.TokenType;
 import de.cuioss.sheriff.oauth.core.TokenValidator;
+import de.cuioss.sheriff.oauth.core.domain.context.AccessTokenRequest;
 import de.cuioss.sheriff.oauth.core.exception.TokenValidationException;
 import de.cuioss.sheriff.oauth.core.test.InMemoryJWKSFactory;
 import de.cuioss.sheriff.oauth.core.test.TestTokenHolder;
@@ -82,7 +83,7 @@ class JkuX5uAttackTest {
         String tamperedToken = tamperedHeader + "." + parts[1] + "." + parts[2];
 
         assertThrows(TokenValidationException.class,
-                () -> tokenValidator.createAccessToken(tamperedToken),
+                () -> tokenValidator.createAccessToken(AccessTokenRequest.of(tamperedToken)),
                 "Should reject token with malicious JKU header");
         assertTrue(tokenValidator.getSecurityEventCounter().getCount(SecurityEventCounter.EventType.SIGNATURE_VALIDATION_FAILED) >= 0,
                 "Security event counter should track JKU header attack attempts");
@@ -105,7 +106,7 @@ class JkuX5uAttackTest {
         String tamperedToken = tamperedHeader + "." + parts[1] + "." + parts[2];
 
         assertThrows(TokenValidationException.class,
-                () -> tokenValidator.createAccessToken(tamperedToken),
+                () -> tokenValidator.createAccessToken(AccessTokenRequest.of(tamperedToken)),
                 "Should reject token with malicious X5U header");
         assertTrue(tokenValidator.getSecurityEventCounter().getCount(SecurityEventCounter.EventType.SIGNATURE_VALIDATION_FAILED) >= 0,
                 "Security event counter should track X5U header attack attempts");

--- a/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/security/KeyInjectionAttackTest.java
+++ b/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/security/KeyInjectionAttackTest.java
@@ -19,6 +19,7 @@ import de.cuioss.sheriff.oauth.core.IssuerConfig;
 import de.cuioss.sheriff.oauth.core.ParserConfig;
 import de.cuioss.sheriff.oauth.core.TokenType;
 import de.cuioss.sheriff.oauth.core.TokenValidator;
+import de.cuioss.sheriff.oauth.core.domain.context.AccessTokenRequest;
 import de.cuioss.sheriff.oauth.core.exception.TokenValidationException;
 import de.cuioss.sheriff.oauth.core.test.TestTokenHolder;
 import de.cuioss.sheriff.oauth.core.test.generator.TestTokenGenerators;
@@ -184,7 +185,7 @@ class KeyInjectionAttackTest {
 
         // Verify that the token is rejected
         var exception = assertThrows(TokenValidationException.class,
-                () -> tokenValidator.createAccessToken(token));
+                () -> tokenValidator.createAccessToken(AccessTokenRequest.of(token)));
 
         // Verify the error message if needed
         LOGGER.debug("Exception message: %s", exception.getMessage());
@@ -206,7 +207,7 @@ class KeyInjectionAttackTest {
 
         LOGGER.debug("Using valid token: %s", token);
 
-        var accessToken = tokenValidator.createAccessToken(token);
+        var accessToken = tokenValidator.createAccessToken(AccessTokenRequest.of(token));
         assertNotNull(accessToken, "Token with valid KID should be accepted");
         assertEquals(0, tokenValidator.getSecurityEventCounter().getCount(SecurityEventCounter.EventType.KEY_NOT_FOUND),
                 "No KEY_NOT_FOUND security events should be recorded for valid token");

--- a/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/security/PsychicSignatureAttackTest.java
+++ b/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/security/PsychicSignatureAttackTest.java
@@ -18,6 +18,7 @@ package de.cuioss.sheriff.oauth.core.security;
 import de.cuioss.sheriff.oauth.core.IssuerConfig;
 import de.cuioss.sheriff.oauth.core.ParserConfig;
 import de.cuioss.sheriff.oauth.core.TokenValidator;
+import de.cuioss.sheriff.oauth.core.domain.context.AccessTokenRequest;
 import de.cuioss.sheriff.oauth.core.exception.TokenValidationException;
 import de.cuioss.sheriff.oauth.core.test.InMemoryJWKSFactory;
 import de.cuioss.sheriff.oauth.core.test.InMemoryKeyMaterialHandler;
@@ -81,7 +82,7 @@ class PsychicSignatureAttackTest {
 
         // Verify that the token is rejected
         assertThrows(TokenValidationException.class,
-                () -> tokenValidator.createAccessToken(tamperedToken));
+                () -> tokenValidator.createAccessToken(AccessTokenRequest.of(tamperedToken)));
 
         // Verify that the security event counter was incremented
         // The logs show that ES256 is an unsupported algorithm, so we should check for that event
@@ -111,7 +112,7 @@ class PsychicSignatureAttackTest {
 
         // Verify that the token is rejected
         assertThrows(TokenValidationException.class,
-                () -> tokenValidator.createAccessToken(tamperedToken));
+                () -> tokenValidator.createAccessToken(AccessTokenRequest.of(tamperedToken)));
 
         // Verify that the security event counter was incremented
         // The logs show that ES384 is an unsupported algorithm, so we should check for that event
@@ -141,7 +142,7 @@ class PsychicSignatureAttackTest {
 
         // Verify that the token is rejected
         assertThrows(TokenValidationException.class,
-                () -> tokenValidator.createAccessToken(tamperedToken));
+                () -> tokenValidator.createAccessToken(AccessTokenRequest.of(tamperedToken)));
 
         // Verify that the security event counter was incremented
         // The logs show that ES512 is an unsupported algorithm, so we should check for that event

--- a/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/security/TokenValidationSecurityTest.java
+++ b/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/security/TokenValidationSecurityTest.java
@@ -19,6 +19,7 @@ import de.cuioss.sheriff.oauth.core.IssuerConfig;
 import de.cuioss.sheriff.oauth.core.ParserConfig;
 import de.cuioss.sheriff.oauth.core.TokenType;
 import de.cuioss.sheriff.oauth.core.TokenValidator;
+import de.cuioss.sheriff.oauth.core.domain.context.AccessTokenRequest;
 import de.cuioss.sheriff.oauth.core.domain.token.AccessTokenContent;
 import de.cuioss.sheriff.oauth.core.exception.TokenValidationException;
 import de.cuioss.sheriff.oauth.core.test.InMemoryJWKSFactory;
@@ -90,7 +91,7 @@ class TokenValidationSecurityTest {
         String tamperedToken = parts[0] + "." + tamperedPayload + ".";
 
         assertThrows(TokenValidationException.class, () ->
-                        tokenValidator.createAccessToken(tamperedToken),
+                        tokenValidator.createAccessToken(AccessTokenRequest.of(tamperedToken)),
                 "Should reject token with tampered payload");
     }
 
@@ -105,7 +106,7 @@ class TokenValidationSecurityTest {
         assertNotEquals(validToken, tamperedToken, "Tampered token should be different from valid token");
 
         assertThrows(TokenValidationException.class, () ->
-                        tokenValidator.createAccessToken(tamperedToken),
+                        tokenValidator.createAccessToken(AccessTokenRequest.of(tamperedToken)),
                 "Should reject token with tampered signature: " + tamperedToken);
     }
 
@@ -117,7 +118,7 @@ class TokenValidationSecurityTest {
         String tamperedToken = JwtTokenTamperingUtil.applyTamperingStrategy(validToken, TamperingStrategy.ALGORITHM_NONE);
 
         assertThrows(TokenValidationException.class, () ->
-                        tokenValidator.createAccessToken(tamperedToken),
+                        tokenValidator.createAccessToken(AccessTokenRequest.of(tamperedToken)),
                 "Should reject token with 'none' algorithm");
     }
 
@@ -146,7 +147,7 @@ class TokenValidationSecurityTest {
 
         // Verify that the tampered token is rejected
         assertThrows(TokenValidationException.class, () ->
-                tokenValidator.createAccessToken(tamperedToken));
+                tokenValidator.createAccessToken(AccessTokenRequest.of(tamperedToken)));
     }
 
     @ParameterizedTest
@@ -154,7 +155,7 @@ class TokenValidationSecurityTest {
     @DisplayName("Should accept valid tokens")
     void shouldAcceptValidTokens(TestTokenHolder tokenHolder) {
         String validToken = tokenHolder.getRawToken();
-        AccessTokenContent tokenContent = tokenValidator.createAccessToken(validToken);
+        AccessTokenContent tokenContent = tokenValidator.createAccessToken(AccessTokenRequest.of(validToken));
 
         assertNotNull(tokenContent, "Token content should not be null");
         assertEquals("Token-Test-testIssuer", tokenContent.getIssuer(), "Issuer should match expected");
@@ -168,7 +169,7 @@ class TokenValidationSecurityTest {
         String tamperedToken = JwtTokenTamperingUtil.applyTamperingStrategy(validToken, TamperingStrategy.ALGORITHM_DOWNGRADE);
 
         assertThrows(TokenValidationException.class, () ->
-                        tokenValidator.createAccessToken(tamperedToken),
+                        tokenValidator.createAccessToken(AccessTokenRequest.of(tamperedToken)),
                 "Should reject token with downgraded algorithm");
     }
 
@@ -180,7 +181,7 @@ class TokenValidationSecurityTest {
         String tamperedToken = JwtTokenTamperingUtil.applyTamperingStrategy(validToken, TamperingStrategy.INVALID_KID);
 
         assertThrows(TokenValidationException.class, () ->
-                        tokenValidator.createAccessToken(tamperedToken),
+                        tokenValidator.createAccessToken(AccessTokenRequest.of(tamperedToken)),
                 "Should reject token with invalid key ID");
     }
 }

--- a/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/test/JwtTokenTamperingUtilTest.java
+++ b/oauth-sheriff-core/src/test/java/de/cuioss/sheriff/oauth/core/test/JwtTokenTamperingUtilTest.java
@@ -18,6 +18,8 @@ package de.cuioss.sheriff.oauth.core.test;
 import de.cuioss.sheriff.oauth.core.IssuerConfig;
 import de.cuioss.sheriff.oauth.core.ParserConfig;
 import de.cuioss.sheriff.oauth.core.TokenValidator;
+import de.cuioss.sheriff.oauth.core.domain.context.AccessTokenRequest;
+import de.cuioss.sheriff.oauth.core.domain.context.IdTokenRequest;
 import de.cuioss.sheriff.oauth.core.domain.token.AccessTokenContent;
 import de.cuioss.sheriff.oauth.core.domain.token.IdTokenContent;
 import de.cuioss.sheriff.oauth.core.exception.TokenValidationException;
@@ -66,7 +68,7 @@ class JwtTokenTamperingUtilTest {
     void shouldValidateUntamperedAccessToken() {
 
         String token = TestTokenGenerators.accessTokens().next().getRawToken();
-        AccessTokenContent result = tokenValidator.createAccessToken(token);
+        AccessTokenContent result = tokenValidator.createAccessToken(AccessTokenRequest.of(token));
         assertNotNull(result, "Untampered token should be valid");
     }
 
@@ -75,7 +77,7 @@ class JwtTokenTamperingUtilTest {
     void shouldValidateUntamperedIdToken() {
 
         String token = TestTokenGenerators.idTokens().next().getRawToken();
-        IdTokenContent result = tokenValidator.createIdToken(token);
+        IdTokenContent result = tokenValidator.createIdToken(IdTokenRequest.of(token));
         assertNotNull(result, "Untampered token should be valid");
     }
 
@@ -91,7 +93,7 @@ class JwtTokenTamperingUtilTest {
         assertNotEquals(originalToken, tamperedToken,
                 "Token should be tampered using strategy: " + strategy.getDescription());
         TokenValidationException exception = assertThrows(TokenValidationException.class,
-                () -> tokenValidator.createAccessToken(tamperedToken),
+                () -> tokenValidator.createAccessToken(AccessTokenRequest.of(tamperedToken)),
                 "Tampered token should be rejected. Strategy: " + strategy.getDescription());
 
         // Verify the exception has a valid event type
@@ -111,7 +113,7 @@ class JwtTokenTamperingUtilTest {
         assertNotEquals(originalToken, tamperedToken,
                 "Token should be tampered using strategy: " + strategy.getDescription());
         TokenValidationException exception = assertThrows(TokenValidationException.class,
-                () -> tokenValidator.createIdToken(tamperedToken),
+                () -> tokenValidator.createIdToken(IdTokenRequest.of(tamperedToken)),
                 "Tampered token should be rejected. Strategy: " + strategy.getDescription());
 
         // Verify the exception has a valid event type

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus-integration-tests/src/main/java/de/cuioss/sheriff/oauth/integration/endpoint/JwtValidationEndpoint.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus-integration-tests/src/main/java/de/cuioss/sheriff/oauth/integration/endpoint/JwtValidationEndpoint.java
@@ -16,6 +16,9 @@
 package de.cuioss.sheriff.oauth.integration.endpoint;
 
 import de.cuioss.sheriff.oauth.core.TokenValidator;
+import de.cuioss.sheriff.oauth.core.domain.context.AccessTokenRequest;
+import de.cuioss.sheriff.oauth.core.domain.context.IdTokenRequest;
+import de.cuioss.sheriff.oauth.core.domain.context.RefreshTokenRequest;
 import de.cuioss.sheriff.oauth.core.domain.token.AccessTokenContent;
 import de.cuioss.sheriff.oauth.core.exception.TokenValidationException;
 import de.cuioss.sheriff.oauth.quarkus.annotation.BearerAuth;
@@ -120,7 +123,7 @@ public class JwtValidationEndpoint {
         }
 
         try {
-            AccessTokenContent token = tokenValidator.createAccessToken(tokenRequest.token().trim());
+            AccessTokenContent token = tokenValidator.createAccessToken(AccessTokenRequest.of(tokenRequest.token().trim()));
             LOGGER.debug("Explicit token validated successfully - Subject: %s, Roles: %s, Groups: %s, Scopes: %s",
                     token.getSubject().orElse("none"), token.getRoles(), token.getGroups(), token.getScopes());
             return Response.ok(createTokenResponse(token, "Access token is valid")).build();
@@ -146,7 +149,7 @@ public class JwtValidationEndpoint {
         }
 
         try {
-            tokenValidator.createIdToken(tokenRequest.token().trim());
+            tokenValidator.createIdToken(IdTokenRequest.of(tokenRequest.token().trim()));
             return Response.ok(new ValidationResponse(true, "ID token is valid")).build();
         } catch (TokenValidationException e) {
             LOGGER.debug("ID token validation failed: %s", e.getMessage());
@@ -170,7 +173,7 @@ public class JwtValidationEndpoint {
         }
 
         try {
-            tokenValidator.createRefreshToken(tokenRequest.token().trim());
+            tokenValidator.createRefreshToken(RefreshTokenRequest.of(tokenRequest.token().trim()));
             return Response.ok(new ValidationResponse(true, "Refresh token is valid")).build();
         } catch (TokenValidationException e) {
             LOGGER.debug("Refresh token validation failed: %s", e.getMessage());

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/README.adoc
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/README.adoc
@@ -149,7 +149,7 @@ TokenValidator tokenValidator;
 
 public void processRequest(String jwtString) {
     try {
-        AccessTokenContent token = tokenValidator.createAccessToken(jwtString);
+        AccessTokenContent token = tokenValidator.createAccessToken(AccessTokenRequest.of(jwtString));
         String subject = token.getSubject();
         List<String> roles = token.getRoles();
         // Process valid token

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/runtime/OAuthSheriffDevUIRuntimeService.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/runtime/OAuthSheriffDevUIRuntimeService.java
@@ -18,6 +18,7 @@ package de.cuioss.sheriff.oauth.quarkus.runtime;
 import de.cuioss.sheriff.oauth.core.IssuerConfig;
 import de.cuioss.sheriff.oauth.core.ParserConfig;
 import de.cuioss.sheriff.oauth.core.TokenValidator;
+import de.cuioss.sheriff.oauth.core.domain.context.AccessTokenRequest;
 import de.cuioss.sheriff.oauth.core.domain.token.TokenContent;
 import de.cuioss.sheriff.oauth.core.exception.TokenValidationException;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -209,7 +210,7 @@ public class OAuthSheriffDevUIRuntimeService {
 
         try {
             // Only validate as access token
-            TokenContent tokenContent = tokenValidator.createAccessToken(token.trim());
+            TokenContent tokenContent = tokenValidator.createAccessToken(AccessTokenRequest.of(token.trim()));
 
             result.put(VALID, true);
             result.put(TOKEN_TYPE, "ACCESS_TOKEN");

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/test/java/de/cuioss/sheriff/oauth/quarkus/metrics/MetricsIntegrationTest.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/test/java/de/cuioss/sheriff/oauth/quarkus/metrics/MetricsIntegrationTest.java
@@ -16,6 +16,7 @@
 package de.cuioss.sheriff.oauth.quarkus.metrics;
 
 import de.cuioss.sheriff.oauth.core.TokenValidator;
+import de.cuioss.sheriff.oauth.core.domain.context.AccessTokenRequest;
 import de.cuioss.sheriff.oauth.core.exception.TokenValidationException;
 import de.cuioss.sheriff.oauth.core.security.SecurityEventCounter;
 import de.cuioss.sheriff.oauth.quarkus.config.JwtPropertyKeys;
@@ -62,7 +63,7 @@ class MetricsIntegrationTest {
 
         String invalidToken = "invalid.jwt.token";
 
-        assertThrows(TokenValidationException.class, () -> tokenValidator.createAccessToken(invalidToken),
+        assertThrows(TokenValidationException.class, () -> tokenValidator.createAccessToken(AccessTokenRequest.of(invalidToken)),
                 "Should have thrown TokenValidationException for invalid token");
 
         assertNotNull(meterRegistry.find(JwtPropertyKeys.METRICS.VALIDATION_ERRORS).counters(),
@@ -135,7 +136,7 @@ class MetricsIntegrationTest {
         // Force initialization of metrics collector
         metricsCollector.updateCounters();
 
-        Exception thrownException = assertThrows(expectedException, () -> tokenValidator.createAccessToken(invalidToken), "Should throw an exception for invalid token: " + description);
+        Exception thrownException = assertThrows(expectedException, () -> tokenValidator.createAccessToken(AccessTokenRequest.of(invalidToken)), "Should throw an exception for invalid token: " + description);
 
         assertTrue(expectedException.isAssignableFrom(thrownException.getClass()),
                 "Expected exception of type " + expectedException.getSimpleName() +

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/test/java/de/cuioss/sheriff/oauth/quarkus/producer/BearerTokenProducerTest.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/test/java/de/cuioss/sheriff/oauth/quarkus/producer/BearerTokenProducerTest.java
@@ -16,6 +16,7 @@
 package de.cuioss.sheriff.oauth.quarkus.producer;
 
 import de.cuioss.sheriff.oauth.core.TokenValidator;
+import de.cuioss.sheriff.oauth.core.domain.context.AccessTokenRequest;
 import de.cuioss.sheriff.oauth.core.domain.token.AccessTokenContent;
 import de.cuioss.sheriff.oauth.core.exception.TokenValidationException;
 import de.cuioss.sheriff.oauth.core.security.SecurityEventCounter;
@@ -89,7 +90,7 @@ class BearerTokenProducerTest {
         servletResolverMock.setBearerToken(token);
 
         AccessTokenContent mockContent = createMock(AccessTokenContent.class);
-        expect(tokenValidator.createAccessToken(token)).andReturn(mockContent);
+        expect(tokenValidator.createAccessToken(anyObject(AccessTokenRequest.class))).andReturn(mockContent);
         expect(mockContent.determineMissingScopes(anyObject())).andReturn(Set.of());
         expect(mockContent.determineMissingRoles(anyObject())).andReturn(Set.of());
         expect(mockContent.determineMissingGroups(anyObject())).andReturn(Set.of());
@@ -115,7 +116,7 @@ class BearerTokenProducerTest {
         Set<String> requiredScopes = Set.of("admin", "write");
         Set<String> missingScopes = Set.of("admin");
 
-        expect(tokenValidator.createAccessToken(token)).andReturn(mockContent);
+        expect(tokenValidator.createAccessToken(anyObject(AccessTokenRequest.class))).andReturn(mockContent);
         expect(mockContent.determineMissingScopes(requiredScopes)).andReturn(missingScopes);
         expect(mockContent.determineMissingRoles(anyObject())).andReturn(Set.of());
         expect(mockContent.determineMissingGroups(anyObject())).andReturn(Set.of());
@@ -142,7 +143,7 @@ class BearerTokenProducerTest {
         Set<String> requiredRoles = Set.of("user", "admin");
         Set<String> missingRoles = Set.of("admin");
 
-        expect(tokenValidator.createAccessToken(token)).andReturn(mockContent);
+        expect(tokenValidator.createAccessToken(anyObject(AccessTokenRequest.class))).andReturn(mockContent);
         expect(mockContent.determineMissingScopes(anyObject())).andReturn(Set.of());
         expect(mockContent.determineMissingRoles(requiredRoles)).andReturn(missingRoles);
         expect(mockContent.determineMissingGroups(anyObject())).andReturn(Set.of());
@@ -169,7 +170,7 @@ class BearerTokenProducerTest {
         Set<String> requiredGroups = Set.of("developers", "managers");
         Set<String> missingGroups = Set.of("managers");
 
-        expect(tokenValidator.createAccessToken(token)).andReturn(mockContent);
+        expect(tokenValidator.createAccessToken(anyObject(AccessTokenRequest.class))).andReturn(mockContent);
         expect(mockContent.determineMissingScopes(anyObject())).andReturn(Set.of());
         expect(mockContent.determineMissingRoles(anyObject())).andReturn(Set.of());
         expect(mockContent.determineMissingGroups(requiredGroups)).andReturn(missingGroups);
@@ -194,7 +195,7 @@ class BearerTokenProducerTest {
 
         TokenValidationException exception = new TokenValidationException(
                 SecurityEventCounter.EventType.SIGNATURE_VALIDATION_FAILED, "Invalid signature");
-        expect(tokenValidator.createAccessToken(token)).andThrow(exception);
+        expect(tokenValidator.createAccessToken(anyObject(AccessTokenRequest.class))).andThrow(exception);
         replay(tokenValidator);
 
         BearerTokenResult result = producer.getBearerTokenResult(Set.of(), Set.of(), Set.of());
@@ -214,7 +215,7 @@ class BearerTokenProducerTest {
         servletResolverMock.setBearerToken(token);
 
         AccessTokenContent mockContent = createMock(AccessTokenContent.class);
-        expect(tokenValidator.createAccessToken(token)).andReturn(mockContent);
+        expect(tokenValidator.createAccessToken(anyObject(AccessTokenRequest.class))).andReturn(mockContent);
         expect(mockContent.determineMissingScopes(anyObject())).andReturn(Set.of());
         expect(mockContent.determineMissingRoles(anyObject())).andReturn(Set.of());
         expect(mockContent.determineMissingGroups(anyObject())).andReturn(Set.of());

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/test/java/de/cuioss/sheriff/oauth/quarkus/producer/QuarkusTokenValidatorProducerTest.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/test/java/de/cuioss/sheriff/oauth/quarkus/producer/QuarkusTokenValidatorProducerTest.java
@@ -17,6 +17,7 @@ package de.cuioss.sheriff.oauth.quarkus.producer;
 
 import de.cuioss.sheriff.oauth.core.IssuerConfig;
 import de.cuioss.sheriff.oauth.core.TokenValidator;
+import de.cuioss.sheriff.oauth.core.domain.context.AccessTokenRequest;
 import de.cuioss.sheriff.oauth.core.exception.TokenValidationException;
 import de.cuioss.sheriff.oauth.core.security.SecurityEventCounter;
 import de.cuioss.sheriff.oauth.quarkus.config.JwtTestProfile;
@@ -77,7 +78,7 @@ class QuarkusTokenValidatorProducerTest {
     void shouldRejectInvalidTokensInIntegratedEnvironment() {
         String invalidToken = "invalid.token.format";
 
-        assertThrows(TokenValidationException.class, () -> tokenValidator.createAccessToken(invalidToken),
+        assertThrows(TokenValidationException.class, () -> tokenValidator.createAccessToken(AccessTokenRequest.of(invalidToken)),
                 "Integrated TokenValidator should reject invalid tokens");
     }
 


### PR DESCRIPTION
## Summary

Introduces sealed record types (`AccessTokenRequest`, `IdTokenRequest`, `RefreshTokenRequest`) as parameter objects for `TokenValidator`'s public API, replacing bare `String` parameters. This carries both the token string and HTTP headers through the validation pipeline.

**Motivation:** Prerequisite for RFC 9068 `typ` header validation (#238) and RFC 9449 DPoP sender-constrained token support (#239), both of which require HTTP request context during validation.

### Changes

- **New types** (`domain.context` package): `TokenValidationRequest` sealed interface with `AccessTokenRequest`, `IdTokenRequest`, `RefreshTokenRequest` record implementations
- **Core API**: `TokenValidator.createAccessToken/createIdToken/createRefreshToken` now accept request objects
- **Pipeline**: All three validation pipelines updated to thread request objects through
- **TokenHeaderValidator**: `validate(DecodedJwt, TokenValidationRequest)` — enables future `typ`/DPoP validation
- **BearerTokenProducer**: Resolves HTTP headers once and passes them through to `AccessTokenRequest`
- **Security**: `DecodedJwt.toString()` redacts `rawToken`; `BaseTokenContent` excludes `rawToken` from `@ToString`
- **Tests**: 27 test files updated + 3 new test files for the parameter objects
- **Docs**: 8 `.adoc` files updated with new API examples

### Design decisions

- **Sealed interface** with separate record types for type safety (prevents passing wrong request to wrong pipeline)
- **Clean break** (no deprecation) per pre-1.0 rules
- **No new validation logic** — this is purely plumbing; `typ` and DPoP logic will come in follow-up PRs
- **`String` retained** for token representation (no `byte[]` migration) — see plan analysis for rationale

## Test plan

- [x] `./mvnw -Ppre-commit clean verify -pl oauth-sheriff-core` — 1327 tests pass
- [x] `./mvnw -Ppre-commit clean verify -pl oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus` — all tests pass
- [x] `./mvnw clean install` — full build passes
- [x] No OpenRewrite markers introduced
- [x] No build artifacts in source directories

Refs #238, #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)