### PR TITLE
chore(ci): adopt gate-based push/PR dedup (cuioss-organization v0.6.7)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   auto-merge:
-    uses: cuioss/cuioss-organization/.github/workflows/reusable-dependabot-auto-merge.yml@14a19791f40f31521ba48fc84d699ef5e52ff7c1 # v0.6.6
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-dependabot-auto-merge.yml@a7368d92f50df26ff8e495b9bd8ecee4cf9a8471 # v0.6.7
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   dependency-review:
-    uses: cuioss/cuioss-organization/.github/workflows/reusable-dependency-review.yml@14a19791f40f31521ba48fc84d699ef5e52ff7c1 # v0.6.6
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-dependency-review.yml@a7368d92f50df26ff8e495b9bd8ecee4cf9a8471 # v0.6.7
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -3,7 +3,7 @@ name: End-to-End Tests
 
 on:
   push:
-    branches: [main, "feature/*", "fix/*", "chore/*", "dependabot/**"]
+    branches: [main]
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -13,9 +13,7 @@ permissions:
 
 jobs:
   e2e-tests:
-    # Run on push events, OR on pull_request only if from a fork
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-    uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-integration-tests.yml@14a19791f40f31521ba48fc84d699ef5e52ff7c1 # v0.6.6
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-integration-tests.yml@a7368d92f50df26ff8e495b9bd8ecee4cf9a8471 # v0.6.7
     with:
       report-name: e-2-e-playwright
       maven-args-input: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -4,7 +4,7 @@ name: Integration Tests
 
 on:
   push:
-    branches: [main, "feature/*", "fix/*", "chore/*", "dependabot/**"]
+    branches: [main]
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -15,10 +15,7 @@ permissions:
 jobs:
   integration-tests:
     # Multi-IDP tests (Keycloak + Dex + Zitadel) — superset that includes standard integration tests
-    # Run on push events, OR on pull_request only if from a fork
-    # This prevents duplicate runs: push handles internal branches, PR handles forks
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-    uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-integration-tests.yml@14a19791f40f31521ba48fc84d699ef5e52ff7c1 # v0.6.6
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-integration-tests.yml@a7368d92f50df26ff8e495b9bd8ecee4cf9a8471 # v0.6.7
     with:
       report-name: oauth-sheriff-multi-idp-tests
       maven-args-input: |

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,13 +11,11 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   build:
-    # Run on push events, OR on pull_request only if from a fork
-    # This prevents duplicate runs: push handles internal branches, PR handles forks
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-    uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-build.yml@14a19791f40f31521ba48fc84d699ef5e52ff7c1 # v0.6.6
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-build.yml@a7368d92f50df26ff8e495b9bd8ecee4cf9a8471 # v0.6.7
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       OSS_SONATYPE_USERNAME: ${{ secrets.OSS_SONATYPE_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       contents: write
     if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
-    uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-release.yml@14a19791f40f31521ba48fc84d699ef5e52ff7c1 # v0.6.6
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-release.yml@a7368d92f50df26ff8e495b9bd8ecee4cf9a8471 # v0.6.7
     secrets:
       RELEASE_APP_ID: ${{ secrets.RELEASE_APP_ID }}
       RELEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   analysis:
-    uses: cuioss/cuioss-organization/.github/workflows/reusable-scorecards.yml@14a19791f40f31521ba48fc84d699ef5e52ff7c1 # v0.6.6
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-scorecards.yml@a7368d92f50df26ff8e495b9bd8ecee4cf9a8471 # v0.6.7
     permissions:
       security-events: write
       id-token: write


### PR DESCRIPTION
Bumps cuioss-organization refs to v0.6.7. Maven build: drop the fork-only if: guard (reusable workflow gate handles dedup) + add pull-requests: read. Integration/E2E: deferred to push:[main]+pull_request. Supersedes the closed bot SHA-only PR.