### PR TITLE
chore: remove all @since version tags from pre-1.0 project

### DIFF
--- a/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/oauth/core/benchmark/BenchmarkKeyCache.java
+++ b/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/oauth/core/benchmark/BenchmarkKeyCache.java
@@ -33,7 +33,6 @@ import static de.cuioss.benchmarking.common.util.BenchmarkingLogMessages.WARN;
  * not during benchmark execution, preventing p99 latency spikes caused by setup costs.
  * 
  * @author Oliver Wolff
- * @since 1.0
  */
 public final class BenchmarkKeyCache {
 

--- a/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/oauth/core/benchmark/LibraryMetricsExporter.java
+++ b/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/oauth/core/benchmark/LibraryMetricsExporter.java
@@ -37,7 +37,6 @@ import static de.cuioss.benchmarking.common.util.BenchmarkingLogMessages.WARN;
  * Metrics exporter for library benchmarks that exports StripedRingBufferStatistics
  * from TokenValidatorMonitor. This handles JVM-level performance metrics.
  *
- * @since 1.0
  */
 public class LibraryMetricsExporter {
 

--- a/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/oauth/core/benchmark/MockTokenRepository.java
+++ b/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/oauth/core/benchmark/MockTokenRepository.java
@@ -49,7 +49,6 @@ import java.util.concurrent.atomic.AtomicInteger;
  * </p>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @Getter
 public class MockTokenRepository implements TokenProvider {

--- a/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/oauth/core/benchmark/UnifiedJfrBenchmark.java
+++ b/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/oauth/core/benchmark/UnifiedJfrBenchmark.java
@@ -34,7 +34,6 @@ import java.util.concurrent.TimeUnit;
  * JFR instrumentation for all benchmark types.
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @State(Scope.Benchmark)
 @SuppressWarnings("java:S112")

--- a/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/oauth/core/benchmark/base/AbstractBenchmark.java
+++ b/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/oauth/core/benchmark/base/AbstractBenchmark.java
@@ -32,7 +32,6 @@ import static de.cuioss.benchmarking.common.util.BenchmarkingLogMessages.ERROR;
  * Provides token repository and validator setup for library-specific benchmarks.
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 public abstract class AbstractBenchmark {
 

--- a/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/oauth/core/benchmark/base/AbstractJfrBenchmark.java
+++ b/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/oauth/core/benchmark/base/AbstractJfrBenchmark.java
@@ -25,7 +25,6 @@ import org.openjdk.jmh.annotations.TearDown;
  * Extends AbstractBenchmark to add JFR-specific functionality.
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 public abstract class AbstractJfrBenchmark extends AbstractBenchmark {
 

--- a/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/oauth/core/benchmark/delegates/BenchmarkDelegate.java
+++ b/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/oauth/core/benchmark/delegates/BenchmarkDelegate.java
@@ -26,7 +26,6 @@ import de.cuioss.sheriff.oauth.core.exception.TokenValidationException;
  * This allows the same logic to be used by both regular and JFR-instrumented benchmarks.
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 public abstract class BenchmarkDelegate {
 

--- a/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/oauth/core/benchmark/delegates/CoreValidationDelegate.java
+++ b/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/oauth/core/benchmark/delegates/CoreValidationDelegate.java
@@ -26,7 +26,6 @@ import java.util.concurrent.atomic.AtomicInteger;
  * Delegate for core validation benchmarks including average time and throughput.
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 public class CoreValidationDelegate extends BenchmarkDelegate {
 

--- a/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/oauth/core/benchmark/delegates/ErrorLoadDelegate.java
+++ b/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/oauth/core/benchmark/delegates/ErrorLoadDelegate.java
@@ -32,7 +32,6 @@ import java.util.concurrent.atomic.AtomicInteger;
  * Delegate for error load benchmarks that test validation behavior under various error conditions.
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 public class ErrorLoadDelegate extends BenchmarkDelegate {
 

--- a/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/oauth/core/benchmark/jfr/benchmarks/CoreJfrBenchmark.java
+++ b/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/oauth/core/benchmark/jfr/benchmarks/CoreJfrBenchmark.java
@@ -28,7 +28,6 @@ import java.util.concurrent.TimeUnit;
  * Contains only core validation benchmarks (3 methods maximum).
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @State(Scope.Thread)
 @SuppressWarnings("java:S112")

--- a/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/oauth/core/benchmark/jfr/benchmarks/ErrorJfrBenchmark.java
+++ b/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/oauth/core/benchmark/jfr/benchmarks/ErrorJfrBenchmark.java
@@ -28,7 +28,6 @@ import java.util.concurrent.TimeUnit;
  * Contains only error scenario benchmarks (4 methods maximum).
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @State(Scope.Thread)
 @SuppressWarnings("java:S112")

--- a/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/oauth/core/benchmark/jfr/benchmarks/MixedJfrBenchmark.java
+++ b/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/oauth/core/benchmark/jfr/benchmarks/MixedJfrBenchmark.java
@@ -28,7 +28,6 @@ import java.util.concurrent.TimeUnit;
  * Contains only mixed token validation benchmarks (2 methods maximum).
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @State(Scope.Thread)
 @SuppressWarnings("java:S112")

--- a/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/oauth/core/benchmark/jfr/package-info.java
+++ b/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/oauth/core/benchmark/jfr/package-info.java
@@ -55,6 +55,5 @@
  * report.printSummary();
  * }</pre>
  * 
- * @since 1.0
  */
 package de.cuioss.sheriff.oauth.core.benchmark.jfr;

--- a/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/oauth/core/benchmark/package-info.java
+++ b/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/oauth/core/benchmark/package-info.java
@@ -20,7 +20,6 @@
  * the oauth-sheriff-library library in isolation, without any framework overhead.
  * </p>
  *
- * @since 1.0.0
  * @author CUI-OpenSource-Software
  */
 @NullMarked

--- a/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/oauth/core/benchmark/standard/SimpleCoreValidationBenchmark.java
+++ b/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/oauth/core/benchmark/standard/SimpleCoreValidationBenchmark.java
@@ -28,7 +28,6 @@ import java.util.concurrent.TimeUnit;
  * Designed to eliminate JMH threading contention by keeping class complexity minimal.
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @State(Scope.Thread)
 @SuppressWarnings("java:S112")

--- a/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/oauth/core/benchmark/standard/SimpleErrorLoadBenchmark.java
+++ b/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/oauth/core/benchmark/standard/SimpleErrorLoadBenchmark.java
@@ -28,7 +28,6 @@ import java.util.concurrent.TimeUnit;
  * Designed to eliminate JMH threading contention by removing @Param annotations.
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @State(Scope.Thread)
 @SuppressWarnings("java:S112")

--- a/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/base/AbstractBenchmarkBase.java
+++ b/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/base/AbstractBenchmarkBase.java
@@ -40,7 +40,6 @@ import java.time.Duration;
  * </ul>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 public abstract class AbstractBenchmarkBase {
 

--- a/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/base/package-info.java
+++ b/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/base/package-info.java
@@ -21,6 +21,5 @@
  * ensuring consistent behavior.</p>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 package de.cuioss.benchmarking.common.base;

--- a/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/config/BenchmarkConfiguration.java
+++ b/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/config/BenchmarkConfiguration.java
@@ -43,7 +43,6 @@ import static de.cuioss.benchmarking.common.util.BenchmarkingLogMessages.WARN.UN
  * Options jmhOptions = config.toJmhOptions();
  * }</pre>
  * 
- * @since 1.0
  */
 public record BenchmarkConfiguration(
 ReportConfiguration reportConfig,

--- a/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/config/IntegrationConfiguration.java
+++ b/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/config/IntegrationConfiguration.java
@@ -28,7 +28,6 @@ import static de.cuioss.benchmarking.common.repository.TokenRepositoryConfig.req
  * String serviceUrl = integrationConfig.integrationServiceUrl();
  * }</pre>
  * 
- * @since 1.0
  */
 public record IntegrationConfiguration(
 String integrationServiceUrl,

--- a/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/config/ReportConfiguration.java
+++ b/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/config/ReportConfiguration.java
@@ -39,7 +39,6 @@ import static de.cuioss.benchmarking.common.util.BenchmarkingLogMessages.WARN.UN
  *     .build();
  * }</pre>
  * 
- * @since 1.0
  */
 public record ReportConfiguration(
 BenchmarkType benchmarkType,

--- a/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/metrics/BenchmarkMetricsTransformer.java
+++ b/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/metrics/BenchmarkMetricsTransformer.java
@@ -23,7 +23,6 @@ import java.util.*;
  * Transforms Prometheus time-series data into the benchmark server metrics format
  * as defined in benchmark-metrics.adoc.
  *
- * @since 1.0
  */
 public class BenchmarkMetricsTransformer {
 

--- a/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/metrics/MetricsJsonExporter.java
+++ b/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/metrics/MetricsJsonExporter.java
@@ -39,7 +39,6 @@ import static de.cuioss.benchmarking.common.util.BenchmarkingLogMessages.WARN.*;
  * Exports metrics data to JSON files in a target directory.
  * Handles JSON serialization, file writing, and metrics aggregation.
  *
- * @since 1.0
  */
 public class MetricsJsonExporter {
 

--- a/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/metrics/MetricsTransformer.java
+++ b/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/metrics/MetricsTransformer.java
@@ -25,7 +25,6 @@ import java.util.Map;
  * Transforms raw Prometheus metrics into structured Quarkus runtime metrics.
  * This class is responsible for all metric restructuring, renaming, and organization.
  *
- * @since 1.0
  */
 public class MetricsTransformer {
 

--- a/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/metrics/PrometheusClient.java
+++ b/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/metrics/PrometheusClient.java
@@ -44,7 +44,6 @@ import static de.cuioss.benchmarking.common.util.BenchmarkingLogMessages.WARN.FA
  * HTTP client for querying Prometheus API endpoints.
  * Supports query_range operations for time-series data retrieval during benchmark execution.
  *
- * @since 1.0
  */
 public class PrometheusClient {
 

--- a/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/package-info.java
+++ b/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/package-info.java
@@ -32,7 +32,6 @@
  * with automatic detection based on package naming conventions.
  * </p>
  *
- * @since 1.0.0
  * @author CUI-OpenSource-Software
  */
 @NullMarked

--- a/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/repository/KeycloakTokenRepository.java
+++ b/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/repository/KeycloakTokenRepository.java
@@ -53,7 +53,6 @@ import static de.cuioss.benchmarking.common.util.BenchmarkingLogMessages.WARN.TO
  * </ul>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 public class KeycloakTokenRepository implements TokenProvider {
 

--- a/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/repository/TokenRepositoryConfig.java
+++ b/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/repository/TokenRepositoryConfig.java
@@ -22,7 +22,6 @@ import lombok.Value;
  * Configuration for TokenRepository to connect to Keycloak and fetch tokens
  * for benchmark testing.
  *
- * @since 1.0
  */
 @Value
 @Builder

--- a/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/runner/BenchmarkResultProcessor.java
+++ b/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/runner/BenchmarkResultProcessor.java
@@ -111,7 +111,7 @@ public class BenchmarkResultProcessor {
         // Convert JMH JSON to BenchmarkData using converter, passing configured benchmark names
         JmhBenchmarkConverter converter = reportConfig != null
                 ? new JmhBenchmarkConverter(benchmarkType,
-                        reportConfig.throughputBenchmarkName(), reportConfig.latencyBenchmarkName())
+                reportConfig.throughputBenchmarkName(), reportConfig.latencyBenchmarkName())
                 : new JmhBenchmarkConverter(benchmarkType);
         BenchmarkData benchmarkData;
         try {

--- a/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/token/TokenProvider.java
+++ b/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/token/TokenProvider.java
@@ -30,7 +30,6 @@ package de.cuioss.benchmarking.common.token;
  * </p>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 public interface TokenProvider {
 

--- a/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/util/BenchmarkLoggingSetup.java
+++ b/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/util/BenchmarkLoggingSetup.java
@@ -38,7 +38,6 @@ import java.util.logging.*;
  *   <li>Configurable java.util.logging levels</li>
  * </ul>
  *
- * @since 1.0
  */
 @SuppressWarnings("java:S106") // System.out and System.err usage is intentional for logging setup
 public final class BenchmarkLoggingSetup {

--- a/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/util/BenchmarkingLogMessages.java
+++ b/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/util/BenchmarkingLogMessages.java
@@ -30,7 +30,6 @@ import de.cuioss.tools.logging.LogRecordModel;
  *   <li>500-599: DEBUG messages</li>
  * </ul>
  *
- * @since 1.0.0
  */
 public final class BenchmarkingLogMessages {
 

--- a/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/util/JsonSerializationHelper.java
+++ b/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/util/JsonSerializationHelper.java
@@ -32,7 +32,6 @@ import java.util.Map;
  * Common JSON serialization utilities for benchmark results.
  * Provides consistent formatting and serialization across all benchmark modules.
  *
- * @since 1.0
  */
 public final class JsonSerializationHelper {
 

--- a/benchmarking/benchmarking-common/src/test/java/de/cuioss/benchmarking/common/base/AbstractBenchmarkBaseTest.java
+++ b/benchmarking/benchmarking-common/src/test/java/de/cuioss/benchmarking/common/base/AbstractBenchmarkBaseTest.java
@@ -35,7 +35,6 @@ import static org.junit.jupiter.api.Assertions.*;
  * Unit tests for {@link AbstractBenchmarkBase}.
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 class AbstractBenchmarkBaseTest {
 

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/IssuerConfig.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/IssuerConfig.java
@@ -76,7 +76,6 @@ import java.util.*;
  * For more detailed specifications, see the
  * <a href="https://github.com/cuioss/OAuthSheriff/tree/main/doc/specification/technical-components.adoc#_issuerconfig_and_multi_issuer_support">Technical Components Specification - IssuerConfig and Multi-Issuer Support</a>
  *
- * @since 1.0
  */
 @Getter
 @EqualsAndHashCode
@@ -242,7 +241,6 @@ public class IssuerConfig implements LoadingStatusProvider {
      * </ol>
      *
      * @return the issuer identifier, never null
-     * @since 1.0
      */
    
     public String getIssuerIdentifier() {
@@ -284,7 +282,6 @@ public class IssuerConfig implements LoadingStatusProvider {
      * </ul>
      *
      * @return the current health status of this issuer configuration
-     * @since 1.0
      */
     @Override
     public LoaderStatus getLoaderStatus() {

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/JWTValidationLogMessages.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/JWTValidationLogMessages.java
@@ -33,7 +33,6 @@ import lombok.experimental.UtilityClass;
  * For more detailed information about log messages, see the
  * <a href="https://github.com/cuioss/OAuthSheriff/tree/main/doc/LogMessages.adoc">Log Messages Documentation</a>
  *
- * @since 1.0
  */
 @UtilityClass
 public final class JWTValidationLogMessages {

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/ParserConfig.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/ParserConfig.java
@@ -68,7 +68,6 @@ import lombok.ToString;
  * For more detailed specifications, see the
  * <a href="https://github.com/cuioss/OAuthSheriff/tree/main/doc/specification/token-size-validation.adoc">Token Size Validation Specification</a>
  *
- * @since 1.0
  */
 @Builder
 @Getter

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/TokenType.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/TokenType.java
@@ -47,7 +47,6 @@ import static de.cuioss.sheriff.oauth.core.domain.claim.ClaimName.*;
  * <a href="https://github.com/cuioss/OAuthSheriff/tree/main/doc/specification/technical-components.adoc#_token_architecture_and_types">Technical Components Specification - Token Architecture and Types</a>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 public enum TokenType {
 

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/TokenValidator.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/TokenValidator.java
@@ -131,7 +131,6 @@ import java.util.Map;
  * For more detailed specifications, see the
  * <a href="https://github.com/cuioss/OAuthSheriff/tree/main/doc/specification/technical-components.adoc#_tokenvalidator">Technical Components Specification</a>
  *
- * @since 1.0
  */
 @SuppressWarnings({"JavadocLinkAsPlainText", "java:S6539"}) // java:S6539: Intentional facade pattern - high coupling is by design
 public class TokenValidator implements Closeable {

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/cache/AccessTokenCache.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/cache/AccessTokenCache.java
@@ -58,7 +58,6 @@ import java.util.concurrent.TimeUnit;
  * JWTs self-expire via their exp claim, reducing need for complex eviction strategies.
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 public class AccessTokenCache {
 

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/cache/AccessTokenCacheConfig.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/cache/AccessTokenCacheConfig.java
@@ -51,7 +51,6 @@ import java.util.concurrent.ScheduledExecutorService;
  * </pre>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @Builder
 @Getter

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/cache/CachedToken.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/cache/CachedToken.java
@@ -33,7 +33,6 @@ import java.time.OffsetDateTime;
  * without needing to parse the token content.
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @RequiredArgsConstructor
 @Builder

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/cache/package-info.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/cache/package-info.java
@@ -29,6 +29,5 @@
  *   <li>No external dependencies (Quarkus compatible)</li>
  * </ul>
  *
- * @since 1.0
  */
 package de.cuioss.sheriff.oauth.core.cache;

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/claim/ClaimName.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/claim/ClaimName.java
@@ -32,7 +32,6 @@ import java.util.concurrent.ConcurrentHashMap;
  * This is a replacement for the org.eclipse.microprofile.jwt.ClaimNames interface
  * to provide a standardized set of JWT claim names and types.
  *
- * @since 1.0
  */
 @Getter
 public enum ClaimName {

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/claim/ClaimValue.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/claim/ClaimValue.java
@@ -52,7 +52,6 @@ import java.util.SortedSet;
  * specification.
  *
  * @author Oliver Wolff
- * @since 1.0
  * @see ClaimName
  * @see ClaimValueType
  */

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/claim/ClaimValueType.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/claim/ClaimValueType.java
@@ -22,7 +22,6 @@ import lombok.RequiredArgsConstructor;
  * Defines the types of claim values supported by the system.
  * Based on the OAuth 2.0/OpenID Connect specifications and actual usage patterns.
  *
- * @since 1.0
  */
 @Getter
 @RequiredArgsConstructor

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/claim/CollectionClaimHandler.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/claim/CollectionClaimHandler.java
@@ -50,7 +50,6 @@ import java.util.*;
  * </pre>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 public class CollectionClaimHandler {
 

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/claim/mapper/ClaimMapper.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/claim/mapper/ClaimMapper.java
@@ -43,7 +43,6 @@ import de.cuioss.sheriff.oauth.core.json.MapRepresentation;
  *
  * @author Oliver Wolff
  * @see ClaimValue
- * @since 1.0
  */
 @FunctionalInterface
 public interface ClaimMapper {

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/claim/mapper/IdentityMapper.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/claim/mapper/IdentityMapper.java
@@ -26,7 +26,6 @@ import java.util.Optional;
  * {@link ClaimValue} without any transformation.
  * This is useful for claims that are already in the desired format.
  *
- * @since 1.0
  */
 public class IdentityMapper implements ClaimMapper {
     @Override

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/claim/mapper/JsonCollectionMapper.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/claim/mapper/JsonCollectionMapper.java
@@ -35,7 +35,6 @@ import java.util.stream.Collectors;
  * </ul>
  * This is particularly useful for {@link ClaimValueType#STRING_LIST} claims.
  *
- * @since 1.0
  */
 public class JsonCollectionMapper implements ClaimMapper {
     @Override

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/claim/mapper/KeycloakDefaultGroupsMapper.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/claim/mapper/KeycloakDefaultGroupsMapper.java
@@ -52,7 +52,6 @@ import java.util.Optional;
  * and the OAuth Sheriff library's expected format, ensuring seamless integration
  * without requiring custom protocol mappers in Keycloak.
  *
- * @since 1.0
  * @see <a href="https://www.keycloak.org/docs/latest/server_admin/index.html#_group-mappers">Keycloak Group Mappers</a>
  */
 public class KeycloakDefaultGroupsMapper implements ClaimMapper {

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/claim/mapper/KeycloakDefaultRolesMapper.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/claim/mapper/KeycloakDefaultRolesMapper.java
@@ -50,7 +50,6 @@ import java.util.Optional;
  *   <li>Non-array roles value - returns empty list</li>
  * </ul>
  *
- * @since 1.0
  * @see <a href="https://www.keycloak.org/docs/latest/server_admin/index.html#_protocol-mappers">Keycloak Protocol Mappers</a>
  */
 public class KeycloakDefaultRolesMapper implements ClaimMapper {

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/claim/mapper/OffsetDateTimeMapper.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/claim/mapper/OffsetDateTimeMapper.java
@@ -29,7 +29,6 @@ import java.util.Optional;
  * According to JWT specification (RFC 7519), date-time values are represented as NumericDate,
  * which is the number of seconds from 1970-01-01T00:00:00Z UTC until the specified UTC date/time.
  *
- * @since 1.0
  */
 public class OffsetDateTimeMapper implements ClaimMapper {
     @Override

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/claim/mapper/ScopeMapper.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/claim/mapper/ScopeMapper.java
@@ -31,7 +31,6 @@ import java.util.TreeSet;
  * It handles both space-separated string scopes and JSON arrays of scopes.
  * <em>Note:</em> Although technically the result is a list, it is treated as a SortedSet
  *
- * @since 1.0
  */
 public class ScopeMapper implements ClaimMapper {
     @Override

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/claim/mapper/StringSplitterMapper.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/claim/mapper/StringSplitterMapper.java
@@ -43,7 +43,6 @@ import java.util.Optional;
  * ClaimValue roles = commaMapper.map(jsonObject, "roles");
  * </pre>
  *
- * @since 1.0
  */
 public class StringSplitterMapper implements ClaimMapper {
 

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/claim/mapper/package-info.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/claim/mapper/package-info.java
@@ -51,7 +51,6 @@
  * specification.
  * 
  * @author Oliver Wolff
- * @since 1.0
  * @see de.cuioss.sheriff.oauth.core.domain.claim.ClaimName
  * @see de.cuioss.sheriff.oauth.core.domain.claim.ClaimValue
  */

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/claim/package-info.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/claim/package-info.java
@@ -50,7 +50,6 @@
  * specification.
  * 
  * @author Oliver Wolff
- * @since 1.0
  * @see <a href="https://datatracker.ietf.org/doc/html/rfc7519">RFC 7519 - JSON Web Token (JWT)</a>
  * @see <a href="https://openid.net/specs/openid-connect-core-1_0.html">OpenID Connect Core 1.0</a>
  */

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/context/AccessTokenRequest.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/context/AccessTokenRequest.java
@@ -36,7 +36,6 @@ import java.util.Objects;
  *
  * @param tokenString the raw token string, must not be null
  * @param httpHeaders the HTTP headers from the original request, defensively copied
- * @since 1.0
  */
 public record AccessTokenRequest(String tokenString, Map<String, List<String>> httpHeaders)
         implements TokenValidationRequest {

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/context/IdTokenRequest.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/context/IdTokenRequest.java
@@ -36,7 +36,6 @@ import java.util.Objects;
  *
  * @param tokenString the raw token string, must not be null
  * @param httpHeaders the HTTP headers from the original request, defensively copied
- * @since 1.0
  */
 public record IdTokenRequest(String tokenString, Map<String, List<String>> httpHeaders)
         implements TokenValidationRequest {

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/context/RefreshTokenRequest.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/context/RefreshTokenRequest.java
@@ -36,7 +36,6 @@ import java.util.Objects;
  *
  * @param tokenString the raw token string, must not be null
  * @param httpHeaders the HTTP headers from the original request, defensively copied
- * @since 1.0
  */
 public record RefreshTokenRequest(String tokenString, Map<String, List<String>> httpHeaders)
         implements TokenValidationRequest {

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/context/TokenValidationRequest.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/context/TokenValidationRequest.java
@@ -35,7 +35,6 @@ import java.util.Map;
  * <p>
  * Implementations are immutable and thread-safe.
  *
- * @since 1.0
  */
 public sealed interface TokenValidationRequest
         permits AccessTokenRequest, IdTokenRequest, RefreshTokenRequest {

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/context/ValidationContext.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/context/ValidationContext.java
@@ -37,7 +37,6 @@ import java.time.OffsetDateTime;
  * </ul>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 public class ValidationContext {
 

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/context/package-info.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/context/package-info.java
@@ -34,6 +34,5 @@
  *       Request object for refresh token validation</li>
  * </ul>
  *
- * @since 1.0
  */
 package de.cuioss.sheriff.oauth.core.domain.context;

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/package-info.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/package-info.java
@@ -24,6 +24,5 @@
  * </ul>
  * <p>
  * 
- * @since 1.0
  */
 package de.cuioss.sheriff.oauth.core.domain;

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/token/AccessTokenContent.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/token/AccessTokenContent.java
@@ -58,7 +58,6 @@ import java.util.*;
  * specification.
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/token/BaseTokenContent.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/token/BaseTokenContent.java
@@ -46,7 +46,6 @@ import java.util.Map;
  * specification.
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @ToString
 @EqualsAndHashCode

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/token/IdTokenContent.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/token/IdTokenContent.java
@@ -57,7 +57,6 @@ import java.util.Optional;
  * specification.
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/token/MinimalTokenContent.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/token/MinimalTokenContent.java
@@ -37,7 +37,6 @@ import java.io.Serializable;
  * a common base for token handling regardless of the specific token format.
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 public interface MinimalTokenContent extends Serializable {
 

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/token/RefreshTokenContent.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/token/RefreshTokenContent.java
@@ -51,7 +51,6 @@ import java.util.Map;
  * </ul>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @ToString
 @EqualsAndHashCode

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/token/TokenContent.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/token/TokenContent.java
@@ -48,7 +48,6 @@ import java.util.Optional;
  * specification.
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 public interface TokenContent extends MinimalTokenContent {
 

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/token/package-info.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/domain/token/package-info.java
@@ -48,7 +48,6 @@
  * specification.
  *
  * @author Oliver Wolff
- * @since 1.0
  * @see de.cuioss.sheriff.oauth.core.domain.claim.ClaimName
  * @see <a href="https://datatracker.ietf.org/doc/html/rfc6749">RFC 6749 - OAuth 2.0</a>
  * @see <a href="https://openid.net/specs/openid-connect-core-1_0.html">OpenID Connect Core 1.0</a>

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/dpop/DpopConfig.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/dpop/DpopConfig.java
@@ -37,7 +37,6 @@ import lombok.ToString;
  * </ul>
  *
  * @see <a href="https://datatracker.ietf.org/doc/html/rfc9449">RFC 9449 - OAuth 2.0 Demonstrating Proof of Possession (DPoP)</a>
- * @since 1.1
  */
 @Getter
 @EqualsAndHashCode

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/dpop/DpopProofValidator.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/dpop/DpopProofValidator.java
@@ -62,7 +62,6 @@ import java.util.Optional;
  * while DSL-JSON's {@code JwtHeader} expects it as a String.
  *
  * @see <a href="https://datatracker.ietf.org/doc/html/rfc9449">RFC 9449</a>
- * @since 1.1
  */
 public class DpopProofValidator {
 

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/dpop/DpopReplayProtection.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/dpop/DpopReplayProtection.java
@@ -41,7 +41,6 @@ import java.util.concurrent.atomic.AtomicLong;
  * Call {@link #close()} to shut down the eviction scheduler.
  * </p>
  *
- * @since 1.1
  */
 public class DpopReplayProtection implements Closeable {
 

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/exception/InternalCacheException.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/exception/InternalCacheException.java
@@ -24,7 +24,6 @@ import java.io.Serial;
  * not a validation failure of the token itself.
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 public class InternalCacheException extends RuntimeException {
 

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/exception/TokenValidationException.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/exception/TokenValidationException.java
@@ -37,7 +37,6 @@ import java.io.Serial;
  * validation.
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 public class TokenValidationException extends RuntimeException {
 

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/json/JwkKey.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/json/JwkKey.java
@@ -38,7 +38,6 @@ import static de.cuioss.sheriff.oauth.core.JWTValidationLogMessages.WARN;
  * validation should happen later in the validation chain.
  * 
  * @author Generated
- * @since 1.0
  */
 @CompiledJson
 public record JwkKey(
@@ -169,7 +168,6 @@ String y      // EC y coordinate (Base64url-encoded, EC only)
      * represents the raw public key bytes rather than a BigInteger coordinate.
      *
      * @return Optional containing the decoded x coordinate as byte array, empty if null or invalid
-     * @since 1.0
      */
     public Optional<byte[]> getXCoordinateAsBytes() {
         return decodeBase64UrlToBytes(x);

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/json/Jwks.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/json/Jwks.java
@@ -31,7 +31,6 @@ import java.util.Optional;
  * validation should happen later in the validation chain.
  * 
  * @author Generated
- * @since 1.0
  */
 @CompiledJson
 public record Jwks(List<JwkKey> keys) {

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/json/JwtHeader.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/json/JwtHeader.java
@@ -70,7 +70,6 @@ import java.util.Optional;
  *             OPTIONAL by RFC 7515. Contains a list of header parameter names that are critical. Stored as String for DSL-JSON compatibility.
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @CompiledJson
 public record JwtHeader(

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/json/MapRepresentation.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/json/MapRepresentation.java
@@ -47,7 +47,6 @@ import java.util.stream.Collectors;
  * </ul>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 public record MapRepresentation(Map<String, Object> data) implements Serializable {
 

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/json/WellKnownResult.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/json/WellKnownResult.java
@@ -39,7 +39,6 @@ import java.util.Optional;
  * maintaining extensibility for additional OpenID Connect discovery fields.
  *
  * @author Oliver Wolff
- * @since 1.0
  * @see <a href="https://openid.net/specs/openid-connect-discovery-1_0.html">OpenID Connect Discovery</a>
  * @see <a href="https://datatracker.ietf.org/doc/html/rfc8414">RFC 8414 - OAuth 2.0 Authorization Server Metadata</a>
  */

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/json/package-info.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/json/package-info.java
@@ -31,7 +31,6 @@
  * The @NullUnmarked annotation removes JSpecify nullability enforcement,
  * allowing natural nullable-by-default behavior for JSON mapping scenarios.
  *
- * @since 1.0
  */
 @NullUnmarked
 package de.cuioss.sheriff.oauth.core.json;

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/jwks/JwksLoader.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/jwks/JwksLoader.java
@@ -40,7 +40,6 @@ import java.util.concurrent.CompletableFuture;
  * </pre>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @SuppressWarnings("JavadocLinkAsPlainText")
 public interface JwksLoader extends LoadingStatusProvider {

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/jwks/JwksLoaderFactory.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/jwks/JwksLoaderFactory.java
@@ -49,7 +49,6 @@ import lombok.experimental.UtilityClass;
  * See specification: <a href="https://github.com/cuioss/OAuthSheriff/tree/main/doc/specification/technical-components.adoc#_jwksloader">Technical Components Specification - JwksLoader</a>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @UtilityClass
 public class JwksLoaderFactory {

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/jwks/http/HttpJwksLoader.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/jwks/http/HttpJwksLoader.java
@@ -66,7 +66,6 @@ import static de.cuioss.sheriff.oauth.core.JWTValidationLogMessages.WARN;
  * @author Oliver Wolff
  * @see HttpJwksLoaderConfig
  * @see <a href="https://github.com/cuioss/OAuthSheriff/issues/110">Issue #110: Key rotation grace period</a>
- * @since 1.0
  */
 public class HttpJwksLoader implements JwksLoader, LoadingStatusProvider, AutoCloseable {
 

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/jwks/http/HttpJwksLoaderConfig.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/jwks/http/HttpJwksLoaderConfig.java
@@ -50,7 +50,6 @@ import java.util.concurrent.ScheduledExecutorService;
  * <a href="https://github.com/cuioss/OAuthSheriff/tree/main/doc/specification/technical-components.adoc#_jwksloader">Technical Components Specification</a>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @ToString
 @EqualsAndHashCode

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/jwks/http/JwksHttpContentConverter.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/jwks/http/JwksHttpContentConverter.java
@@ -40,7 +40,6 @@ import static de.cuioss.sheriff.oauth.core.JWTValidationLogMessages.WARN;
  * and provides proper empty value semantics for error cases.
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 public class JwksHttpContentConverter extends StringContentConverter<Jwks> {
 

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/jwks/http/package-info.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/jwks/http/package-info.java
@@ -115,6 +115,5 @@
  * <a href="https://github.com/cuioss/OAuthSheriff/tree/main/doc/specification/technical-components.adoc#_jwksloader">Technical Components Specification - JwksLoader</a>
  * 
  * @author Oliver Wolff
- * @since 1.0
  */
 package de.cuioss.sheriff.oauth.core.jwks.http;

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/jwks/key/JWKSKeyLoader.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/jwks/key/JWKSKeyLoader.java
@@ -62,7 +62,6 @@ import java.util.concurrent.ConcurrentHashMap;
  * <a href="https://github.com/cuioss/OAuthSheriff/tree/main/doc/specification/security.adoc">Security Specification</a>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @ToString(of = {"keyInfoMap", "parserConfig", "securityEventCounter"})
 @EqualsAndHashCode(of = {"keyInfoMap", "parserConfig", "securityEventCounter"})

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/jwks/key/JwkKeyHandler.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/jwks/key/JwkKeyHandler.java
@@ -50,7 +50,6 @@ import java.util.concurrent.ConcurrentHashMap;
  * <a href="https://github.com/cuioss/OAuthSheriff/tree/main/doc/specification/security.adoc">Security Specification</a>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class JwkKeyHandler {
@@ -127,7 +126,6 @@ public final class JwkKeyHandler {
      * @param jwk the JwkKey record containing OKP parameters (crv, x)
      * @return the parsed EdDSA public key
      * @throws InvalidKeySpecException if the key specification is invalid or the curve is unsupported
-     * @since 1.0
      */
     public static PublicKey parseOkpKey(JwkKey jwk) throws InvalidKeySpecException {
         // Validate curve
@@ -170,7 +168,6 @@ public final class JwkKeyHandler {
      *
      * @param curve the OKP curve name (Ed25519 or Ed448)
      * @return always "EdDSA" for supported OKP curves
-     * @since 1.0
      */
     public static String determineOkpAlgorithm(String curve) {
         return EDDSA_ALGORITHM;

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/jwks/key/KeyInfo.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/jwks/key/KeyInfo.java
@@ -43,7 +43,6 @@ import java.security.PublicKey;
  *              valid keys may exist simultaneously.
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 public record KeyInfo(
 PublicKey key,

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/jwks/key/package-info.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/jwks/key/package-info.java
@@ -47,7 +47,6 @@
  * For more detailed specifications, see the
  * <a href="https://github.com/cuioss/OAuthSheriff/tree/main/doc/specification/technical-components.adoc#_jwksloader">Technical Components Specification - JwksLoader</a>
  * 
- * @since 1.0
  * @see de.cuioss.sheriff.oauth.core.jwks.JwksLoader
  * @see de.cuioss.sheriff.oauth.core.pipeline.validator.TokenSignatureValidator
  * @see <a href="https://datatracker.ietf.org/doc/html/rfc7517">RFC 7517 - JSON Web Key (JWK)</a>

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/jwks/package-info.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/jwks/package-info.java
@@ -47,7 +47,6 @@
  * For more detailed specifications, see the
  * <a href="https://github.com/cuioss/OAuthSheriff/tree/main/doc/specification/technical-components.adoc#_jwksloader">Technical Components Specification - JwksLoader</a>
  * 
- * @since 1.0
  * @see de.cuioss.sheriff.oauth.core.pipeline.validator.TokenSignatureValidator
  * @see <a href="https://datatracker.ietf.org/doc/html/rfc7517">RFC 7517 - JSON Web Key (JWK)</a>
  */

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/jwks/parser/package-info.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/jwks/parser/package-info.java
@@ -26,6 +26,5 @@
  * with proper validation, error handling, and security event tracking.
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 package de.cuioss.sheriff.oauth.core.jwks.parser;

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/metrics/ActiveMetricsTicker.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/metrics/ActiveMetricsTicker.java
@@ -31,7 +31,6 @@ import lombok.RequiredArgsConstructor;
  * Note: This implementation is not thread-safe. Each thread should use its own instance.
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @RequiredArgsConstructor
 public final class ActiveMetricsTicker implements MetricsTicker {

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/metrics/MeasurementType.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/metrics/MeasurementType.java
@@ -58,7 +58,6 @@ import lombok.RequiredArgsConstructor;
  * </ul>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @RequiredArgsConstructor
 @Getter

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/metrics/MetricsTicker.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/metrics/MetricsTicker.java
@@ -25,7 +25,6 @@ package de.cuioss.sheriff.oauth.core.metrics;
  * Implementations must be thread-safe if they will be used in concurrent contexts.
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 public interface MetricsTicker {
 

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/metrics/MetricsTickerFactory.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/metrics/MetricsTickerFactory.java
@@ -25,7 +25,6 @@ import lombok.experimental.UtilityClass;
  * MeasurementType, TokenValidatorMonitor, and ActiveMetricsTicker.
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @UtilityClass
 public class MetricsTickerFactory {

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/metrics/NoOpMetricsTicker.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/metrics/NoOpMetricsTicker.java
@@ -22,7 +22,6 @@ package de.cuioss.sheriff.oauth.core.metrics;
  * by the JVM's JIT compiler. The singleton pattern ensures minimal memory footprint.
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @SuppressWarnings("java:S6548") // owolff: fits for its purpose as a no-op implementation
 public final class NoOpMetricsTicker implements MetricsTicker {

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/metrics/TokenValidatorMonitor.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/metrics/TokenValidatorMonitor.java
@@ -68,7 +68,6 @@ import java.util.concurrent.TimeUnit;
  * metrics systems but does not create any dependency on external monitoring frameworks.
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 public class TokenValidatorMonitor {
 
@@ -154,7 +153,6 @@ public class TokenValidatorMonitor {
      *
      * @param measurementType the type of measurement to analyze
      * @return optional containing striped ring buffer statistics, empty if measurement type is not enabled
-     * @since 1.0
      */
     public Optional<StripedRingBufferStatistics> getValidationMetrics(MeasurementType measurementType) {
         StripedRingBuffer buffer = measurementBuffers[measurementType.ordinal()];

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/metrics/TokenValidatorMonitorConfig.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/metrics/TokenValidatorMonitorConfig.java
@@ -58,7 +58,6 @@ import java.util.Set;
  * </pre>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @Builder
 @Getter

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/metrics/package-info.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/metrics/package-info.java
@@ -35,6 +35,5 @@
  * external monitoring systems like Micrometer/Prometheus in higher-level modules.
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 package de.cuioss.sheriff.oauth.core.metrics;

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/package-info.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/package-info.java
@@ -45,7 +45,6 @@
  * Note: The implementation is primarily tested with Keycloak as the identity provider.
  * Some features may be specific to Keycloak's token implementation.
  *
- * @since 1.0
  */
 @NullMarked
 package de.cuioss.sheriff.oauth.core;

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/AccessTokenValidationPipeline.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/AccessTokenValidationPipeline.java
@@ -75,7 +75,6 @@ import java.util.Optional;
  * and cached in immutable maps for optimal performance.
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 public class AccessTokenValidationPipeline {
 

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/DecodedJwt.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/DecodedJwt.java
@@ -55,7 +55,6 @@ import java.util.Optional;
  * @param rawToken the original raw token string
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 public record DecodedJwt(
 JwtHeader header,

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/IdTokenValidationPipeline.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/IdTokenValidationPipeline.java
@@ -60,7 +60,6 @@ import java.util.Map;
  * and cached in immutable maps for optimal performance.
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 public class IdTokenValidationPipeline {
 

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/NonValidatingJwtParser.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/NonValidatingJwtParser.java
@@ -115,7 +115,6 @@ import java.util.Base64;
  * <a href="https://github.com/cuioss/OAuthSheriff/tree/main/doc/specification/security.adoc">Security Specification</a>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @ToString
 @EqualsAndHashCode

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/RefreshTokenValidationPipeline.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/RefreshTokenValidationPipeline.java
@@ -52,7 +52,6 @@ import java.util.Map;
  * This class is thread-safe and stateless after construction.
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 public class RefreshTokenValidationPipeline {
 

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/SignatureTemplateManager.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/SignatureTemplateManager.java
@@ -47,7 +47,6 @@ import java.util.Map;
  * </ul>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 public final class SignatureTemplateManager {
 

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/TokenBuilder.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/TokenBuilder.java
@@ -46,7 +46,6 @@ import java.util.Optional;
  * <a href="https://github.com/cuioss/OAuthSheriff/tree/main/doc/specification/technical-components.adoc#token-validation-pipeline">Token Validation Pipeline</a>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 public class TokenBuilder {
 

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/package-info.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/package-info.java
@@ -54,7 +54,6 @@
  * <a href="https://github.com/cuioss/OAuthSheriff/tree/main/doc/specification/technical-components.adoc">Technical Components Specification</a>
  * 
  * @author Oliver Wolff
- * @since 1.0
  * @see de.cuioss.sheriff.oauth.core.TokenValidator
  * @see de.cuioss.sheriff.oauth.core.domain.token.TokenContent
  */

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/validator/AudienceValidator.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/validator/AudienceValidator.java
@@ -44,7 +44,6 @@ import java.util.Set;
  * </ul>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @RequiredArgsConstructor
 public class AudienceValidator {

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/validator/AuthorizedPartyValidator.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/validator/AuthorizedPartyValidator.java
@@ -35,7 +35,6 @@ import java.util.Set;
  * one of the expected client IDs if client ID validation is configured.
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @RequiredArgsConstructor
 public class AuthorizedPartyValidator {

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/validator/ExpirationValidator.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/validator/ExpirationValidator.java
@@ -36,7 +36,6 @@ import lombok.RequiredArgsConstructor;
  * to account for time differences between token issuer and validator.
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @RequiredArgsConstructor
 public class ExpirationValidator {

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/validator/MandatoryClaimsValidator.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/validator/MandatoryClaimsValidator.java
@@ -42,7 +42,6 @@ import java.util.stream.Collectors;
  * subject claim in access tokens by default.
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @RequiredArgsConstructor
 public class MandatoryClaimsValidator {

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/validator/TokenClaimValidator.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/validator/TokenClaimValidator.java
@@ -59,7 +59,6 @@ import java.util.Set;
  * </ul>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 public class TokenClaimValidator {
 

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/validator/TokenHeaderValidator.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/validator/TokenHeaderValidator.java
@@ -42,7 +42,6 @@ import lombok.Builder;
  * <a href="https://github.com/cuioss/OAuthSheriff/tree/main/doc/specification/technical-components.adoc#token-validation-pipeline">Token Validation Pipeline</a>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @Builder
 public class TokenHeaderValidator {

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/validator/TokenSignatureValidator.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/validator/TokenSignatureValidator.java
@@ -55,7 +55,6 @@ import java.security.*;
  * and <a href="https://github.com/cuioss/OAuthSheriff/tree/main/doc/specification/security.adoc">Security Specification</a>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 public class TokenSignatureValidator {
 

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/validator/TokenStringValidator.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/validator/TokenStringValidator.java
@@ -43,7 +43,6 @@ import java.nio.charset.StandardCharsets;
  * This class is thread-safe and stateless after construction.
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 public class TokenStringValidator {
 

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/validator/package-info.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/pipeline/validator/package-info.java
@@ -36,6 +36,5 @@
  * to perform comprehensive token validation.
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 package de.cuioss.sheriff.oauth.core.pipeline.validator;

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/security/EventCategory.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/security/EventCategory.java
@@ -29,7 +29,6 @@ package de.cuioss.sheriff.oauth.core.security;
  * </ul>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 public enum EventCategory {
     /**

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/security/JwkAlgorithmPreferences.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/security/JwkAlgorithmPreferences.java
@@ -32,7 +32,6 @@ import java.util.List;
  * <a href="https://github.com/cuioss/OAuthSheriff/tree/main/doc/specification/security.adoc">Security Specification</a>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 public class JwkAlgorithmPreferences {
 

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/security/SecurityEventCounter.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/security/SecurityEventCounter.java
@@ -50,7 +50,6 @@ import java.util.stream.Collectors;
  * <a href="https://github.com/cuioss/OAuthSheriff/tree/main/doc/specification/security.adoc">Security Specification</a>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 public class SecurityEventCounter {
 

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/security/SignatureAlgorithmPreferences.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/security/SignatureAlgorithmPreferences.java
@@ -34,7 +34,6 @@ import java.util.Optional;
  * <a href="https://github.com/cuioss/OAuthSheriff/tree/main/doc/specification/security.adoc">Security Specification</a>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 public class SignatureAlgorithmPreferences {
 

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/security/package-info.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/security/package-info.java
@@ -53,6 +53,5 @@
  * @author Oliver Wolff
  * @see de.cuioss.sheriff.oauth.core.pipeline.validator.TokenSignatureValidator
  * @see de.cuioss.sheriff.oauth.core.jwks.http.HttpJwksLoader
- * @since 1.0
  */
 package de.cuioss.sheriff.oauth.core.security;

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/util/JwkThumbprintUtil.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/util/JwkThumbprintUtil.java
@@ -38,7 +38,6 @@ import java.util.Map;
  * Uses only {@link MessageDigest} and {@link Base64} — no external dependencies.
  *
  * @see <a href="https://datatracker.ietf.org/doc/html/rfc7638">RFC 7638 - JSON Web Key (JWK) Thumbprint</a>
- * @since 1.1
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class JwkThumbprintUtil {

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/util/LoadingStatusProvider.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/util/LoadingStatusProvider.java
@@ -42,7 +42,6 @@ package de.cuioss.sheriff.oauth.core.util;
  * </pre>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 public interface LoadingStatusProvider {
 

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/well_known/HttpWellKnownResolver.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/well_known/HttpWellKnownResolver.java
@@ -42,7 +42,6 @@ import java.util.concurrent.atomic.AtomicReference;
  * The compareAndSet pattern prevents duplicate loads while allowing concurrent access.
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 public class HttpWellKnownResolver implements LoadingStatusProvider {
 

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/well_known/WellKnownConfig.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/well_known/WellKnownConfig.java
@@ -38,7 +38,6 @@ import java.net.URI;
  * and provides comprehensive SSL/TLS configuration options through the HttpHandler builder pattern.
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @ToString
 @EqualsAndHashCode

--- a/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/well_known/WellKnownConfigurationConverter.java
+++ b/oauth-sheriff-core/src/main/java/de/cuioss/sheriff/oauth/core/well_known/WellKnownConfigurationConverter.java
@@ -40,7 +40,6 @@ import java.util.Optional;
  * Path: HttpResponse.BodyHandler → DSL-JSON → WellKnownResult
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 public class WellKnownConfigurationConverter implements HttpResponseConverter<WellKnownResult> {
 

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus-deployment/src/main/java/de/cuioss/sheriff/oauth/quarkus/deployment/package-info.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus-deployment/src/main/java/de/cuioss/sheriff/oauth/quarkus/deployment/package-info.java
@@ -20,6 +20,5 @@
  * including build steps, configuration validation, and Dev UI integration.
  * </p>
  *
- * @since 1.0
  */
 package de.cuioss.sheriff.oauth.quarkus.deployment;

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/annotation/BearerAuth.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/annotation/BearerAuth.java
@@ -132,7 +132,6 @@ import java.lang.annotation.Target;
  * @see BearerToken
  * @see de.cuioss.sheriff.oauth.quarkus.interceptor.BearerTokenInterceptor
  * @see de.cuioss.sheriff.oauth.quarkus.producer.BearerTokenResult
- * @since 1.0
  */
 @InterceptorBinding
 @Retention(RetentionPolicy.RUNTIME)

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/annotation/BearerToken.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/annotation/BearerToken.java
@@ -100,7 +100,6 @@ import java.lang.annotation.Target;
  *
  * @author Oliver Wolff
  * @see BearerAuth
- * @since 1.0
  */
 @Qualifier
 @Retention(RetentionPolicy.RUNTIME)

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/annotation/ServletObjectsResolver.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/annotation/ServletObjectsResolver.java
@@ -36,7 +36,6 @@ import java.lang.annotation.Target;
  * }</pre>
  * 
  * @author Oliver Wolff
- * @since 1.0
  */
 @Qualifier
 @Retention(RetentionPolicy.RUNTIME)

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/annotation/package-info.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/annotation/package-info.java
@@ -28,6 +28,5 @@
  * </ul>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 package de.cuioss.sheriff.oauth.quarkus.annotation;

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/config/AccessTokenCacheConfigResolver.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/config/AccessTokenCacheConfigResolver.java
@@ -33,7 +33,6 @@ import static de.cuioss.sheriff.oauth.quarkus.config.JwtPropertyKeys.CACHE;
  *   <li>Eviction interval in seconds</li>
  * </ul>
  *
- * @since 1.0
  */
 @RequiredArgsConstructor
 public class AccessTokenCacheConfigResolver {

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/config/IssuerConfigResolver.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/config/IssuerConfigResolver.java
@@ -52,7 +52,6 @@ import static de.cuioss.sheriff.oauth.quarkus.OAuthSheriffQuarkusLogMessages.INF
  * with the core validation logic without duplication.
  * </p>
  *
- * @since 1.0
  */
 public class IssuerConfigResolver {
 

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/config/JwtPropertyKeys.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/config/JwtPropertyKeys.java
@@ -29,7 +29,6 @@ import lombok.experimental.UtilityClass;
  * All properties are prefixed with "sheriff.oauth".
  * </p>
  *
- * @since 1.0
  */
 @UtilityClass
 public final class JwtPropertyKeys {
@@ -418,7 +417,6 @@ public final class JwtPropertyKeys {
          *
          * @see HttpJwksLoaderConfig#getKeyRotationGracePeriod()
          * @see <a href="https://github.com/cuioss/OAuthSheriff/issues/110">Issue #110: Key rotation grace period</a>
-         * @since 1.1
          */
         public static final String KEY_ROTATION_GRACE_PERIOD_SECONDS = HTTP_BASE + "key-rotation-grace-period-seconds";
 
@@ -439,7 +437,6 @@ public final class JwtPropertyKeys {
          *
          * @see de.cuioss.sheriff.oauth.core.jwks.http.HttpJwksLoaderConfig#getMaxRetiredKeySets()
          * @see <a href="https://github.com/cuioss/OAuthSheriff/issues/110">Issue #110: Key rotation grace period</a>
-         * @since 1.1
          */
         public static final String MAX_RETIRED_KEY_SETS = HTTP_BASE + "max-retired-key-sets";
 
@@ -456,7 +453,6 @@ public final class JwtPropertyKeys {
      * All properties are prefixed with "sheriff.oauth.keycloak".
      * </p>
      *
-     * @since 1.0
      */
     @UtilityClass
     public static final class KEYCLOAK {

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/config/ParserConfigResolver.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/config/ParserConfigResolver.java
@@ -36,7 +36,6 @@ import static de.cuioss.sheriff.oauth.quarkus.OAuthSheriffQuarkusLogMessages.INF
  * duplication and ensuring consistency with the core validation rules.
  * </p>
  *
- * @since 1.0
  */
 public class ParserConfigResolver {
 

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/config/RetryStrategyConfigResolver.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/config/RetryStrategyConfigResolver.java
@@ -35,7 +35,6 @@ import java.time.Duration;
  *   <li>Global enable/disable flag</li>
  * </ul>
  *
- * @since 1.0
  */
 public class RetryStrategyConfigResolver {
 

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/config/package-info.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/config/package-info.java
@@ -28,6 +28,5 @@
  * All properties are prefixed with "sheriff.oauth".
  * </p>
  * 
- * @since 1.0
  */
 package de.cuioss.sheriff.oauth.quarkus.config;

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/interceptor/BearerTokenInterceptor.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/interceptor/BearerTokenInterceptor.java
@@ -77,7 +77,6 @@ import static de.cuioss.sheriff.oauth.quarkus.OAuthSheriffQuarkusLogMessages.WAR
  * </ul>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @BearerAuth
 @Interceptor

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/interceptor/package-info.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/interceptor/package-info.java
@@ -29,6 +29,5 @@
  * validation (interceptor).
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 package de.cuioss.sheriff.oauth.quarkus.interceptor;

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/mapper/ClaimMapperRegistry.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/mapper/ClaimMapperRegistry.java
@@ -41,7 +41,6 @@ import static de.cuioss.sheriff.oauth.quarkus.OAuthSheriffQuarkusLogMessages.INF
  *   <li>Logs the number of registered mappers</li>
  * </ul>
  *
- * @since 1.0
  * @see DiscoverableClaimMapper
  */
 @ApplicationScoped

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/mapper/DiscoverableClaimMapper.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/mapper/DiscoverableClaimMapper.java
@@ -49,7 +49,6 @@ import de.cuioss.sheriff.oauth.core.domain.claim.mapper.ClaimMapper;
  * {@link IllegalStateException}.
  * </p>
  *
- * @since 1.0
  * @see ClaimMapperRegistry
  * @see ClaimMapper
  */

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/mapper/keycloak/KeycloakGroupsMapperBean.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/mapper/keycloak/KeycloakGroupsMapperBean.java
@@ -35,7 +35,6 @@ import org.eclipse.microprofile.config.Config;
  * The mapper is applied globally to all configured issuers.
  * </p>
  *
- * @since 1.0
  * @see KeycloakDefaultGroupsMapper
  * @see DiscoverableClaimMapper
  */

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/mapper/keycloak/KeycloakRolesMapperBean.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/mapper/keycloak/KeycloakRolesMapperBean.java
@@ -35,7 +35,6 @@ import org.eclipse.microprofile.config.Config;
  * format. The mapper is applied globally to all configured issuers.
  * </p>
  *
- * @since 1.0
  * @see KeycloakDefaultRolesMapper
  * @see DiscoverableClaimMapper
  */

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/mapper/keycloak/package-info.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/mapper/keycloak/package-info.java
@@ -29,6 +29,5 @@
  *       Maps Keycloak's {@code groups} claim</li>
  * </ul>
  *
- * @since 1.0
  */
 package de.cuioss.sheriff.oauth.quarkus.mapper.keycloak;

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/mapper/package-info.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/mapper/package-info.java
@@ -29,6 +29,5 @@
  *       Registry that collects and manages discovered mappers</li>
  * </ul>
  *
- * @since 1.0
  */
 package de.cuioss.sheriff.oauth.quarkus.mapper;

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/metrics/MetricIdentifier.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/metrics/MetricIdentifier.java
@@ -27,7 +27,6 @@ import lombok.experimental.UtilityClass;
  * All metrics are prefixed with "sheriff.oauth".
  * </p>
  *
- * @since 1.0
  */
 @UtilityClass
 public final class MetricIdentifier {

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/package-info.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/package-info.java
@@ -35,7 +35,6 @@
  * runtime and deployment modules.
  * </p>
  * 
- * @since 1.0
  */
 @NullMarked
 package de.cuioss.sheriff.oauth.quarkus;

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/producer/BearerTokenProducer.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/producer/BearerTokenProducer.java
@@ -99,7 +99,6 @@ import static de.cuioss.sheriff.oauth.quarkus.OAuthSheriffQuarkusLogMessages.WAR
  * }</pre>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @ApplicationScoped
 public class BearerTokenProducer {

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/producer/BearerTokenResponseFactory.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/producer/BearerTokenResponseFactory.java
@@ -40,7 +40,6 @@ import java.util.stream.Collectors;
  * </ul>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @UtilityClass
 public class BearerTokenResponseFactory {

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/producer/BearerTokenResult.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/producer/BearerTokenResult.java
@@ -63,7 +63,6 @@ import java.util.Set;
  * }</pre>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @Value
 @Builder
@@ -300,7 +299,6 @@ public class BearerTokenResult implements Serializable {
      *
      * @return Response object with appropriate HTTP status code, headers, and body
      * @throws IllegalStateException if called on a successfully authorized token
-     * @since 1.0
      */
     public Response createErrorResponse() {
         if (isSuccessfullyAuthorized()) {

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/producer/BearerTokenStatus.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/producer/BearerTokenStatus.java
@@ -28,7 +28,6 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
  * HTTP responses can be created using {@link BearerTokenResult#createErrorResponse()}.
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @RegisterForReflection(methods = false, fields = false)
 public enum BearerTokenStatus {

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/producer/TokenValidatorProducer.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/producer/TokenValidatorProducer.java
@@ -56,7 +56,6 @@ import static de.cuioss.sheriff.oauth.quarkus.OAuthSheriffQuarkusLogMessages.INF
  *   <li>{@link SecurityEventCounter} - Security event counter for monitoring</li>
  * </ul>
  *
- * @since 1.0
  */
 @ApplicationScoped
 public class TokenValidatorProducer {

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/servlet/HttpServletRequestResolver.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/servlet/HttpServletRequestResolver.java
@@ -35,7 +35,6 @@ import java.util.*;
  * implementations may throw {@link IllegalStateException} which gets wrapped by CDI.</p>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 public interface HttpServletRequestResolver {
 

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/servlet/VertxHttpServletRequestAdapter.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/servlet/VertxHttpServletRequestAdapter.java
@@ -72,7 +72,6 @@ import java.util.concurrent.ConcurrentHashMap;
  * </ul>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @RequiredArgsConstructor
 public class VertxHttpServletRequestAdapter implements HttpServletRequest {

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/servlet/VertxServletObjectsResolver.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/servlet/VertxServletObjectsResolver.java
@@ -48,7 +48,6 @@ import static de.cuioss.sheriff.oauth.quarkus.OAuthSheriffQuarkusLogMessages.ERR
  * and provides access to HTTP request data through the native Vertx APIs.</p>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @ApplicationScoped
 @ServletObjectsResolver(ServletObjectsResolver.Variant.VERTX)

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/test/java/de/cuioss/sheriff/oauth/quarkus/producer/BearerTokenResponseFactoryTest.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/test/java/de/cuioss/sheriff/oauth/quarkus/producer/BearerTokenResponseFactoryTest.java
@@ -40,7 +40,6 @@ import static org.junit.jupiter.api.Assertions.*;
  * {@link BearerTokenResult} objects.
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @DisplayName("BearerTokenResponseFactory Tests")
 class BearerTokenResponseFactoryTest {

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/test/java/de/cuioss/sheriff/oauth/quarkus/producer/BearerTokenResultTest.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/test/java/de/cuioss/sheriff/oauth/quarkus/producer/BearerTokenResultTest.java
@@ -35,7 +35,6 @@ import static org.junit.jupiter.api.Assertions.*;
  * Tests all methods, builders, static factory methods, and edge cases.
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @DisplayName("BearerTokenResult Unit Tests")
 class BearerTokenResultTest {

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/test/java/de/cuioss/sheriff/oauth/quarkus/servlet/HttpServletRequestMock.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/test/java/de/cuioss/sheriff/oauth/quarkus/servlet/HttpServletRequestMock.java
@@ -47,7 +47,6 @@ import java.util.*;
  * }</pre>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @Getter
 @Setter

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/test/java/de/cuioss/sheriff/oauth/quarkus/servlet/HttpServletRequestResolverMock.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/test/java/de/cuioss/sheriff/oauth/quarkus/servlet/HttpServletRequestResolverMock.java
@@ -47,7 +47,6 @@ import lombok.NonNull;
  * }</pre>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 public class HttpServletRequestResolverMock implements HttpServletRequestResolver {
 

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/test/java/de/cuioss/sheriff/oauth/quarkus/servlet/HttpServletRequestResolverMockTest.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/test/java/de/cuioss/sheriff/oauth/quarkus/servlet/HttpServletRequestResolverMockTest.java
@@ -30,7 +30,6 @@ import static org.junit.jupiter.api.Assertions.*;
  * Unit tests for {@link HttpServletRequestResolverMock}.
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @DisplayName("HttpServletRequestResolverMock Tests")
 class HttpServletRequestResolverMockTest {

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/test/java/de/cuioss/sheriff/oauth/quarkus/servlet/VertxServletObjectsResolverErrorPathsTest.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/test/java/de/cuioss/sheriff/oauth/quarkus/servlet/VertxServletObjectsResolverErrorPathsTest.java
@@ -36,7 +36,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * These scenarios should not occur in properly configured applications but are tested for completeness.</p>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @EnableTestLogger
 @DisplayName("VertxServletObjectsResolver Error Path Tests")

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/test/java/de/cuioss/sheriff/oauth/quarkus/servlet/VertxServletObjectsResolverQuarkusTest.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/test/java/de/cuioss/sheriff/oauth/quarkus/servlet/VertxServletObjectsResolverQuarkusTest.java
@@ -46,7 +46,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * which focus on the UnsupportedOperationException cases.</p>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @QuarkusTest
 @TestProfile(JwtTestProfile.class)

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/test/java/de/cuioss/sheriff/oauth/quarkus/servlet/VertxServletObjectsResolverScopingTest.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/test/java/de/cuioss/sheriff/oauth/quarkus/servlet/VertxServletObjectsResolverScopingTest.java
@@ -48,7 +48,6 @@ import static org.junit.jupiter.api.Assertions.*;
  * </ul>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @QuarkusTest
 @TestProfile(JwtTestProfile.class)

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/test/java/de/cuioss/sheriff/oauth/quarkus/servlet/adapter/VertxHttpServletRequestAdapterTest.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/test/java/de/cuioss/sheriff/oauth/quarkus/servlet/adapter/VertxHttpServletRequestAdapterTest.java
@@ -48,7 +48,6 @@ import static org.junit.jupiter.api.Assertions.*;
  * </ul>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @DisplayName("VertxHttpServletRequestAdapter Tests")
 class VertxHttpServletRequestAdapterTest {

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/test/java/de/cuioss/sheriff/oauth/quarkus/servlet/adapter/VertxHttpServletRequestAdapterUnsupportedOperationsTest.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/test/java/de/cuioss/sheriff/oauth/quarkus/servlet/adapter/VertxHttpServletRequestAdapterUnsupportedOperationsTest.java
@@ -38,7 +38,6 @@ import static org.junit.jupiter.api.Assertions.*;
  * descriptive messages.</p>
  *
  * @author Oliver Wolff
- * @since 1.0
  */
 @DisplayName("VertxHttpServletRequestAdapter Unsupported Operations Tests")
 class VertxHttpServletRequestAdapterUnsupportedOperationsTest {


### PR DESCRIPTION
## Summary

- Remove all 178 `@since` tag occurrences across all modules (oauth-sheriff-core, quarkus, benchmarking)
- Tags referenced non-existent versions (`1.0`, `1.0.0`, `1.1`) which are misleading for a pre-1.0 (`1.0.0-SNAPSHOT`) project
- Will be reintroduced meaningfully after 1.0 release

## Test plan

- [x] `grep -r "@since" --include="*.java" .` returns 0 matches
- [x] `./mvnw -Ppre-commit clean verify` passes (Javadoc, checkstyle, spotbugs, all tests)
- [x] `./mvnw clean install` full build passes
- [x] OpenRewrite formatting changes (trailing blank line cleanup) included

🤖 Generated with [Claude Code](https://claude.com/claude-code)