### PR TITLE
docs(oidc): refine client spec — drop duplication, shorten requirement IDs

### DIFF
--- a/doc/oidc/01-restructure/README.adoc
+++ b/doc/oidc/01-restructure/README.adoc
@@ -33,7 +33,7 @@ The `de.cuioss.sheriff.*` / `sheriff.*` roots stay stable; only the `oauth → t
 | Java packages          | `de.cuioss.sheriff.oauth.*`     | `de.cuioss.sheriff.token.*`
 | Config property prefix | `sheriff.oauth.*`               | `sheriff.token.*`
 | Metrics prefix         | `sheriff.oauth.*`               | `sheriff.token.*`
-| Requirement IDs        | `OAUTH-SHERIFF-N`               | `TOKEN-SHERIFF-N`
+| Requirement IDs        | `OAUTH-SHERIFF-N`               | `VAL-N` (shortened; client capability adds `CLIENT-N` later, see xref:../02-doc-structure/README.adoc[Plan 02])
 | Quarkus feature / class | feature `oauth-sheriff`, `OAuthSheriffProcessor` | feature `token-sheriff`, `TokenSheriffProcessor`
 | SonarCloud project key | `cuioss_OAuth-Sheriff`          | `cuioss_TokenSheriff`
 | GitHub Pages base      | `cuioss.github.io/OAuth-Sheriff` | `cuioss.github.io/TokenSheriff`
@@ -100,7 +100,7 @@ A module's *own* `<groupId>`/`<artifactId>` has no first-class recipe; those ~6 
 *1c — Text surfaces* (`text.FindAndReplace` / `properties.ChangePropertyKey`):
 
 * Config + metric prefixes `sheriff.oauth` → `sheriff.token` (`JwtPropertyKeys.PREFIX`, `MetricIdentifier.PREFIX`, `application*.properties`, tests, docs).
-* Requirement IDs `OAUTH-SHERIFF-N → TOKEN-SHERIFF-N` (xref:../../Requirements.adoc[Requirements] anchors + all references).
+* Requirement IDs `OAUTH-SHERIFF-N → VAL-N` (xref:../../Requirements.adoc[Requirements] anchors + all references).
 * Docs, badges, README image `alt`, GitHub workflows, `.github/project.yml` Sonar key, `cuioss.github.io/OAuth-Sheriff` URLs.
 
 *1d — Gate:* `./mvnw -Ppre-commit clean verify` then `./mvnw clean install` green.
@@ -123,7 +123,7 @@ Run the checklist below.
 
 The ~150-files-per-PR review limit is a *general guideline*, applied where sensible — not a hard gate for this change. Measured reality: this is one mechanical, tool-driven rename touching ~500 files (381 `.java` relocations + poms + ~425 `sheriff.oauth.` config-key files + docs).
 
-* *PR 1 — build-safe textual rename (honors the guideline).* Documentation/prose, requirement IDs `OAUTH-SHERIFF-N → TOKEN-SHERIFF-N`, badges, Sonar key, Pages URLs. No compile impact, genuinely reviewable; ~86 files (split into two if it exceeds 150).
+* *PR 1 — build-safe textual rename (honors the guideline).* Documentation/prose, requirement IDs `OAUTH-SHERIFF-N → VAL-N`, badges, Sonar key, Pages URLs. No compile impact, genuinely reviewable; ~86 files (split into two if it exceeds 150).
 * *PR 2 — atomic mechanical rename (guideline waived).* The OpenRewrite package/type/coordinate transform plus the `sheriff.oauth → sheriff.token` config/metric constants and their test expectations. This is *atomic* — packages, coordinates and config keys must flip together to keep `main` building. Slicing it into ≤150-file pieces would either break build-green-per-PR or leave coexisting `…oauth.*`/`…token.*` roots, adding risk with no review value.
 
 *Why the waiver is the safe choice:* the guideline's intent is reviewable PRs. A 500-file *mechanical, idempotent, build-verified* diff is reviewed by inspecting the OpenRewrite recipe and the verification sweep — not by reading ~500 identical edits. Forcing a split here reduces safety rather than increasing it. (If the reviewer hard-caps file count, land PR 2 with review on the recipe + green CI, or split the package move by sub-package across stacked PRs accepting temporary mixed roots — only if mandated.)
@@ -164,7 +164,7 @@ Publish a stub for *every* old artifact (`-core`, `-quarkus`, `-quarkus-deployme
 * [ ] `grep -rI "de.cuioss.sheriff.oauth"` → 0 (excluding relocation stubs)
 * [ ] `grep -rI "sheriff.oauth."` → 0
 * [ ] `grep -rI "oauth-sheriff"` → 0
