### PR TITLE
docs: drop README mascot below the Status heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # OAuth-Sheriff
 
-<img align="right" width="300" src="doc/resources/Sheriff.png" alt="OAuth Sheriff">
-
 ## Status
+
+<img align="right" width="300" src="doc/resources/Sheriff.png" alt="OAuth Sheriff">
 
 **Build & Quality**
 


### PR DESCRIPTION
Move the floated `<img>` to after the `## Status` heading so the float starts
lower: the H1 title rule now passes above the mascot's head instead of through
it, while the image stays within the Status section.

Source-position is the reliable lever here — GitHub's HTML sanitizer strips
inline `style`/`vspace`, so a CSS margin would not survive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README layout by moving the Status section higher on the page.
  * Adjusted spacing around the top section for a cleaner presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->