### PR TITLE
feat: add optional RFC 9068 typ header validation

### DIFF
--- a/doc/LogMessages.adoc
+++ b/doc/LogMessages.adoc
@@ -53,7 +53,7 @@ For more details about security events related to these log messages, see the Se
 |JWTValidation-010 |ISSUER |Issuer configuration loaded successfully: %s |Logged when an issuer configuration is successfully loaded
 |===
 
-== WARN Level (100-147)
+== WARN Level (100-148)
 
 [cols="1,1,2,2", options="header"]
 |===
@@ -106,6 +106,7 @@ For more details about security events related to these log messages, see the Se
 |JWTValidation-145 |JWKS |DSL-JSON returned null for JWKS parsing |Logged when DSL-JSON parser returns null while parsing JWKS content
 |JWTValidation-146 |JWKS |Failed to parse JWKS content: %s |Logged when JWKS content parsing fails due to IO error or invalid JSON structure
 |JWTValidation-147 |JWKS |Failed to parse OKP key with ID %s: %s |Logged when OKP (EdDSA) key parsing fails for a specific key ID
+|JWTValidation-148 |TOKEN |Token type '%s' does not match expected type '%s' |Logged when the JWT typ header does not match the expected token type configured for the issuer (RFC 9068 validation)
 |===
 
 == ERROR Level (200-211)

--- a/doc/Requirements.adoc
+++ b/doc/Requirements.adoc
@@ -49,12 +49,12 @@ OAuthSheriff already satisfies the OAuth 2.1 resource server requirements:
 * **Algorithm security** - Whitelisted RS/ES/PS families only; HMAC and "none" rejected per https://datatracker.ietf.org/doc/html/rfc8725[RFC 8725]
 * **Issuer validation** - `iss` mandatory, matched against configured issuers
 * **Signature verification** - Full cryptographic validation pipeline
