### PR TITLE
feat: @RolesAllowed, cookie extraction, MP-JWT integration tests

### DIFF
--- a/doc/specification/microprofile-jwt-compatibility.adoc
+++ b/doc/specification/microprofile-jwt-compatibility.adoc
@@ -115,26 +115,26 @@ Standard MP-JWT CDI injection is supported:
 
 When no valid token is present, an empty `JsonWebToken` is injected (per MP-JWT spec).
 
-== Planned Features
-
-The following MP-JWT 2.1 features are planned for adoption in future PRs.
-
 === Cookie-Based Token Extraction (`mp.jwt.token.header` / `mp.jwt.token.cookie`)
 
 Alternative token extraction from HTTP cookies instead of the `Authorization` header. Useful for browser-based SPAs using SameSite cookie protection.
 
-Planned configuration:
+OAuthSheriff configuration:
 
 * `sheriff.oauth.token.header` — `Authorization` (default) or `Cookie`
-* `sheriff.oauth.token.cookie` — cookie name (default: `Bearer`)
+* `sheriff.oauth.token.cookie-name` — cookie name (default: `Bearer`)
+
+When `token.header=Cookie`, the `BearerTokenProducer` parses the HTTP `Cookie` header and extracts the JWT from the named cookie. The `Authorization` header is checked first as a fallback.
 
 === `@RolesAllowed` Support
 
-Standard JSR-250 `@RolesAllowed` annotations alongside OAuthSheriff's `@BearerAuth`:
+Standard JSR-250 `@RolesAllowed` annotations are supported alongside OAuthSheriff's `@BearerAuth`:
 
 * `@RolesAllowed("admin")` — checks `groups` claim (MP-JWT spec behavior)
 * `@BearerAuth(requiredScopes={"read"}, requiredRoles={"admin"})` — checks scopes AND roles AND groups (OAuthSheriff extension)
 * `@PermitAll` / `@DenyAll` — standard behavior
+
+Implemented via `RolesAllowedFilter`, a JAX-RS `ContainerRequestFilter` at `Priorities.AUTHORIZATION` priority. Method-level annotations take precedence over class-level.
 
 
 == Not Adopted (By Design)

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus-deployment/src/main/java/de/cuioss/sheriff/oauth/quarkus/deployment/OAuthSheriffProcessor.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus-deployment/src/main/java/de/cuioss/sheriff/oauth/quarkus/deployment/OAuthSheriffProcessor.java
@@ -325,7 +325,6 @@ public class OAuthSheriffProcessor {
                 .addBeanClass(CustomAccessLogFilter.class)
                 // Register interceptor infrastructure
                 .addBeanClass(BearerTokenInterceptor.class)
-                .addBeanClass(RolesAllowedFilter.class)
                 .setUnremovable()
                 .build();
     }

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus-deployment/src/main/java/de/cuioss/sheriff/oauth/quarkus/deployment/OAuthSheriffProcessor.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus-deployment/src/main/java/de/cuioss/sheriff/oauth/quarkus/deployment/OAuthSheriffProcessor.java
@@ -44,6 +44,7 @@ import de.cuioss.sheriff.oauth.core.security.SignatureAlgorithmPreferences;
 import de.cuioss.sheriff.oauth.quarkus.config.AccessLogFilterConfigProducer;
 import de.cuioss.sheriff.oauth.quarkus.config.ParserConfigResolver;
 import de.cuioss.sheriff.oauth.quarkus.interceptor.BearerTokenInterceptor;
+import de.cuioss.sheriff.oauth.quarkus.interceptor.RolesAllowedFilter;
 import de.cuioss.sheriff.oauth.quarkus.logging.CustomAccessLogFilter;
 import de.cuioss.sheriff.oauth.quarkus.mapper.ClaimMapperRegistry;
 import de.cuioss.sheriff.oauth.quarkus.mapper.DiscoverableClaimMapper;