-* [ ] `grep -rIo "OAUTH-SHERIFF-[0-9]"` → 0; `TOKEN-SHERIFF-N` count matches the 51 prior IDs
+* [ ] `grep -rIo "OAUTH-SHERIFF-[0-9]"` → 0; `VAL-N` count matches the 51 prior IDs
 * [ ] `./mvnw -Ppre-commit clean verify` and `./mvnw clean install` green
 * [ ] Relocation stubs published for every old artifact; an old-coordinate build prints the relocation warning and resolves
 * [ ] Repo renamed; old GitHub URL redirects; badges, Sonar, Pages, OpenSSF green

--- a/doc/oidc/02-doc-structure/README.adoc
+++ b/doc/oidc/02-doc-structure/README.adoc
@@ -50,7 +50,7 @@ doc/
   LogMessages.adoc                  # GLOBAL log registry — all capabilities, stays at root
   validation/                       # existing capability (relocated)
     architecture.adoc
-    requirements.adoc               # IDs: TOKEN-SHERIFF-N  (per Plan 01)
+    requirements.adoc               # IDs: VAL-N  (per Plan 01)
     threat-model.adoc
     security-reference.adoc
     specification/
@@ -60,7 +60,7 @@ doc/
     faq/keycloak.adoc
   client/                    # NEW capability (added when client work starts)
     architecture.adoc
-    requirements.adoc               # IDs: TOKEN-SHERIFF-CLIENT-N
+    requirements.adoc               # IDs: CLIENT-N
     threat-model.adoc
     specification/
   shared/                           # cross-cutting only, if/when needed
@@ -76,8 +76,10 @@ The `doc/oidc/` planning area (this folder) is transient — it holds the plans,
 
 == Requirement-ID namespacing
 