+* **RFC 9068 token type validation** - Optional per-issuer `typ: at+jwt` header validation (see xref:#OAUTH-SHERIFF-8.6[OAUTH-SHERIFF-8.6])
 
 === Future Enhancements (Optional)
 
 The following optional enhancements are tracked as separate issues:
 
-* **https://datatracker.ietf.org/doc/html/rfc9068[RFC 9068] - `typ: at+jwt` header validation**: Optional per-issuer validation of the JWT `typ` header for access tokens. Not enabled by default since many authorization servers do not yet set this header.
 * **https://datatracker.ietf.org/doc/html/rfc9449[RFC 9449] - DPoP sender-constrained tokens**: Proof-of-possession mechanism where access tokens contain a `cnf.jkt` claim binding them to a client's public key. This is a major feature requiring HTTP context (DPoP header), not just a token string.
 
 == Functional Requirements
@@ -390,6 +390,18 @@ _See specification: xref:security/security-specifications.adoc#claims-validation
 The library must support cryptographic agility as recommended by https://datatracker.ietf.org/doc/html/rfc8725#section-3.2[RFC 8725 Section 3.2 - Use Appropriate Algorithms], allowing for algorithm upgrades without breaking changes.
 
 _See specification: xref:security/security-specifications.adoc#cryptographic-agility[Cryptographic Agility]_
+
+[#OAUTH-SHERIFF-8.6]
+==== OAUTH-SHERIFF-8.6: Token Type Header Validation (RFC 9068)
+
+The library must support optional per-issuer validation of the JWT `typ` header parameter as defined in https://datatracker.ietf.org/doc/html/rfc9068[RFC 9068 - JSON Web Token (JWT) Profile for OAuth 2.0 Access Tokens] (October 2021).
+
+* When `expected-token-type` is configured for an issuer, tokens with a missing or mismatched `typ` header are rejected
+* When not configured (default), no token type validation is performed for backward compatibility
+* Comparison is case-insensitive per RFC convention
+* Validation occurs in the `TokenHeaderValidator` as part of the header validation pipeline step
+
+_See specification: xref:specification/technical-components.adoc#token-validation-pipeline[Token Validation Pipeline]_
 
 [#OAUTH-SHERIFF-12]
 === OAUTH-SHERIFF-12: Testing and Quality Assurance

--- a/doc/Specification.adoc
+++ b/doc/Specification.adoc
@@ -68,7 +68,7 @@ _See Requirement xref:Requirements.adoc#OAUTH-SHERIFF-1.3[OAUTH-SHERIFF-1.3: Sig
 
 The token validation pipeline consists of the following components:
 
-* **TokenHeaderValidator**: Validates token headers (algorithm, issuer)
+* **TokenHeaderValidator**: Validates token headers (algorithm, key ID, embedded JWK protection, optional token type per RFC 9068)
 * **TokenSignatureValidator**: Validates token signatures using JWKS
 * **TokenBuilder**: Creates token content objects
 * **TokenClaimValidator**: Validates token claims (expiration, audience, etc.)

--- a/doc/specification/technical-components.adoc
+++ b/doc/specification/technical-components.adoc
@@ -41,7 +41,7 @@ The `TokenValidator` is the primary entry point for applications using the libra
 
 The `TokenValidator` uses a pipeline of validators and builders to process tokens:
 
-1. `TokenHeaderValidator` - Validates token headers (algorithm, issuer)
+1. `TokenHeaderValidator` - Validates token headers (algorithm, key ID, embedded JWK protection, optional token type per RFC 9068)
 2. `TokenSignatureValidator` - Validates token signatures using JWKS
 3. `TokenBuilder` - Creates token content objects
 4. `TokenClaimValidator` - Validates token claims (expiration, audience, etc.)
@@ -67,7 +67,7 @@ This specification has been implemented in the following classes:
 
 Each component in the pipeline has a specific responsibility:
 
-* `TokenHeaderValidator` - Validates token headers (algorithm, issuer)
+* `TokenHeaderValidator` - Validates token headers (algorithm, key ID, embedded JWK protection, optional token type per RFC 9068)
 * `TokenSignatureValidator` - Validates token signatures using JWKS
 * `TokenBuilder` - Creates token content objects
 * `TokenClaimValidator` - Validates token claims (expiration, audience, etc.)

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/IssuerConfig.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/IssuerConfig.java
@@ -145,6 +145,18 @@ public class IssuerConfig implements LoadingStatusProvider {
      */
     boolean claimSubOptional;
 
+    /**
+     * The expected value for the JWT "typ" header parameter.
+     * When configured, the {@link de.cuioss.sheriff.oauth.core.pipeline.validator.TokenHeaderValidator}
+     * will validate that the token's "typ" header matches this value
+     * (e.g., "at+jwt" per RFC 9068).
+     * When {@code null}, no token type validation is performed (default, backward compatible).
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/html/rfc9068">RFC 9068</a>
+     */
+    @Nullable
+    String expectedTokenType;
+
     SignatureAlgorithmPreferences algorithmPreferences;
 
     /**
@@ -297,6 +309,7 @@ public class IssuerConfig implements LoadingStatusProvider {
         private Set<String> expectedAudience;
         private Set<String> expectedClientId;
         private boolean claimSubOptional = false;
+        private String expectedTokenType;
         private SignatureAlgorithmPreferences algorithmPreferences = new SignatureAlgorithmPreferences();
         private Map<String, ClaimMapper> claimMappers;
         private JwksLoader jwksLoader;
@@ -459,6 +472,26 @@ public class IssuerConfig implements LoadingStatusProvider {
          */
         public IssuerConfigBuilder claimSubOptional(boolean claimSubOptional) {
             this.claimSubOptional = claimSubOptional;
+            return this;
+        }
+
+        /**
+         * Sets the expected JWT "typ" header parameter value for this issuer.
+         * <p>
+         * When configured, the {@link de.cuioss.sheriff.oauth.core.pipeline.validator.TokenHeaderValidator}
+         * will validate that the token's "typ" header matches this value (e.g., "at+jwt" per RFC 9068).
+         * The comparison is case-insensitive per RFC convention.
+         * </p>
+         * <p>
+         * When not set (default), no token type validation is performed for backward compatibility.
+         * </p>
+         *
+         * @param expectedTokenType the expected token type value (e.g., "at+jwt")
+         * @return this builder instance for method chaining
+         * @see <a href="https://datatracker.ietf.org/doc/html/rfc9068">RFC 9068</a>
+         */
+        public IssuerConfigBuilder expectedTokenType(String expectedTokenType) {
+            this.expectedTokenType = expectedTokenType;
             return this;
         }
 
@@ -745,7 +778,7 @@ public class IssuerConfig implements LoadingStatusProvider {
             }
 
             return new IssuerConfig(enabled, issuerIdentifier, expectedAudience, expectedClientId,
-                    claimSubOptional, algorithmPreferences, claimMappers, jwksLoader);
+                    claimSubOptional, expectedTokenType, algorithmPreferences, claimMappers, jwksLoader);
         }
 
         private void validateConfiguration() {
@@ -793,13 +826,15 @@ public class IssuerConfig implements LoadingStatusProvider {
      */
     @SuppressWarnings("java:S107") // ok for private constructor
     private IssuerConfig(boolean enabled, @Nullable String issuerIdentifier, @Nullable Set<String> expectedAudience,
-            @Nullable Set<String> expectedClientId, boolean claimSubOptional, @Nullable SignatureAlgorithmPreferences algorithmPreferences,
+            @Nullable Set<String> expectedClientId, boolean claimSubOptional, @Nullable String expectedTokenType,
+            @Nullable SignatureAlgorithmPreferences algorithmPreferences,
             @Nullable Map<String, ClaimMapper> claimMappers, @Nullable JwksLoader jwksLoader) {
         this.enabled = enabled;
         this.issuerIdentifier = issuerIdentifier;
         this.expectedAudience = expectedAudience != null ? expectedAudience : Set.of();
         this.expectedClientId = expectedClientId != null ? expectedClientId : Set.of();
         this.claimSubOptional = claimSubOptional;
+        this.expectedTokenType = expectedTokenType;
         this.algorithmPreferences = algorithmPreferences != null ? algorithmPreferences : new SignatureAlgorithmPreferences();
         this.claimMappers = claimMappers != null ? claimMappers : Map.of();
         this.jwksLoader = jwksLoader;

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/JWTValidationLogMessages.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/JWTValidationLogMessages.java
@@ -489,6 +489,12 @@ public final class JWTValidationLogMessages {
                 .identifier(147)
                 .template("Failed to parse OKP key with ID %s: %s")
                 .build();
+
+        public static final LogRecord TOKEN_TYPE_MISMATCH = LogRecordModel.builder()
+                .prefix(PREFIX)
+                .identifier(148)
+                .template("Token type '%s' does not match expected type '%s'")
+                .build();
     }
 
 }

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/security/SecurityEventCounter.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/security/SecurityEventCounter.java
@@ -79,6 +79,7 @@ public class SecurityEventCounter {
         AZP_MISMATCH(JWTValidationLogMessages.WARN.AZP_MISMATCH, EventCategory.SEMANTIC_ISSUES),
         NO_ISSUER_CONFIG(JWTValidationLogMessages.WARN.NO_ISSUER_CONFIG, EventCategory.SEMANTIC_ISSUES),
         ISSUER_MISMATCH(JWTValidationLogMessages.WARN.ISSUER_MISMATCH, EventCategory.SEMANTIC_ISSUES),
+        TOKEN_TYPE_MISMATCH(JWTValidationLogMessages.WARN.TOKEN_TYPE_MISMATCH, EventCategory.SEMANTIC_ISSUES),
 
         // Signature issues
         SIGNATURE_VALIDATION_FAILED(JWTValidationLogMessages.ERROR.SIGNATURE_VALIDATION_FAILED, EventCategory.INVALID_SIGNATURE),

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus-integration-tests/src/main/resources/application.properties
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus-integration-tests/src/main/resources/application.properties
@@ -29,6 +29,8 @@ sheriff.oauth.issuers.keycloak.expected-client-id=benchmark-client
 sheriff.oauth.issuers.keycloak.jwks.http.refresh-interval-seconds=10
 # Make subject claim optional for benchmark realm (Keycloak access tokens don't include 'sub' by default)
 sheriff.oauth.issuers.keycloak.claim-sub-optional=true
+# RFC 9068: Token type validation (disabled by default - Keycloak does not set typ: at+jwt)
+# sheriff.oauth.issuers.keycloak.expected-token-type=at+jwt
 
 # Integration issuer for direct JWKS URL testing (uses protocol mappers)
 sheriff.oauth.issuers.integration.enabled=true

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/config/IssuerConfigResolver.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/config/IssuerConfigResolver.java
@@ -230,6 +230,7 @@ public class IssuerConfigResolver {
         configureClientId(builder, issuerName);
         configureAlgorithmPreferences(builder, issuerName);
         configureClaimSubOptional(builder, issuerName);
+        configureExpectedTokenType(builder, issuerName);
 
         // Configure JWKS source (mutually exclusive)
         configureJwksSource(builder, issuerName);
@@ -328,6 +329,21 @@ public class IssuerConfigResolver {
         if (claimSubOptional.isPresent()) {
             builder.claimSubOptional(claimSubOptional.get());
             LOGGER.debug("Set claim subject optional for %s: %s", issuerName, claimSubOptional.get());
+        }
+    }
+
+    /**
+     * Configures the expected token type from properties.
+     */
+    private void configureExpectedTokenType(IssuerConfig.IssuerConfigBuilder builder, String issuerName) {
+        Optional<String> expectedTokenType = config.getOptionalValue(
+                JwtPropertyKeys.ISSUERS.EXPECTED_TOKEN_TYPE.formatted(issuerName),
+                String.class
+        );
+
+        if (expectedTokenType.isPresent()) {
+            builder.expectedTokenType(expectedTokenType.get());
+            LOGGER.debug("Set expected token type for %s: %s", issuerName, expectedTokenType.get());
         }
     }
 

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/config/JwtPropertyKeys.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/config/JwtPropertyKeys.java
@@ -207,6 +207,19 @@ public final class JwtPropertyKeys {
          */
         public static final String CLAIM_SUB_OPTIONAL = BASE + "claim-sub-optional";
 
+        /**
+         * Expected JWT "typ" header value for this issuer (e.g., "at+jwt").
+         * Template: "sheriff.oauth.issuers.%s.expected-token-type"
+         * <p>
+         * When configured, tokens with a missing or mismatched "typ" header will be rejected.
+         * When not set (default), no token type validation is performed.
+         * </p>
+         *
+         * @see <a href="https://datatracker.ietf.org/doc/html/rfc9068">RFC 9068</a>
+         * @see de.cuioss.sheriff.oauth.core.IssuerConfig#getExpectedTokenType()
+         */
+        public static final String EXPECTED_TOKEN_TYPE = BASE + "expected-token-type";
+
         // === JWKS Source Configuration (Mutually Exclusive) ===
 
         /**


### PR DESCRIPTION
## Summary

Closes #238

- Add optional per-issuer JWT `typ` header validation as defined in [RFC 9068](https://datatracker.ietf.org/doc/html/rfc9068) (JWT Profile for OAuth 2.0 Access Tokens)
- When `expected-token-type` is configured for an issuer (e.g., `at+jwt`), tokens with missing or mismatched `typ` headers are rejected
- Disabled by default for backward compatibility — most authorization servers (including Keycloak) don't yet set `typ: at+jwt`
- Comparison is case-insensitive per RFC convention

### Files changed (12)

| Area | File | Change |
|------|------|--------|
| Core | `JWTValidationLogMessages.java` | Add `WARN.TOKEN_TYPE_MISMATCH` (id 148) |
| Core | `SecurityEventCounter.java` | Add `TOKEN_TYPE_MISMATCH` EventType |
| Core | `IssuerConfig.java` | Add `expectedTokenType` field + builder method |
| Core | `TokenHeaderValidator.java` | Add `validateTokenType()` method |
| Quarkus | `JwtPropertyKeys.java` | Add `EXPECTED_TOKEN_TYPE` constant |
| Quarkus | `IssuerConfigResolver.java` | Add `configureExpectedTokenType()` |
| Test | `TokenHeaderValidatorTest.java` | Add 5 new tests for token type validation |
| Config | `application.properties` | Add commented-out config example |
| Docs | `Requirements.adoc` | Add OAUTH-SHERIFF-8.6, update OAuth 2.1 section |
| Docs | `Specification.adoc` | Update TokenHeaderValidator description |
| Docs | `technical-components.adoc` | Update pipeline description |
| Docs | `LogMessages.adoc` | Add JWTValidation-148 entry |

## Test plan

- [x] All 1332 unit tests pass (`./mvnw clean install -pl oauth-sheriff-core`)
- [x] Pre-commit quality checks pass (`./mvnw -Ppre-commit clean verify -pl oauth-sheriff-core`)
- [x] 5 new tests cover: default (no validation), matching type, case-insensitive match, mismatch rejection, missing type rejection
- [x] Quarkus module compiles with new property key and resolver
- [ ] CI pipeline passes
- [ ] Integration tests pass (backward compatible — no `expected-token-type` configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)