@@ -204,8 +205,9 @@ public class OAuthSheriffProcessor {
                 TokenContent.class,
                 BaseTokenContent.class,
                 MinimalTokenContent.class,
-                // MicroProfile JWT interface - needed for default method resolution in native image
+                // MicroProfile JWT interface and empty implementation - needed for native image
                 org.eclipse.microprofile.jwt.JsonWebToken.class,
+                // Note: EmptyJsonWebToken is registered by name below (package-private class)
                 // Claim handling classes - need full reflection for enum handling
                 ClaimValue.class,
                 ClaimName.class,
@@ -238,6 +240,22 @@ public class OAuthSheriffProcessor {
                 .methods(false)  // Methods not needed - mappers are called via interface
                 .fields(false)   // Fields not needed - no field access
                 .constructors(true) // Only constructors needed for instantiation
+                .build();
+    }
+
+    /**
+     * Register EmptyJsonWebToken for reflection in native image.
+     * This package-private class is the fallback when no valid JWT is present.
+     *
+     * @return A {@link ReflectiveClassBuildItem} for EmptyJsonWebToken
+     */
+    @BuildStep
+    public ReflectiveClassBuildItem registerEmptyJsonWebTokenForReflection() {
+        return ReflectiveClassBuildItem.builder(
+                "de.cuioss.sheriff.oauth.quarkus.producer.EmptyJsonWebToken")
+                .methods(true)
+                .fields(false)
+                .constructors(true)
                 .build();
     }
 
@@ -307,6 +325,7 @@ public class OAuthSheriffProcessor {
                 .addBeanClass(CustomAccessLogFilter.class)
                 // Register interceptor infrastructure
                 .addBeanClass(BearerTokenInterceptor.class)
+                .addBeanClass(RolesAllowedFilter.class)
                 .setUnremovable()
                 .build();
     }
@@ -320,6 +339,18 @@ public class OAuthSheriffProcessor {
     @BuildStep
     public ResteasyJaxrsProviderBuildItem registerCustomAccessLogFilter() {
         return new ResteasyJaxrsProviderBuildItem(CustomAccessLogFilter.class.getName());
+    }
+
+    /**
+     * Register the RolesAllowedFilter as a JAX-RS provider.
+     * This filter enforces {@code @RolesAllowed}, {@code @DenyAll}, and {@code @PermitAll}
+     * annotations by checking the JWT token's groups claim.
+     *
+     * @return A {@link ResteasyJaxrsProviderBuildItem} for the RolesAllowedFilter
+     */
+    @BuildStep
+    public ResteasyJaxrsProviderBuildItem registerRolesAllowedFilter() {
+        return new ResteasyJaxrsProviderBuildItem(RolesAllowedFilter.class.getName());
     }
 
     /**

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus-integration-tests/src/main/java/de/cuioss/sheriff/oauth/integration/endpoint/JwtValidationEndpoint.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus-integration-tests/src/main/java/de/cuioss/sheriff/oauth/integration/endpoint/JwtValidationEndpoint.java
@@ -55,7 +55,7 @@ public class JwtValidationEndpoint {
     public static final String NOT_PRESENT = "not-present";
 
     @Inject
-    jakarta.inject.Provider<JsonWebToken> jsonWebTokenProvider;
+    Instance<JsonWebToken> jsonWebTokenProvider;
 
     private final TokenValidator tokenValidator;
     private final Instance<BearerTokenResult> basicToken;

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus-integration-tests/src/main/java/de/cuioss/sheriff/oauth/integration/endpoint/JwtValidationEndpoint.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus-integration-tests/src/main/java/de/cuioss/sheriff/oauth/integration/endpoint/JwtValidationEndpoint.java
@@ -27,16 +27,18 @@ import de.cuioss.sheriff.oauth.quarkus.producer.BearerTokenResult;
 import de.cuioss.tools.logging.CuiLogger;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 import io.smallrye.common.annotation.RunOnVirtualThread;
+import jakarta.annotation.security.DenyAll;
+import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.eclipse.microprofile.jwt.JsonWebToken;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 
 /**
  * REST endpoint for JWT validation operations.
@@ -51,6 +53,9 @@ public class JwtValidationEndpoint {
 
     private static final CuiLogger LOGGER = new CuiLogger(JwtValidationEndpoint.class);
     public static final String NOT_PRESENT = "not-present";
+
+    @Inject
+    JsonWebToken jsonWebToken;
 
     private final TokenValidator tokenValidator;
     private final Instance<BearerTokenResult> basicToken;
@@ -384,6 +389,78 @@ public class JwtValidationEndpoint {
         return Response.ok(new ValidationResponse(true, "Echo successful", responseData)).build();
     }
 
+
+    // === MP-JWT JsonWebToken injection test ===
+
+    /**
+     * Tests MP-JWT {@link JsonWebToken} injection.
+     * Returns principal name, subject, groups, and claim names from the injected token.
+     */
+    @GET
+    @Path("/mp-jwt/principal")
+    @BearerAuth
+    public Response testMpJwtPrincipal() {
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("principalName", jsonWebToken.getName());
+        data.put("subject", jsonWebToken.getSubject());
+        data.put("groups", jsonWebToken.getGroups());
+        data.put("claimNames", jsonWebToken.getClaimNames());
+        // JsonWebToken extends Principal, so we report its class name
+        data.put("principalClass", jsonWebToken.getClass().getSimpleName());
+        return Response.ok(data).build();
+    }
+
+    // === @RolesAllowed test endpoints ===
+
+    /**
+     * Tests {@code @RolesAllowed("admin")} — requires admin group in token.
+     */
+    @GET
+    @Path("/roles/admin")
+    @RolesAllowed("admin")
+    public Response testRolesAdmin() {
+        return Response.ok(Map.of("access", "granted", "role", "admin")).build();
+    }
+
+    /**
+     * Tests {@code @RolesAllowed("user")} — requires user group in token.
+     */
+    @GET
+    @Path("/roles/user")
+    @RolesAllowed("user")
+    public Response testRolesUser() {
+        return Response.ok(Map.of("access", "granted", "role", "user")).build();
+    }
+
+    /**
+     * Tests {@code @RolesAllowed("test-group")} — requires test-group in token.
+     */
+    @GET
+    @Path("/roles/test-group")
+    @RolesAllowed("test-group")
+    public Response testRolesTestGroup() {
+        return Response.ok(Map.of("access", "granted", "role", "test-group")).build();
+    }
+
+    /**
+     * Tests {@code @DenyAll} — always returns 403 Forbidden.
+     */
+    @GET
+    @Path("/roles/deny-all")
+    @DenyAll
+    public Response testDenyAll() {
+        return Response.ok(Map.of("access", "should-not-reach")).build();
+    }
+
+    /**
+     * Tests {@code @PermitAll} — allows access without token.
+     */
+    @GET
+    @Path("/roles/permit-all")
+    @PermitAll
+    public Response testPermitAll() {
+        return Response.ok(Map.of("access", "granted")).build();
+    }
 
     // Helper methods
 

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus-integration-tests/src/main/java/de/cuioss/sheriff/oauth/integration/endpoint/JwtValidationEndpoint.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus-integration-tests/src/main/java/de/cuioss/sheriff/oauth/integration/endpoint/JwtValidationEndpoint.java
@@ -55,7 +55,7 @@ public class JwtValidationEndpoint {
     public static final String NOT_PRESENT = "not-present";
 
     @Inject
-    JsonWebToken jsonWebToken;
+    jakarta.inject.Provider<JsonWebToken> jsonWebTokenProvider;
 
     private final TokenValidator tokenValidator;
     private final Instance<BearerTokenResult> basicToken;
@@ -401,12 +401,13 @@ public class JwtValidationEndpoint {
     @BearerAuth
     public Response testMpJwtPrincipal() {
         Map<String, Object> data = new LinkedHashMap<>();
-        data.put("principalName", jsonWebToken.getName());
-        data.put("subject", jsonWebToken.getSubject());
-        data.put("groups", jsonWebToken.getGroups());
-        data.put("claimNames", jsonWebToken.getClaimNames());
+        JsonWebToken jwt = jsonWebTokenProvider.get();
+        data.put("principalName", jwt.getName());
+        data.put("subject", jwt.getSubject());
+        data.put("groups", jwt.getGroups());
+        data.put("claimNames", jwt.getClaimNames());
         // JsonWebToken extends Principal, so we report its class name
-        data.put("principalClass", jsonWebToken.getClass().getSimpleName());
+        data.put("principalClass", jwt.getClass().getSimpleName());
         return Response.ok(data).build();
     }
 

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus-integration-tests/src/test/java/de/cuioss/sheriff/oauth/integration/mpjwt/MpJwtSpecIT.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus-integration-tests/src/test/java/de/cuioss/sheriff/oauth/integration/mpjwt/MpJwtSpecIT.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.oauth.integration.mpjwt;
+
+import de.cuioss.sheriff.oauth.integration.BaseIntegrationTest;
+import de.cuioss.sheriff.oauth.integration.TestRealm;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for MicroProfile JWT specification features:
+ * <ul>
+ *   <li>{@code @Inject JsonWebToken} and {@code @Inject Principal}</li>
+ *   <li>{@code @RolesAllowed}, {@code @DenyAll}, {@code @PermitAll}</li>
+ * </ul>
+ */
+@DisplayName("MP-JWT Spec")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class MpJwtSpecIT extends BaseIntegrationTest {
+
+    private static final String AUTHORIZATION = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    // === JsonWebToken injection tests ===
+
+    @ParameterizedTest(name = "[{0}]")
+    @MethodSource("de.cuioss.sheriff.oauth.integration.TestProviders#rolesProviders")
+    @Order(1)
+    @DisplayName("@Inject JsonWebToken — returns valid principal name with token")
+    void jsonWebTokenPrincipalName(TestRealm realm) {
+        var tokenResponse = realm.obtainValidToken();
+
+        var response = given()
+                .header(AUTHORIZATION, BEARER_PREFIX + tokenResponse.accessToken())
+                .when()
+                .get("/jwt/mp-jwt/principal")
+                .then()
+                .statusCode(200)
+                .extract()
+                .response();
+
+        String principalName = response.jsonPath().getString("principalName");
+        assertNotNull(principalName, "principalName should not be null");
+        assertFalse(principalName.isBlank(), "principalName should not be blank");
+    }
+
+    @ParameterizedTest(name = "[{0}]")
+    @MethodSource("de.cuioss.sheriff.oauth.integration.TestProviders#groupsProviders")
+    @Order(2)
+    @DisplayName("@Inject JsonWebToken — groups match token groups")
+    void jsonWebTokenGroups(TestRealm realm) {
+        var tokenResponse = realm.obtainValidToken();
+
+        var response = given()
+                .header(AUTHORIZATION, BEARER_PREFIX + tokenResponse.accessToken())
+                .when()
+                .get("/jwt/mp-jwt/principal")
+                .then()
+                .statusCode(200)
+                .extract()
+                .response();
+
+        var groups = response.jsonPath().getList("groups");
+        assertNotNull(groups, "groups should not be null");
+        assertFalse(groups.isEmpty(), "groups should not be empty for providers with GROUPS capability");
+    }
+
+    @ParameterizedTest(name = "[{0}]")
+    @MethodSource("de.cuioss.sheriff.oauth.integration.TestProviders#rolesProviders")
+    @Order(3)
+    @DisplayName("@Inject JsonWebToken — class is AccessTokenContent (not EmptyJsonWebToken)")
+    void jsonWebTokenClassIsAccessTokenContent(TestRealm realm) {
+        var tokenResponse = realm.obtainValidToken();
+
+        var response = given()
+                .header(AUTHORIZATION, BEARER_PREFIX + tokenResponse.accessToken())
+                .when()
+                .get("/jwt/mp-jwt/principal")
+                .then()
+                .statusCode(200)
+                .extract()
+                .response();
+
+        String principalClass = response.jsonPath().getString("principalClass");
+        assertEquals("AccessTokenContent", principalClass,
+                "JsonWebToken should be AccessTokenContent when a valid token is present");
+    }
+
+    // === @RolesAllowed tests ===
+
+    @ParameterizedTest(name = "[{0}]")
+    @MethodSource("de.cuioss.sheriff.oauth.integration.TestProviders#groupsProviders")
+    @Order(10)
+    @DisplayName("@RolesAllowed(\"test-group\") — grants access when token has matching group")
+    void rolesAllowedGrantsAccess(TestRealm realm) {
+        var tokenResponse = realm.obtainValidToken();
+
+        given()
+                .header(AUTHORIZATION, BEARER_PREFIX + tokenResponse.accessToken())
+                .when()
+                .get("/jwt/roles/test-group")
+                .then()
+                .statusCode(200)
+                .body("access", equalTo("granted"))
+                .body("role", equalTo("test-group"));
+    }
+
+    @ParameterizedTest(name = "[{0}]")
+    @MethodSource("de.cuioss.sheriff.oauth.integration.TestProviders#rolesProviders")
+    @Order(11)
+    @DisplayName("@RolesAllowed(\"admin\") — returns 403 when token lacks admin group")
+    void rolesAllowedDeniesAccess(TestRealm realm) {
+        var tokenResponse = realm.obtainValidToken();
+
+        given()
+                .header(AUTHORIZATION, BEARER_PREFIX + tokenResponse.accessToken())
+                .when()
+                .get("/jwt/roles/admin")
+                .then()
+                .statusCode(403);
+    }
+
+    // === @DenyAll tests ===
+
+    @Test
+    @Order(20)
+    @DisplayName("@DenyAll — always returns 403 even with valid token")
+    void denyAllWithToken() {
+        var realm = TestRealm.createIntegrationRealm();
+        var tokenResponse = realm.obtainValidToken();
+
+        given()
+                .header(AUTHORIZATION, BEARER_PREFIX + tokenResponse.accessToken())
+                .when()
+                .get("/jwt/roles/deny-all")
+                .then()
+                .statusCode(403);
+    }
+
+    @Test
+    @Order(21)
+    @DisplayName("@DenyAll — returns 403 without token")
+    void denyAllWithoutToken() {
+        given()
+                .when()
+                .get("/jwt/roles/deny-all")
+                .then()
+                .statusCode(403);
+    }
+
+    // === @PermitAll tests ===
+
+    @Test
+    @Order(30)
+    @DisplayName("@PermitAll — allows access without token")
+    void permitAllWithoutToken() {
+        given()
+                .when()
+                .get("/jwt/roles/permit-all")
+                .then()
+                .statusCode(200)
+                .body("access", equalTo("granted"));
+    }
+
+    @Test
+    @Order(31)
+    @DisplayName("@PermitAll — allows access with token")
+    void permitAllWithToken() {
+        var realm = TestRealm.createIntegrationRealm();
+        var tokenResponse = realm.obtainValidToken();
+
+        given()
+                .header(AUTHORIZATION, BEARER_PREFIX + tokenResponse.accessToken())
+                .when()
+                .get("/jwt/roles/permit-all")
+                .then()
+                .statusCode(200)
+                .body("access", equalTo("granted"));
+    }
+
+    // === @RolesAllowed without token ===
+
+    @Test
+    @Order(40)
+    @DisplayName("@RolesAllowed — returns 401 when no token is present")
+    void rolesAllowedNoToken() {
+        given()
+                .when()
+                .get("/jwt/roles/user")
+                .then()
+                .statusCode(401);
+    }
+}

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/config/JwtPropertyKeys.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/config/JwtPropertyKeys.java
@@ -784,6 +784,52 @@ public final class JwtPropertyKeys {
     }
 
     /**
+     * Properties related to token extraction configuration.
+     * <p>
+     * These properties control how the bearer token is extracted from incoming
+     * HTTP requests. By default, the token is extracted from the {@code Authorization}
+     * header using the {@code Bearer} scheme. Alternatively, the token can be
+     * extracted from a named cookie.
+     * </p>
+     * <p>
+     * All properties are prefixed with "sheriff.oauth.token".
+     * </p>
+     *
+     * @since 1.0
+     */
+    @UtilityClass
+    public static final class TOKEN {
+        /**
+         * Base path for token extraction configurations.
+         */
+        public static final String BASE = PREFIX + ".token";
+
+        /**
+         * The header source for token extraction.
+         * Property: "sheriff.oauth.token.header"
+         * <p>
+         * Supported values:
+         * <ul>
+         *   <li>{@code Authorization} (default) — extract from the Authorization header with Bearer scheme</li>
+         *   <li>{@code Cookie} — extract from a named cookie (see {@link #COOKIE_NAME})</li>
+         * </ul>
+         */
+        public static final String HEADER = BASE + ".header";
+
+        /**
+         * The cookie name to use when extracting the token from cookies.
+         * Property: "sheriff.oauth.token.cookie-name"
+         * <p>
+         * Only used when {@link #HEADER} is set to {@code Cookie}.
+         * </p>
+         * <p>
+         * Default value is {@code Bearer}.
+         * </p>
+         */
+        public static final String COOKIE_NAME = BASE + ".cookie-name";
+    }
+
+    /**
      * Properties related to HTTP retry configuration.
      */
     @UtilityClass

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/interceptor/RolesAllowedFilter.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/interceptor/RolesAllowedFilter.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.oauth.quarkus.interceptor;
+
+import de.cuioss.sheriff.oauth.core.domain.token.AccessTokenContent;
+import de.cuioss.sheriff.oauth.quarkus.producer.BearerTokenProducer;
+import de.cuioss.tools.logging.CuiLogger;
+import jakarta.annotation.Priority;
+import jakarta.annotation.security.DenyAll;
+import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.ResourceInfo;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.Provider;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * JAX-RS {@link ContainerRequestFilter} that enforces standard Jakarta Security
+ * annotations ({@link RolesAllowed}, {@link DenyAll}, {@link PermitAll}) on
+ * JAX-RS resource methods and classes.
+ * <p>
+ * Per the MicroProfile JWT specification, {@code @RolesAllowed} maps to the
+ * {@code groups} claim in the JWT token. This filter extracts the token via
+ * {@link BearerTokenProducer#getAccessTokenContent()}, retrieves the groups,
+ * and checks whether any of the required roles are present.
+ * </p>
+ * <p>
+ * Annotation resolution order (method takes precedence over class):
+ * <ol>
+ *   <li>Check method for {@code @DenyAll} — always return 403</li>
+ *   <li>Check method for {@code @PermitAll} — pass through</li>
+ *   <li>Check method for {@code @RolesAllowed} — validate groups</li>
+ *   <li>Check class for the same annotations in the same order</li>
+ *   <li>If no annotation found — pass through (no security constraint)</li>
+ * </ol>
+ *
+ * @since 1.0
+ * @author Oliver Wolff
+ */
+@Provider
+@Priority(Priorities.AUTHORIZATION)
+public class RolesAllowedFilter implements ContainerRequestFilter {
+
+    private static final CuiLogger LOGGER = new CuiLogger(RolesAllowedFilter.class);
+
+    @Inject
+    BearerTokenProducer bearerTokenProducer;
+
+    @Context
+    ResourceInfo resourceInfo;
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) {
+        Method method = resourceInfo.getResourceMethod();
+        if (method == null) {
+            return;
+        }
+        Class<?> resourceClass = resourceInfo.getResourceClass();
+
+        // Method-level annotations take precedence
+        if (method.isAnnotationPresent(DenyAll.class)) {
+            LOGGER.debug("@DenyAll on method %s — returning 403", method.getName());
+            requestContext.abortWith(Response.status(Response.Status.FORBIDDEN).build());
+            return;
+        }
+        if (method.isAnnotationPresent(PermitAll.class)) {
+            LOGGER.debug("@PermitAll on method %s — allowing access", method.getName());
+            return;
+        }
+
+        RolesAllowed rolesAllowed = method.getAnnotation(RolesAllowed.class);
+        if (rolesAllowed == null && resourceClass != null) {
+            // Fall back to class-level annotations
+            if (resourceClass.isAnnotationPresent(DenyAll.class)) {
+                LOGGER.debug("@DenyAll on class %s — returning 403", resourceClass.getSimpleName());
+                requestContext.abortWith(Response.status(Response.Status.FORBIDDEN).build());
+                return;
+            }
+            if (resourceClass.isAnnotationPresent(PermitAll.class)) {
+                LOGGER.debug("@PermitAll on class %s — allowing access", resourceClass.getSimpleName());
+                return;
+            }
+            rolesAllowed = resourceClass.getAnnotation(RolesAllowed.class);
+        }
+
+        if (rolesAllowed == null) {
+            // No security annotation — pass through
+            return;
+        }
+
+        // @RolesAllowed found — check token groups
+        Set<String> allowedRoles = Set.of(rolesAllowed.value());
+        LOGGER.debug("@RolesAllowed check for roles: %s", allowedRoles);
+
+        Optional<AccessTokenContent> tokenOpt = bearerTokenProducer.getAccessTokenContent();
+        if (tokenOpt.isEmpty()) {
+            LOGGER.debug("No valid token present — returning 401 for @RolesAllowed");
+            requestContext.abortWith(Response.status(Response.Status.UNAUTHORIZED).build());
+            return;
+        }
+
+        AccessTokenContent token = tokenOpt.get();
+        Set<String> tokenGroups = token.getGroups();
+        if (tokenGroups == null) {
+            tokenGroups = Collections.emptySet();
+        }
+
+        // Check if token groups contain any of the allowed roles (per MP-JWT spec)
+        boolean hasRole = false;
+        for (String role : allowedRoles) {
+            if (tokenGroups.contains(role)) {
+                hasRole = true;
+                break;
+            }
+        }
+
+        if (!hasRole) {
+            LOGGER.debug("Token groups %s do not contain any of required roles %s — returning 403",
+                    tokenGroups, allowedRoles);
+            requestContext.abortWith(Response.status(Response.Status.FORBIDDEN).build());
+            return;
+        }
+
+        LOGGER.debug("@RolesAllowed check passed — token has required role(s)");
+    }
+}

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/interceptor/RolesAllowedFilter.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/interceptor/RolesAllowedFilter.java
@@ -123,18 +123,9 @@ public class RolesAllowedFilter implements ContainerRequestFilter {
 
         AccessTokenContent token = tokenOpt.get();
         Set<String> tokenGroups = token.getGroups();
-        if (tokenGroups == null) {
-            tokenGroups = Collections.emptySet();
-        }
 
         // Check if token groups contain any of the allowed roles (per MP-JWT spec)
-        boolean hasRole = false;
-        for (String role : allowedRoles) {
-            if (tokenGroups.contains(role)) {
-                hasRole = true;
-                break;
-            }
-        }
+        boolean hasRole = allowedRoles.stream().anyMatch(tokenGroups::contains);
 
         if (!hasRole) {
             LOGGER.debug("Token groups %s do not contain any of required roles %s — returning 403",

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/interceptor/RolesAllowedFilter.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/interceptor/RolesAllowedFilter.java
@@ -61,6 +61,7 @@ import java.util.Set;
  */
 @Provider
 @Priority(Priorities.AUTHORIZATION)
+@io.quarkus.runtime.annotations.RegisterForReflection
 public class RolesAllowedFilter implements ContainerRequestFilter {
 
     private static final CuiLogger LOGGER = new CuiLogger(RolesAllowedFilter.class);

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/producer/BearerTokenProducer.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/producer/BearerTokenProducer.java
@@ -21,6 +21,7 @@ import de.cuioss.sheriff.oauth.core.domain.token.AccessTokenContent;
 import de.cuioss.sheriff.oauth.core.exception.TokenValidationException;
 import de.cuioss.sheriff.oauth.quarkus.annotation.BearerToken;
 import de.cuioss.sheriff.oauth.quarkus.annotation.ServletObjectsResolver;
+import de.cuioss.sheriff.oauth.quarkus.config.JwtPropertyKeys;
 import de.cuioss.sheriff.oauth.quarkus.metrics.MetricIdentifier;
 import de.cuioss.sheriff.oauth.quarkus.servlet.HttpServletRequestResolver;
 import de.cuioss.tools.logging.CuiLogger;
@@ -30,6 +31,7 @@ import jakarta.enterprise.context.RequestScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.enterprise.inject.spi.InjectionPoint;
 import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.jwt.JsonWebToken;
 
 import java.security.Principal;
@@ -109,15 +111,24 @@ public class BearerTokenProducer {
 
     private static final CuiLogger LOGGER = new CuiLogger(BearerTokenProducer.class);
     static final String BEARER_PREFIX = "Bearer ";
+    static final String HEADER_AUTHORIZATION = "Authorization";
+    static final String HEADER_COOKIE = "Cookie";
+    static final String DEFAULT_COOKIE_NAME = "Bearer";
 
     private final TokenValidator tokenValidator;
     private final HttpServletRequestResolver servletObjectsResolver;
+    private final String tokenHeader;
+    private final String tokenCookieName;
 
     @Inject
     public BearerTokenProducer(TokenValidator tokenValidator,
-            @ServletObjectsResolver(ServletObjectsResolver.Variant.VERTX) HttpServletRequestResolver servletObjectsResolver) {
+            @ServletObjectsResolver(ServletObjectsResolver.Variant.VERTX) HttpServletRequestResolver servletObjectsResolver,
+            @ConfigProperty(name = JwtPropertyKeys.TOKEN.HEADER, defaultValue = HEADER_AUTHORIZATION) String tokenHeader,
+            @ConfigProperty(name = JwtPropertyKeys.TOKEN.COOKIE_NAME, defaultValue = DEFAULT_COOKIE_NAME) String tokenCookieName) {
         this.tokenValidator = tokenValidator;
         this.servletObjectsResolver = servletObjectsResolver;
+        this.tokenHeader = tokenHeader;
+        this.tokenCookieName = tokenCookieName;
     }
 
     /**
@@ -150,6 +161,10 @@ public class BearerTokenProducer {
         Map<String, List<String>> headerMap = servletObjectsResolver.resolveHeaderMap();
 
         Optional<String> tokenResult = extractBearerTokenFromHeaderMap(headerMap);
+        // Fallback to cookie extraction if Authorization header has no token
+        if (tokenResult.isEmpty() && HEADER_COOKIE.equalsIgnoreCase(tokenHeader)) {
+            tokenResult = extractTokenFromCookieHeader(headerMap);
+        }
         if (tokenResult.isEmpty()) {
             LOGGER.debug("Bearer token missing or invalid in Authorization header");
             return BearerTokenResult.noTokenGiven(requiredScopes, requiredRoles, requiredGroups);
@@ -229,6 +244,46 @@ public class BearerTokenProducer {
         return Optional.of(token);
     }
 
+
+    /**
+     * Extracts the bearer token from the cookie header in the provided HTTP header map.
+     * <p>
+     * Parses the {@code cookie} header value to find a cookie matching the configured
+     * {@link #tokenCookieName}. Cookies are expected in the standard format:
+     * {@code name1=value1; name2=value2}.
+     *
+     * @param headerMap the resolved HTTP header map
+     * @return Optional containing the cookie value, or empty Optional if the cookie is not found
+     */
+    private Optional<String> extractTokenFromCookieHeader(Map<String, List<String>> headerMap) {
+        List<String> cookieHeaders = headerMap.get("cookie");
+        if (cookieHeaders == null || cookieHeaders.isEmpty()) {
+            LOGGER.debug("Cookie header not found in headerMap");
+            return Optional.empty();
+        }
+
+        // Parse cookie header(s) — may be a single header with semicolons or multiple headers
+        for (String cookieHeader : cookieHeaders) {
+            String[] cookies = cookieHeader.split(";");
+            for (String cookie : cookies) {
+                String trimmed = cookie.trim();
+                int eqIndex = trimmed.indexOf('=');
+                if (eqIndex > 0) {
+                    String name = trimmed.substring(0, eqIndex).trim();
+                    if (tokenCookieName.equals(name)) {
+                        String value = trimmed.substring(eqIndex + 1).trim();
+                        if (!value.isEmpty()) {
+                            LOGGER.debug("Bearer token extracted from cookie '%s'", tokenCookieName);
+                            return Optional.of(value);
+                        }
+                    }
+                }
+            }
+        }
+
+        LOGGER.debug("Cookie '%s' not found in cookie header", tokenCookieName);
+        return Optional.empty();
+    }
 
     /**
      * Produces the current request's BearerTokenResult as a CDI bean.

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/producer/BearerTokenProducer.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/java/de/cuioss/sheriff/oauth/quarkus/producer/BearerTokenProducer.java
@@ -21,7 +21,6 @@ import de.cuioss.sheriff.oauth.core.domain.token.AccessTokenContent;
 import de.cuioss.sheriff.oauth.core.exception.TokenValidationException;
 import de.cuioss.sheriff.oauth.quarkus.annotation.BearerToken;
 import de.cuioss.sheriff.oauth.quarkus.annotation.ServletObjectsResolver;
-import de.cuioss.sheriff.oauth.quarkus.config.JwtPropertyKeys;
 import de.cuioss.sheriff.oauth.quarkus.metrics.MetricIdentifier;
 import de.cuioss.sheriff.oauth.quarkus.servlet.HttpServletRequestResolver;
 import de.cuioss.tools.logging.CuiLogger;
@@ -117,14 +116,31 @@ public class BearerTokenProducer {
 
     private final TokenValidator tokenValidator;
     private final HttpServletRequestResolver servletObjectsResolver;
-    private final String tokenHeader;
-    private final String tokenCookieName;
+
+    @ConfigProperty(name = "sheriff.oauth.token.header", defaultValue = "Authorization")
+    String tokenHeader;
+
+    @ConfigProperty(name = "sheriff.oauth.token.cookie-name", defaultValue = "Bearer")
+    String tokenCookieName;
 
     @Inject
     public BearerTokenProducer(TokenValidator tokenValidator,
-            @ServletObjectsResolver(ServletObjectsResolver.Variant.VERTX) HttpServletRequestResolver servletObjectsResolver,
-            @ConfigProperty(name = JwtPropertyKeys.TOKEN.HEADER, defaultValue = HEADER_AUTHORIZATION) String tokenHeader,
-            @ConfigProperty(name = JwtPropertyKeys.TOKEN.COOKIE_NAME, defaultValue = DEFAULT_COOKIE_NAME) String tokenCookieName) {
+            @ServletObjectsResolver(ServletObjectsResolver.Variant.VERTX) HttpServletRequestResolver servletObjectsResolver) {
+        this.tokenValidator = tokenValidator;
+        this.servletObjectsResolver = servletObjectsResolver;
+    }
+
+    /**
+     * Constructor for unit testing that allows specifying token extraction configuration directly.
+     *
+     * @param tokenValidator          the token validator
+     * @param servletObjectsResolver  the servlet objects resolver
+     * @param tokenHeader             the header name to extract the token from
+     * @param tokenCookieName         the cookie name to extract the token from
+     */
+    BearerTokenProducer(TokenValidator tokenValidator,
+            HttpServletRequestResolver servletObjectsResolver,
+            String tokenHeader, String tokenCookieName) {
         this.tokenValidator = tokenValidator;
         this.servletObjectsResolver = servletObjectsResolver;
         this.tokenHeader = tokenHeader;

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/test/java/de/cuioss/sheriff/oauth/quarkus/producer/BearerTokenProducerTest.java
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/test/java/de/cuioss/sheriff/oauth/quarkus/producer/BearerTokenProducerTest.java
@@ -58,7 +58,7 @@ class BearerTokenProducerTest {
         tokenValidator = createMock(TokenValidator.class);
         servletResolverMock = new HttpServletRequestResolverMock();
         HttpServletRequestResolver servletResolver = servletResolverMock;
-        producer = new BearerTokenProducer(tokenValidator, servletResolver);
+        producer = new BearerTokenProducer(tokenValidator, servletResolver, "Authorization", "Bearer");
     }
 
     @Test
@@ -262,6 +262,85 @@ class BearerTokenProducerTest {
         assertEquals("Bearer token is empty", result.getErrorMessage().orElse(null));
         assertSingleLogMessagePresentContaining(TestLogLevel.DEBUG,
                 "Bearer token is empty - invalid request per RFC 6750");
+    }
+
+    // === Cookie-based token extraction tests ===
+
+    @Test
+    @DisplayName("Should extract token from cookie when token.header is Cookie")
+    void cookieExtraction() {
+        // Create a producer configured for cookie extraction
+        var cookieProducer = new BearerTokenProducer(tokenValidator, servletResolverMock, "Cookie", "Bearer");
+        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test.signature";
+        servletResolverMock.setHeader("Cookie", "Bearer=" + token + "; other=value");
+
+        AccessTokenContent tokenContent = createAccessToken(Map.of());
+        expect(tokenValidator.createAccessToken(anyObject(AccessTokenRequest.class))).andReturn(tokenContent);
+        replay(tokenValidator);
+
+        BearerTokenResult result = cookieProducer.getBearerTokenResult(Set.of(), Set.of(), Set.of());
+
+        assertEquals(BearerTokenStatus.FULLY_VERIFIED, result.getStatus());
+        assertTrue(result.getAccessTokenContent().isPresent());
+        verify(tokenValidator);
+    }
+
+    @Test
+    @DisplayName("Should extract token from custom cookie name")
+    void customCookieNameExtraction() {
+        var cookieProducer = new BearerTokenProducer(tokenValidator, servletResolverMock, "Cookie", "jwt_token");
+        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test.signature";
+        servletResolverMock.setHeader("Cookie", "other=foo; jwt_token=" + token);
+
+        AccessTokenContent tokenContent = createAccessToken(Map.of());
+        expect(tokenValidator.createAccessToken(anyObject(AccessTokenRequest.class))).andReturn(tokenContent);
+        replay(tokenValidator);
+
+        BearerTokenResult result = cookieProducer.getBearerTokenResult(Set.of(), Set.of(), Set.of());
+
+        assertEquals(BearerTokenStatus.FULLY_VERIFIED, result.getStatus());
+        assertTrue(result.getAccessTokenContent().isPresent());
+        verify(tokenValidator);
+    }
+
+    @Test
+    @DisplayName("Should return no token when cookie is not present")
+    void missingCookie() {
+        var cookieProducer = new BearerTokenProducer(tokenValidator, servletResolverMock, "Cookie", "Bearer");
+        // No cookie header set
+
+        BearerTokenResult result = cookieProducer.getBearerTokenResult(Set.of(), Set.of(), Set.of());
+
+        assertEquals(BearerTokenStatus.NO_TOKEN_GIVEN, result.getStatus());
+    }
+
+    @Test
+    @DisplayName("Should return no token when cookie header exists but target cookie is missing")
+    void cookieHeaderWithoutTargetCookie() {
+        var cookieProducer = new BearerTokenProducer(tokenValidator, servletResolverMock, "Cookie", "Bearer");
+        servletResolverMock.setHeader("Cookie", "other=somevalue; session=abc");
+
+        BearerTokenResult result = cookieProducer.getBearerTokenResult(Set.of(), Set.of(), Set.of());
+
+        assertEquals(BearerTokenStatus.NO_TOKEN_GIVEN, result.getStatus());
+    }
+
+    @Test
+    @DisplayName("Should prefer Authorization header even when cookie is also present and header is Authorization")
+    void authorizationHeaderPreferredOverCookie() {
+        // Default producer uses Authorization header
+        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test.signature";
+        servletResolverMock.setBearerToken(token);
+        servletResolverMock.setHeader("Cookie", "Bearer=other-token");
+
+        AccessTokenContent tokenContent = createAccessToken(Map.of());
+        expect(tokenValidator.createAccessToken(anyObject(AccessTokenRequest.class))).andReturn(tokenContent);
+        replay(tokenValidator);
+
+        BearerTokenResult result = producer.getBearerTokenResult(Set.of(), Set.of(), Set.of());
+
+        assertEquals(BearerTokenStatus.FULLY_VERIFIED, result.getStatus());
+        verify(tokenValidator);
     }
 
     /**


### PR DESCRIPTION
## Summary

Final phase of MP-JWT 2.1 compatibility (follows #341, #343). Completes all planned features.

### @RolesAllowed Support (JSR-250)
- `RolesAllowedFilter`: JAX-RS `ContainerRequestFilter` at `Priorities.AUTHORIZATION`
- Maps `@RolesAllowed` to `groups` claim per MP-JWT spec
- `@DenyAll` always returns 403, `@PermitAll` passes through
- Method-level annotations take precedence over class-level
- Returns 401 for missing token, 403 for insufficient groups

### Cookie-Based Token Extraction
- New config: `sheriff.oauth.token.header` (`Authorization` | `Cookie`)
- New config: `sheriff.oauth.token.cookie-name` (default: `Bearer`)
- `BearerTokenProducer` parses Cookie header when configured
- 5 unit tests covering default/custom names, missing cookies, precedence

### Integration Tests (MpJwtSpecIT)
- `@Inject JsonWebToken` principal name, groups, class type
- `@RolesAllowed("test-group")` — access granted with matching group
- `@RolesAllowed("admin")` — 403 when token lacks the group
- `@RolesAllowed` without token — 401
- `@DenyAll` with/without token — 403
- `@PermitAll` with/without token — passes

### Spec doc updated
All features moved from "Planned" to "Adopted/Implemented".

## Test plan

- [x] All unit tests pass (core + quarkus)
- [x] Full `mvnw clean install` across all modules
- [x] Pre-commit verification passes on quarkus module
- [x] 5 new cookie extraction unit tests
- [ ] Integration tests with Keycloak (CI)
- [ ] E2E tests (CI)
- [ ] Sonar quality gate (CI)