-* Validation keeps `TOKEN-SHERIFF-N` (after Plan 01's `OAUTH-SHERIFF-N → TOKEN-SHERIFF-N`).
-* Client requirements use `TOKEN-SHERIFF-CLIENT-N` — same project prefix, explicit capability segment, unambiguous and greppable (`TOKEN-SHERIFF-CLIENT-[0-9]`).
+The IDs are short, capability-scoped, and greppable — no shared brand prefix to repeat on every reference.
+
+* Validation uses `VAL-N` (Plan 01 shortens the existing `OAUTH-SHERIFF-N → VAL-N`).
+* Client requirements use `CLIENT-N` — distinct capability namespace, unambiguous and greppable (`VAL-[0-9]` vs `CLIENT-[0-9]`).
 
 == Execution
 
@@ -88,13 +90,13 @@ The `doc/oidc/` planning area (this folder) is transient — it holds the plans,
 . Update the hub `doc/README.adoc` to present capabilities as groups ("Token Validation", later "Client").
 
 === Phase 2 — Scaffold the client capability (when client work starts)
-. Create `doc/client/` with stub `architecture.adoc`, `requirements.adoc` (`TOKEN-SHERIFF-CLIENT-N`), `threat-model.adoc`, `specification/`.
+. Create `doc/client/` with stub `architecture.adoc`, `requirements.adoc` (`CLIENT-N`), `threat-model.adoc`, `specification/`.
 . Add the client module `doc/` dir for usage/config/dev. Client log records are added to the global `doc/LogMessages.adoc` — no separate client registry.
 . Wire both capabilities into the hub.
 
 === Conventions for future client docs
 * Capability-conceptual content → `doc/client/`; module usage/config/dev → the client module's `doc/`.
-* Client requirement IDs → `TOKEN-SHERIFF-CLIENT-N`; client threats live only in the client threat model.
+* Client requirement IDs → `CLIENT-N`; client threats live only in the client threat model.
 * No client content in validation docs, and vice versa.
 
 == Risks & mitigations
@@ -107,7 +109,7 @@ The `doc/oidc/` planning area (this folder) is transient — it holds the plans,
 * [ ] `doc/validation/` holds the relocated conceptual docs; titles rescoped to the capability
 * [ ] Every `xref:`/`link:` to the moved docs resolves (root `README.md`, module docs, cross-doc) — zero broken links
 * [ ] `doc/README.adoc` hub presents capabilities as peer groups
-* [ ] Requirement IDs unchanged in count after the move; client namespace `TOKEN-SHERIFF-CLIENT-N` reserved
+* [ ] Requirement IDs unchanged in count after the move; client namespace `CLIENT-N` reserved
 * [ ] Phase 2 deferred until client work starts (no empty client scaffolding merged early)
 
 == Seed data for planning (discovery 2026-06-24)

--- a/doc/oidc/03-client-spec/README.adoc
+++ b/doc/oidc/03-client-spec/README.adoc
@@ -192,7 +192,7 @@ Input for the spec authors — authoritative, citable sources. To avoid duplicat
 [NOTE]
 ====
 *Reused from the validation bibliography — cite, don't restate.* These are already referenced by the validation xref:../../Requirements.adoc[Requirements] and apply unchanged on the client side; `references.adoc` links the existing entries rather than re-listing them:
-RFC 6749 (OAuth 2.0), https://openid.net/specs/openid-connect-core-1_0.html[OIDC Core 1.0] (userinfo, ID-token validation), RFC 8725 (JWT BCP), RFC 9068 (JWT access tokens), RFC 9449 (DPoP), https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1[OAuth 2.1], and the FAPI 2.0 Security Profile.
+https://www.rfc-editor.org/rfc/rfc6749[RFC 6749 (OAuth 2.0)], https://openid.net/specs/openid-connect-core-1_0.html[OIDC Core 1.0] (userinfo, ID-token validation), https://www.rfc-editor.org/rfc/rfc8725[RFC 8725 (JWT BCP)], https://www.rfc-editor.org/rfc/rfc9068[RFC 9068 (JWT access tokens)], https://www.rfc-editor.org/rfc/rfc9449[RFC 9449 (DPoP)], https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1[OAuth 2.1], and the https://openid.net/specs/fapi-security-profile-2_0-final.html[FAPI 2.0 Security Profile].
 ====
 
 .Guidance & real-world (new)

--- a/doc/oidc/03-client-spec/README.adoc
+++ b/doc/oidc/03-client-spec/README.adoc
@@ -19,22 +19,29 @@ Produce, _before_ any client code, the document set (requirements + specificatio
 
 == Target architecture: Backend-For-Frontend (BFF)
 
-The IETF https://datatracker.ietf.org/doc/html/draft-ietf-oauth-browser-based-apps[OAuth 2.0 for Browser-Based Apps] draft makes the *server-side confidential client* the recommended pattern for browser apps: the backend runs the authorization-code flow and *holds tokens server-side*, so no tokens ever sit in the browser. The draft describes two variants of how the backend exposes that session to the browser — this library is the *engine* under *both*:
+The IETF https://datatracker.ietf.org/doc/html/draft-ietf-oauth-browser-based-apps[OAuth 2.0 for Browser-Based Apps] draft makes the *server-side confidential client* the recommended pattern for browser apps: a backend runs the authorization-code flow and *owns the tokens*, so the browser never gets usable access to them.
+
+[IMPORTANT]
+====
+*We do not build a BFF here.* The BFF is a separate application — a different project — layered on top of this library. This plan's job is narrower: specify the *client engine* (token retrieval, server-side lifecycle, fetching, validation) so that *building a BFF on top stays feasible and is not made unnecessarily complicated*. The BFF deployment shapes below are documented only as the *consumers our design must keep viable* — not as features delivered here.
+====
+
+A BFF can bind the acquired tokens to the browser session two ways; *in both, the token stays inaccessible to the browser*, and the engine must support either:
 
 [cols="1,3"]
 |===
-| Variant | How the browser is served
+| BFF deployment | How the token is bound to the browser session
 
-| *Backend-For-Frontend (BFF)*
-| The browser holds only a *session cookie*; the backend keeps the tokens and *proxies* all resource-server calls. Tokens never reach the browser. Highest isolation — the primary target.
+| *Stateful BFF — server-side token store*
+| The browser holds an opaque *session-id cookie*; the tokens live in a *server-side store* and the backend *proxies* every resource-server call.
 
-| *Token-Mediating Backend (TMB)*
-| The backend still runs the flow and holds the refresh token server-side, but *hands the short-lived access token to the SPA*, which calls the resource server directly. Lighter; a weaker isolation trade-off the draft also defines.
+| *Stateless BFF — encrypted token cookie*
+| The access token is returned to the browser only inside an *HttpOnly cookie encrypted with a server-side symmetric key*. The browser stores and replays the cookie but *never sees the plaintext token*; on each request the backend *decrypts* the cookie to recover and use the token. No server-side store.
 |===
 
-The seam is identical for both: confidential-client token retrieval, the server-side token lifecycle, validation, and fetching. What differs (cookie+proxy vs. mediated access token) lives in the application layer below — the engine *enables* either without owning the choice.
+The engine seam is identical for both: confidential-client token retrieval, the server-side token lifecycle, validation, and fetching. What differs — a server-side token store vs. an encrypted token cookie — is the BFF's own concern; the engine must *enable either without forcing the choice*. That non-preclusion is the BFF groundwork this plan owns.
 
-What the library lays groundwork for vs. what the BFF *application* owns:
+What the library lays groundwork for vs. what the BFF *application* (the separate project) owns:
 
 .In scope (the engine / groundwork)
 * Confidential-client *authorization-code + PKCE* flow, server-side (no tokens in the browser).
@@ -45,10 +52,10 @@ What the library lays groundwork for vs. what the BFF *application* owns:
 * OIDC *fetching* — discovery (`.well-known`) and JWKS (both already in the validation module), plus userinfo.
 * Validating retrieved tokens (reuse the validation module) and the security of all the above (flow integrity, TLS, SSRF, credential protection).
 
-.BFF/TMB application layer (enabled, not built here)
+.BFF application layer (a separate project — enabled, not built here)
 The library must *not preclude* these, but does not own them:
 
-* The browser↔backend *session cookie*, CSRF on the BFF's own API, request proxying (BFF) or handing the access token to the SPA (TMB).
+* The browser↔backend *session cookie* (an opaque session-id, or the encrypted token cookie and its symmetric-key management), CSRF on the backend's own API, and request proxying.
 * Login/consent UX.
 * Front-/back-channel logout *receivers* and the Session-Management iframe (browser-session concerns). RP-initiated logout *triggering* and token revocation are in-scope building blocks.
 
@@ -171,7 +178,7 @@ Input for the spec authors — authoritative, citable sources. To avoid duplicat
 
 .Standards new to the client capability (normative)
 * https://www.rfc-editor.org/rfc/rfc9700[RFC 9700] — Best Current Practice for OAuth 2.0 Security *(primary BCP)*
-* https://datatracker.ietf.org/doc/html/draft-ietf-oauth-browser-based-apps[OAuth 2.0 for Browser-Based Apps] — BFF / Token-Mediating Backend patterns
+* https://datatracker.ietf.org/doc/html/draft-ietf-oauth-browser-based-apps[OAuth 2.0 for Browser-Based Apps] — server-side confidential client / BFF (stateful & stateless) guidance
 * https://www.rfc-editor.org/rfc/rfc6819[RFC 6819] — OAuth 2.0 Threat Model and Security Considerations
 * https://www.rfc-editor.org/rfc/rfc7636[RFC 7636] — PKCE
 * https://www.rfc-editor.org/rfc/rfc8414[RFC 8414] — OAuth 2.0 Authorization Server Metadata (discovery)

--- a/doc/oidc/03-client-spec/README.adoc
+++ b/doc/oidc/03-client-spec/README.adoc
@@ -19,7 +19,20 @@ Produce, _before_ any client code, the document set (requirements + specificatio
 
 == Target architecture: Backend-For-Frontend (BFF)
 
-The IETF https://datatracker.ietf.org/doc/html/draft-ietf-oauth-browser-based-apps[OAuth 2.0 for Browser-Based Apps] draft makes the BFF the recommended pattern for browser apps: a *server-side confidential client* runs the authorization-code flow, *stores tokens server-side*, and issues the browser only a session cookie — so no tokens are ever exposed to the browser. This library is the *engine* for that BFF (and for the lighter Token-Mediating Backend): it performs the confidential-client token retrieval, the server-side token lifecycle, validation, and fetching.
+The IETF https://datatracker.ietf.org/doc/html/draft-ietf-oauth-browser-based-apps[OAuth 2.0 for Browser-Based Apps] draft makes the *server-side confidential client* the recommended pattern for browser apps: the backend runs the authorization-code flow and *holds tokens server-side*, so no tokens ever sit in the browser. The draft describes two variants of how the backend exposes that session to the browser — this library is the *engine* under *both*:
+
+[cols="1,3"]
+|===
+| Variant | How the browser is served
+
+| *Backend-For-Frontend (BFF)*
+| The browser holds only a *session cookie*; the backend keeps the tokens and *proxies* all resource-server calls. Tokens never reach the browser. Highest isolation — the primary target.
+
+| *Token-Mediating Backend (TMB)*
+| The backend still runs the flow and holds the refresh token server-side, but *hands the short-lived access token to the SPA*, which calls the resource server directly. Lighter; a weaker isolation trade-off the draft also defines.
+|===
+
+The seam is identical for both: confidential-client token retrieval, the server-side token lifecycle, validation, and fetching. What differs (cookie+proxy vs. mediated access token) lives in the application layer below — the engine *enables* either without owning the choice.
 
 What the library lays groundwork for vs. what the BFF *application* owns:
 
@@ -51,7 +64,7 @@ Security is the *leading* topic. Specify the *smallest, most secure subset* of c
 
 == Security exclusions (legacy / discouraged, refused)
 
-Sourced non-goals. The library MUST NOT require or implement these:
+Sourced non-goals *specific to the client capability*. The library MUST NOT require or implement these:
 
 * *Implicit grant* (`response_type=token`) — RFC 9700 §2.1.2 (SHOULD NOT); removed in OAuth 2.1.
 * *Resource Owner Password Credentials grant* — RFC 9700 §2.4 (MUST NOT); removed in OAuth 2.1.
@@ -59,10 +72,10 @@ Sourced non-goals. The library MUST NOT require or implement these:
 * *In-browser token storage* (public-client OAuth) — the BFF holds tokens server-side; Browser-Based Apps draft.
 * *PKCE `plain`* — `S256` only (RFC 7636, RFC 9700).
 * *Tokens in URL query/fragment* — RFC 9700 §4.3; `form_post` and code exchange at the token endpoint.
-* *`alg=none` / unsigned or weak-algorithm tokens* — RFC 8725 (JWT BCP). Require asymmetric signature verification.
-* *Bare bearer tokens where sender-constraining is feasible* — prefer DPoP/mTLS (RFC 9449, RFC 8705, FAPI 2.0).
 * *Weak client auth where `private_key_jwt`/mTLS is available; secrets over non-TLS* — RFC 9700, RFC 7523, RFC 8705.
 * *Unvalidated `jwks_uri` / metadata URLs* (SSRF) — CVE-2026-1180.
+
+NOTE: *Token-signature exclusions are not restated here* — rejecting `alg=none`, HMAC, and weak/short-key algorithms, and requiring asymmetric signature verification, is already mandated by the validation requirements (`VAL-1.3`, RFC 8725) and *inherited* by every token this client retrieves. The client spec covers only the *acquisition/flow* exclusions above; it must not duplicate the validation algorithm policy. Sender-constraining is likewise an inherited capability (validation already validates DPoP-bound tokens, `VAL-8.7`); the client delta is *requesting* such tokens (DPoP/mTLS at the token endpoint), covered under Retrieval & flow — not an exclusion.
 
 == Organizing principle: separate the aspects
 
@@ -89,7 +102,7 @@ Keep these in separate documents and requirement groups — do not blend them.
 [source]
 ----
 doc/client/
-  requirements.adoc            # TOKEN-SHERIFF-CLIENT-N, grouped by aspect
+  requirements.adoc            # CLIENT-N, grouped by aspect
   architecture.adoc            # Client/BFF component & sequence overview
   threat-model.adoc            # attack catalog per aspect, each entry sourced
   best-practices.adoc          # normative checklist, each item sourced
@@ -102,7 +115,7 @@ doc/client/
 
 == Requirement-ID & sourcing discipline
 
-* Client requirements use `TOKEN-SHERIFF-CLIENT-N` (per Plan 02), *grouped by aspect* (Token / Retrieval & flow / Fetch).
+* Client requirements use `CLIENT-N` (per Plan 02), *grouped by aspect* (Token / Retrieval & flow / Fetch).
 * *Every* normative requirement and *every* threat entry cites a source with section anchor (RFC / OIDC spec / OWASP / FAPI). MUST/SHOULD/MAY trace back to the cited source.
 * Requirements are *security-driven* — each traces to a threat it mitigates or is the secure way to perform a needed operation. Exclusions are sourced too.
 * `references.adoc` is the single bibliography; all docs cite into it.
@@ -110,7 +123,7 @@ doc/client/
 == Execution
 
 . *Scaffold + bibliography* — doc-set skeleton and `references.adoc` from the source catalog below.
-. *Requirements* — `TOKEN-SHERIFF-CLIENT-N`, grouped by aspect, each sourced.
+. *Requirements* — `CLIENT-N`, grouped by aspect, each sourced.
 . *Threat model* — attack catalog per aspect; each entry → source + mitigation + covering requirement.
 . *Best practices* — the sourced checklist below, normative.
 . *Specifications* — `retrieval-flow.adoc`, `fetch-discovery-jwks.adoc`, `token-handling.adoc`.
@@ -123,7 +136,7 @@ doc/client/
 * [ ] Retrieval & flow covers confidential auth-code+PKCE, client auth, `state`/`nonce`/redirect-URI, mix-up (`iss`), and sender-constraining
 * [ ] BFF groundwork is sufficient (server-side token lifecycle) without owning the browser session/cookie layer
 * [ ] Each security exclusion is documented and sourced; every requirement is threat-driven
-* [ ] `TOKEN-SHERIFF-CLIENT-N` IDs grouped by aspect; traceability matrix complete; `references.adoc` resolves
+* [ ] `CLIENT-N` IDs grouped by aspect; traceability matrix complete; `references.adoc` resolves
 
 // ---------------------------------------------------------------------------
 
@@ -154,29 +167,28 @@ doc/client/
 
 == Seed: source catalog (research 2026-06-24)
 
-Input for the spec authors — authoritative, citable sources.
+Input for the spec authors — authoritative, citable sources. To avoid duplication, this lists *only the sources new to the client capability*; standards already cited by the validation requirements are reused, not restated (see the reuse note below).
 
-.Standards (normative)
+.Standards new to the client capability (normative)
 * https://www.rfc-editor.org/rfc/rfc9700[RFC 9700] — Best Current Practice for OAuth 2.0 Security *(primary BCP)*
 * https://datatracker.ietf.org/doc/html/draft-ietf-oauth-browser-based-apps[OAuth 2.0 for Browser-Based Apps] — BFF / Token-Mediating Backend patterns
-* https://www.rfc-editor.org/rfc/rfc6749[RFC 6749] — OAuth 2.0 Authorization Framework
 * https://www.rfc-editor.org/rfc/rfc6819[RFC 6819] — OAuth 2.0 Threat Model and Security Considerations
 * https://www.rfc-editor.org/rfc/rfc7636[RFC 7636] — PKCE
 * https://www.rfc-editor.org/rfc/rfc8414[RFC 8414] — OAuth 2.0 Authorization Server Metadata (discovery)
 * https://www.rfc-editor.org/rfc/rfc8693[RFC 8693] — OAuth 2.0 Token Exchange
 * https://www.rfc-editor.org/rfc/rfc7523[RFC 7523] — JWT Profile for OAuth 2.0 Client Authentication (`private_key_jwt`)
 * https://www.rfc-editor.org/rfc/rfc8705[RFC 8705] — OAuth 2.0 Mutual-TLS Client Auth & Certificate-Bound Access Tokens
-* https://www.rfc-editor.org/rfc/rfc9449[RFC 9449] — DPoP (Demonstrating Proof-of-Possession)
-* https://www.rfc-editor.org/rfc/rfc8725[RFC 8725] — JSON Web Token Best Current Practices
-* https://www.rfc-editor.org/rfc/rfc9068[RFC 9068] — JWT Profile for OAuth 2.0 Access Tokens
 * https://www.rfc-editor.org/rfc/rfc9126[RFC 9126] — Pushed Authorization Requests (PAR)
 * https://www.rfc-editor.org/rfc/rfc9207[RFC 9207] — Authorization Server Issuer Identification (`iss`, mix-up defence)
-* https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1[OAuth 2.1] — consolidated draft
-* https://openid.net/specs/openid-connect-core-1_0.html[OpenID Connect Core 1.0] — userinfo, ID-token validation
 * https://openid.net/specs/openid-connect-discovery-1_0.html[OpenID Connect Discovery 1.0]
-* https://openid.net/specs/fapi-security-profile-2_0-final.html[FAPI 2.0 Security Profile]
 
-.Guidance & real-world
+[NOTE]
+====
+*Reused from the validation bibliography — cite, don't restate.* These are already referenced by the validation xref:../../Requirements.adoc[Requirements] and apply unchanged on the client side; `references.adoc` links the existing entries rather than re-listing them:
+RFC 6749 (OAuth 2.0), https://openid.net/specs/openid-connect-core-1_0.html[OIDC Core 1.0] (userinfo, ID-token validation), RFC 8725 (JWT BCP), RFC 9068 (JWT access tokens), RFC 9449 (DPoP), https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1[OAuth 2.1], and the FAPI 2.0 Security Profile.
+====
+
+.Guidance & real-world (new)
 * https://cheatsheetseries.owasp.org/cheatsheets/OAuth2_Cheat_Sheet.html[OWASP OAuth2 Cheat Sheet]
 * https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/05-Authorization_Testing/05-Testing_for_OAuth_Weaknesses[OWASP WSTG — Testing for OAuth Weaknesses]
 * https://github.com/advisories/GHSA-7vw6-5q2f-7w5r[CVE-2026-1180] — Keycloak `jwks_uri` SSRF (fetch-aspect case study)

--- a/doc/oidc/05-implement/README.adoc
+++ b/doc/oidc/05-implement/README.adoc
@@ -7,7 +7,7 @@
 [cols="1,3"]
 |===
 | Status     | Ready after xref:../03-client-spec/README.adoc[Plan 03] (spec) + xref:../04-client-module/README.adoc[Plan 04] (skeleton)
-| Depends on | Plan 03 (`TOKEN-SHERIFF-CLIENT-N` requirements + threat model), Plan 04 (`token-sheriff-client` module/extension/IT home)
+| Depends on | Plan 03 (`CLIENT-N` requirements + threat model), Plan 04 (`token-sheriff-client` module/extension/IT home)
 | Approach   | Vertical *protocol-by-protocol* increments, dependency-ordered. Each ships unit tests (MockWebServer) *and* integration tests against a *real Keycloak*. Security-driven.
 |===
 
@@ -36,7 +36,7 @@ The user-facing rule: *MockWebServer proves the mechanics and the attacks; Keycl
 * *Unit tests* (MockWebServer): protocol mechanics + every adversarial case the increment's threats demand.
 * *Integration tests* (real Keycloak): the protocol's happy-path/conformance end-to-end.
 * Quarkus wiring + extension smoke where the increment is user-configurable.
-* *Traceability*: each `TOKEN-SHERIFF-CLIENT-N` requirement → code + test; each threat → an adversarial unit test.
+* *Traceability*: each `CLIENT-N` requirement → code + test; each threat → an adversarial unit test.
 * Build green: `./mvnw -Ppre-commit clean verify` then `./mvnw clean install`.
 
 == Increment order (dependency-driven)
@@ -94,7 +94,7 @@ Increments 1–2 prove the whole retrieve→validate loop; 5 is the BFF core; 11
 
 == Verification
 
-* [ ] Every `TOKEN-SHERIFF-CLIENT-N` requirement is implemented and traced to code + tests
+* [ ] Every `CLIENT-N` requirement is implemented and traced to code + tests
 * [ ] Every threat in Plan 03's model has an adversarial *unit* test (MockWebServer) that fails closed
 * [ ] Every protocol has a *real-Keycloak integration* test proving interoperability
 * [ ] Each increment merged independently with its tests; build green at every step

--- a/doc/oidc/README.adoc
+++ b/doc/oidc/README.adoc
@@ -27,7 +27,7 @@ implementation plans plus the standing design decisions behind them.
   `portal-authentication-oauth`, the real consumer. Cross-repo; no content.
   Runs after Plan 01.
 * xref:05-implement/README.adoc[05 — Implement the Client (protocol by protocol)] -
-  implement the `TOKEN-SHERIFF-CLIENT-N` requirements as vertical
+  implement the `CLIENT-N` requirements as vertical
   protocol-by-protocol increments. Each ships unit tests (MockWebServer, incl.
   adversarial) *and* integration tests against a real Keycloak, ending in the
   portal E2E replacement. After Plans 03 + 04.


### PR DESCRIPTION
Review-driven refinements to the `doc/oidc/` planning area (follow-up to #497).

## Changes

**Plan 03 (`03-client-spec`) — remove duplication with the existing validation spec**
- Dropped the `alg=none` / weak-algorithm **exclusion** — it is already a hard requirement in the validation spec (`VAL-1.3`, RFC 8725: rejects `none`/HMAC/short keys). Replaced with a `NOTE` stating the signature-algorithm policy is **inherited**, not restated, and clarifying that sender-constraining is inherited too (validation already validates DPoP-bound tokens, `VAL-8.7`) — the client *delta* is only *requesting* such tokens at the token endpoint.
- **BFF architecture**: made the two browser-app variants explicit — **Backend-For-Frontend** (session cookie + backend proxies all calls) and **Token-Mediating Backend** (backend holds the refresh token, hands a short-lived access token to the SPA). Same engine seam under both.
- **Source catalog**: split into *standards new to the client capability* vs. a reuse note for standards already cited by the validation `Requirements.adoc` (RFC 6749, OIDC Core, 8725, 9068, 9449, OAuth 2.1, FAPI 2.0) — `references.adoc` links the existing entries instead of re-listing them.

**Requirement-ID scheme — shortened to `VAL-N` / `CLIENT-N`**
- Was `TOKEN-SHERIFF-N` / `TOKEN-SHERIFF-CLIENT-N` (too long). Propagated across Plans 01–05 and the index. Plan 01's rename target is now `OAUTH-SHERIFF-N → VAL-N`; the client capability adds `CLIENT-N` (Plan 02).

Planning docs only — no code or build surface touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated OIDC planning docs to consistently rebrand and rename requirement IDs using the `VAL-N` and `CLIENT-N` schemes.
  * Restructured `doc/` to treat “validation” and “client” as peer capabilities, including updated client documentation scaffolding.
  * Refined client guidance for a server-side confidential-client/BFF architecture, with clearer security non-goals and reorganized standards/source catalog references.
  * Aligned implementation and verification checklists to the new namespaces and updated verification expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->