### PR TITLE
docs(oidc): add token-sheriff-commons base module + step-up, RP-logout, RFC 9457

### DIFF
--- a/doc/oidc/01-restructure/README.adoc
+++ b/doc/oidc/01-restructure/README.adoc
@@ -41,7 +41,7 @@ The `de.cuioss.sheriff.*` / `sheriff.*` roots stay stable; only the `oauth → t
 
 The mascot (`doc/resources/Sheriff.png`) and the "Sheriff" brand are unchanged — only the qualifier changes. There are no `module-info.java` files, so no JPMS module names to migrate.
 
-Modules are renamed with *capability* names (not `-core`): `oauth-sheriff-core → token-sheriff-validation` (package `…token.validation`), `oauth-sheriff-quarkus → token-sheriff-validation-quarkus` (and `-deployment`). Aggregator/test modules keep the neutral form: `oauth-sheriff-quarkus-parent → token-sheriff-quarkus-parent`, `…-integration-tests → token-sheriff-quarkus-integration-tests`. (The client modules are added later by xref:../04-client-module/README.adoc[Plan 04].)
+Modules are renamed with *capability* names (not `-core`): `oauth-sheriff-core → token-sheriff-validation` (package `…token.validation`), `oauth-sheriff-quarkus → token-sheriff-validation-quarkus` (and `-deployment`). Aggregator/test modules keep the neutral form: `oauth-sheriff-quarkus-parent → token-sheriff-quarkus-parent`, `…-integration-tests → token-sheriff-quarkus-integration-tests`. (This plan only *renames*; the wider three-module architecture is added later — the `token-sheriff-commons` base module (transport + error model + events + metrics) is extracted from validation by xref:../03-commons/README.adoc[Plan 03], and the client modules by xref:../05-client-module/README.adoc[Plan 05].)
 
 == Scope (regression baseline)
 

--- a/doc/oidc/02-doc-structure/README.adoc
+++ b/doc/oidc/02-doc-structure/README.adoc
@@ -52,6 +52,7 @@ doc/
     architecture.adoc
     requirements.adoc               # IDs: CMN-N (transport / error / events / metrics)
     threat-model.adoc               # SSRF / TLS / response-DoS / error-detail-leakage
+    references.adoc                 # bibliography / shared standards
     specification/
       transport.adoc                # discovery, JWKS, token/userinfo/…; TLS, SSRF
       error-model.adoc              # typed exceptions -> RFC 9457 at every HTTP edge

--- a/doc/oidc/02-doc-structure/README.adoc
+++ b/doc/oidc/02-doc-structure/README.adoc
@@ -1,4 +1,4 @@
-= Plan 02 — Documentation Structure for the Client Capability
+= Plan 02 — Documentation Structure for the Commons & Client Capabilities
 :toc: macro
 :toclevels: 3
 :sectnums:
@@ -8,14 +8,14 @@
 |===
 | Status     | Ready to execute (after xref:../01-restructure/README.adoc[Plan 01])
 | Depends on | Plan 01 — Restructure (rename); run after it to pay link churn once
-| Scope      | Reshape `doc/` so token validation and the coming OIDC client (RP) are peer capabilities
+| Scope      | Reshape `doc/` so validation, Commons and the coming OIDC client are peer capabilities, with a shared cross-cutting area
 |===
 
 toc::[]
 
 == Goal
 
-Decide how the documentation absorbs the second capability (the xref:../decision-oidc-module.adoc[OIDC client module]) and lay out the target structure so client docs have a clean home before client work starts.
+Decide how the documentation absorbs the two new capabilities from the xref:../decision-oidc-module.adoc[three-module architecture] — `commons` (transport, xref:../03-commons/README.adoc[Plan 03]) and `client` (xref:../04-client-spec/README.adoc[Plan 04]) — and lay out the target structure so their docs have a clean home before that work starts.
 
 == Analysis: current structure
 
@@ -31,15 +31,15 @@ Two facts decide the approach:
 
 == Decision: modularize by capability
 
-Reshape the conceptual layer into peer capabilities — `validation` and `client` — rather than extending the existing validation docs with client content.
+Reshape the conceptual layer into peer capabilities — `validation`, `commons`, and `client` — one per code module, rather than extending the existing validation docs with the new content.
 
 Why not extend:
 
-* `Requirements.adoc` (622) and `threat-model.adoc` (373) would balloon and *mix two very different surfaces*. The client's threats (redirect/callback CSRF, `state`/`nonce`, authorization-code interception, token leakage, session fixation) are unlike validation's — and a security library must keep a clean, per-capability threat model.
-* It mirrors the code boundary (validation module vs client module), keeping doc↔code traceability clean.
+* `Requirements.adoc` (622) and `threat-model.adoc` (373) would balloon and *mix very different surfaces*. The client's threats (redirect/callback CSRF, `state`/`nonce`, authorization-code interception, token leakage, session fixation) and commons's threats (SSRF, TLS downgrade, response DoS) are unlike validation's — and a security library must keep a clean, per-capability threat model.
+* It mirrors the code boundary (one doc capability per module — validation / commons / client), keeping doc↔code traceability clean.
 * It is consistent with the modularity already present (folders, per-module docs) — an increment, not a new paradigm.
 
-The already-modular parts stay as they are: module `doc/` dirs continue per-module (the client module gets its own), and `specification/` stays a folder (now per-capability). `LogMessages.adoc` stays a single *global* registry covering all capabilities — it is not split or duplicated per capability.
+The already-modular parts stay as they are: module `doc/` dirs continue per-module (each new module gets its own), and `specification/` stays a folder (now per-capability). `LogMessages.adoc` stays a single *global* registry covering all capabilities — it is not split or duplicated per capability. The cross-cutting *error model, events and metrics* are *owned by the `commons` capability* (the base module), not a separate bucket; a small `shared/` area holds only a cross-capability glossary.
 
 == Target structure
 
@@ -48,6 +48,14 @@ The already-modular parts stay as they are: module `doc/` dirs continue per-modu
 doc/
   README.adoc                       # hub — grouped by capability + shared
   LogMessages.adoc                  # GLOBAL log registry — all capabilities, stays at root
+  commons/                # NEW base capability (added with Plan 03)
+    architecture.adoc
+    requirements.adoc               # IDs: CMN-N (transport / error / events / metrics)
+    threat-model.adoc               # SSRF / TLS / response-DoS / error-detail-leakage
+    specification/
+      transport.adoc                # discovery, JWKS, token/userinfo/…; TLS, SSRF
+      error-model.adoc              # typed exceptions -> RFC 9457 at every HTTP edge
+      observability.adoc            # SecurityEventCounter events + metric identifiers
   validation/                       # existing capability (relocated)
     architecture.adoc
     requirements.adoc               # IDs: VAL-N  (per Plan 01)
@@ -63,15 +71,15 @@ doc/
     requirements.adoc               # IDs: CLIENT-N
     threat-model.adoc
     specification/
-  shared/                           # cross-cutting only, if/when needed
+  shared/                           # cross-capability glossary only
     glossary.adoc
 ----
 
-Module-level docs are unchanged in pattern: the client module (`token-sheriff-client`) gets its own `doc/` for usage/config/dev. Log records stay in the single global `doc/LogMessages.adoc` — not per module or per capability.
+Module-level docs are unchanged in pattern: each new module (`token-sheriff-commons`, `token-sheriff-client`) gets its own `doc/` for usage/config/dev. Log records stay in the single global `doc/LogMessages.adoc` — not per module or per capability.
 
 [NOTE]
 ====
-The `doc/oidc/` planning area (this folder) is transient — it holds the plans, not the capability docs. The client *capability* docs live under `doc/client/`. Once these plans execute, the planning area can be retired.
+The `doc/oidc/` planning area (this folder) is transient — it holds the plans, not the capability docs. The *capability* docs live under `doc/commons/`, `doc/client/`, etc. Once these plans execute, the planning area can be retired.
 ====
 
 == Requirement-ID namespacing
@@ -79,7 +87,17 @@ The `doc/oidc/` planning area (this folder) is transient — it holds the plans,
 The IDs are short, capability-scoped, and greppable — no shared brand prefix to repeat on every reference.
 
 * Validation uses `VAL-N` (Plan 01 shortens the existing `OAUTH-SHERIFF-N → VAL-N`).
-* Client requirements use `CLIENT-N` — distinct capability namespace, unambiguous and greppable (`VAL-[0-9]` vs `CLIENT-[0-9]`).
+* Commons uses `CMN-N`, grouped by concern — transport / error / events / metrics (xref:../03-commons/README.adoc[Plan 03]).
+* Client requirements use `CLIENT-N` — distinct capability namespace, unambiguous and greppable (`VAL-[0-9]` vs `CMN-[0-9]` vs `CLIENT-[0-9]`).
+
+== Cross-cutting realization: the RFC 9457 error model
+
+The error model is *owned by `commons`* (`doc/commons/specification/error-model.adoc`, `CMN-N`), but its *realization spans modules*, so it is called out here. The contract:
+
+* *Libraries throw typed exceptions* — `commons`, `validation`, the `client` engine — and MUST NOT produce HTTP problem documents. That is correct for a library.
+* *Every HTTP edge MUST emit `application/problem+json`* per https://www.rfc-editor.org/rfc/rfc9457[RFC 9457] — the Quarkus extensions (`token-sheriff-validation-quarkus`, `token-sheriff-client-quarkus`) *and* the `portal-authentication-oauth` RESTEasy adapter. The exception→problem mapping lives at each edge.
+* *Existing errors conform*: the current validation rejection responses retrofit to problem+json as part of this work.
+* *Inbound side*: `commons` normalizes IdP error responses (OAuth `error`/`error_description`, RFC 6749 §5.2) into the same typed model — one contract, both directions.
 
 == Execution
 

--- a/doc/oidc/02-doc-structure/README.adoc
+++ b/doc/oidc/02-doc-structure/README.adoc
@@ -157,7 +157,7 @@ External referencers (outside the moving set):
 * `benchmarking/README.adoc`, `benchmarking/doc/workflow.adoc`
 * `oauth-sheriff-core/doc/developing.adoc`
 * `oauth-sheriff-quarkus-parent/README.adoc` + `doc/README.adoc` + `oauth-sheriff-quarkus/README.adoc` + `oauth-sheriff-quarkus-deployment/README.adoc` + `oauth-sheriff-quarkus-integration-tests/README.adoc`
-* `doc/oidc/01-restructure/README.adoc` (this planning area references Requirements)
+* `doc/oidc/*` planning area — several plans link `xref:../../Requirements.adoc` (e.g. `01-restructure`, `04-client-spec`); rewrite these to `../../validation/requirements.adoc` *as part of this move* (they intentionally point at the current location until then). The planning area is transient and retired after execution.
 
 Intra-set (the moving docs cross-reference each other): `architecture.adoc`, `Requirements.adoc`, `security/*`, `specification/*`, `faq/keycloak.adoc`, and the hub `doc/README.adoc`. (`LogMessages.adoc` is *not* moving — exclude it.)
 

--- a/doc/oidc/03-commons/README.adoc
+++ b/doc/oidc/03-commons/README.adoc
@@ -1,0 +1,141 @@
+= Plan 03 — Commons: the Shared Base Module (transport, error model, events, metrics)
+:toc: macro
+:toclevels: 3
+:sectnums:
+:source-highlighter: highlight.js
+
+[cols="1,3"]
+|===
+| Status     | Ready to execute (spec after xref:../02-doc-structure/README.adoc[Plan 02]; code extraction after xref:../01-restructure/README.adoc[Plan 01])
+| Depends on | Plan 01 (rename → `token-sheriff-*`), Plan 02 (doc structure — establishes `doc/commons/`)
+| Focus      | Gather the *cross-cutting concerns every capability sits on* into one *base* module, `token-sheriff-commons`: *IdP transport* (discovery, JWKS, token, userinfo, revocation, end-session, PAR), the *error model* (typed exceptions → RFC 9457 at the edge), *security events*, and *metrics*. Spec-first plus the *code extraction* of these out of validation.
+| Outcome    | A standalone `token-sheriff-commons` artifact that `token-sheriff-validation` and (later) `token-sheriff-client` both depend on; its requirements/spec/threat-model under `doc/commons/`.
+|===
+
+toc::[]
+
+== Why a base module
+
+Several concerns are *base-layer*: validation and the coming client both consume them, none of them owns, and today they are split or duplicated:
+
+* *IdP transport* — OIDC discovery (`wellknown`) and JWKS (`jwks.http`) live in validation; the client will add token/userinfo/revocation/end-session/PAR. Same TLS/SSRF/resilience hardening, twice.
+* *Error model* — every capability throws errors; the HTTP edge must render them uniformly (RFC 9457). Today there is no shared contract.
+* *Security events* — `SecurityEventCounter` lives in validation; the client needs the same event surface.
+* *Metrics* — metric identifiers/contracts (`sheriff.token.*`) should be defined once and exported by each Quarkus extension.
+
+Pulling these into one base module gives a single place to specify, harden and reuse them — and a clean dependency layering. (Logging stays the *global* `doc/LogMessages.adoc` registry, not a commons concern; "reports" are out of scope for now.)
+
+== Decision: `commons` as the base module
+
+[source]
+----
+token-sheriff-commons         (base — transport + error model + events + metrics)
+  transport/   error/   events/   metrics/
+        ▲                ▲
+token-sheriff-validation      │   (validate tokens; uses commons transport + events + error model)
+        ▲                │
+token-sheriff-client ─────────┘   (run flows; uses commons + validation)
+----
+
+* `token-sheriff-commons` depends on `cui-http` only (no validation, no client). Package `de.cuioss.sheriff.token.commons`, sub-packages `transport`/`error`/`events`/`metrics`.
+* `token-sheriff-validation` → depends on `commons` (loses `jwks.http`, `wellknown`, `SecurityEventCounter`, metric identifiers).
+* `token-sheriff-client` → depends on `commons` (transport, events, error model) **and** `validation` (verify retrieved tokens).
+
+The dependency direction never reverses: the shared substrate is the foundation; validation and flows build on it.
+
+== The four concerns
+
+=== Transport
+All outbound IdP HTTP: discovery (`.well-known`, RFC 8414 / OIDC Discovery), JWKS (RFC 7517), token (RFC 6749), userinfo (OIDC Core), revocation (RFC 7009), introspection (RFC 7662), end-session (RP-Initiated Logout), PAR (RFC 9126). Owns *TLS* enforcement, *SSRF defence* (host allow-list, egress restriction, block internal/link-local), timeouts, response size limits, retry/backoff, the `cui-http` client, and JWKS/discovery caching. It moves bytes and hands back a typed result; it *never interprets a token's trust*.
+
+=== Error model (the exceptions-vs-RFC-9457 split)
+[cols="1,3"]
+|===
+| Layer | Behaviour
+
+| *Libraries* (`commons`, `validation`, `client` engine — pure Java)
+| Throw a *typed exception hierarchy* (defined in `commons.error`). They MUST NOT produce HTTP problem documents — that is not their layer.
+
+| *HTTP edges* (`token-sheriff-validation-quarkus`, `token-sheriff-client-quarkus`, **and the `portal-authentication-oauth` RESTEasy adapter**)
+| MUST map those exceptions to `application/problem+json` per https://www.rfc-editor.org/rfc/rfc9457[RFC 9457], without leaking internal detail. *Existing validation rejection responses retrofit to this.*
+|===
+
+`commons` also *normalizes inbound* IdP error responses (OAuth `error`/`error_description`, RFC 6749 §5.2) into the typed model the edges render — so the same contract covers both directions. This is the cross-cutting requirement called out earlier: *exceptions are correct for libraries; the RFC 9457 representation is mandatory at every HTTP edge, Quarkus or RESTEasy.*
+
+=== Security events
+`SecurityEventCounter` and the security-event types, *extracted from validation* into `commons.events` so validation and client share one event surface (and one place to add events for retrieval/flow threats). Quarkus extensions expose them as before.
+
+=== Metrics
+Metric *identifiers/contracts* (`sheriff.token.*`) defined once in `commons.metrics`; each Quarkus extension wires them to Micrometer. Keeps the metric namespace consistent across capabilities.
+
+== Code extraction (the refactor)
+
+This plan moves existing code, not only spec:
+
+* *Relocate* into `token-sheriff-commons`: `…token.validation.jwks.http` + `…token.validation.wellknown` → `commons.transport`; `SecurityEventCounter` + event types → `commons.events`; the metric identifiers → `commons.metrics`; introduce `commons.error`. (OpenRewrite `ChangePackage`/`MoveClass`, same tooling as Plan 01.)
+* *Re-point* `token-sheriff-validation` at `commons`; re-export or adapt any types that are part of validation's *public* API so the one known consumer (`nifi-extensions`) sees *no functional change* — only a possible transitive coordinate. Capture any consumer-visible move in xref:../01-restructure/migration-nifi-extensions.adoc[the migration guide].
+* *Quarkus*: validation's extension keeps wiring discovery/JWKS/events/metrics, now sourced from `commons`; add the RFC 9457 exception→problem+json mapping at each edge.
+
+[NOTE]
+====
+Prefer *re-exporting* a relocated type from validation over forcing a consumer change where the type is public API — decide per type during execution, and record any real break in the migration guide.
+====
+
+== Target document set (under `doc/commons/`)
+
+[source]
+----
+doc/commons/
+  requirements.adoc            # CMN-N, grouped by concern (transport / error / events / metrics)
+  architecture.adoc            # module + sequence; who depends on what
+  threat-model.adoc            # SSRF / TLS / response-DoS / error-detail-leakage — each sourced
+  specification/
+    transport.adoc             # discovery, JWKS, token/userinfo/…; TLS, SSRF, resilience
+    error-model.adoc           # typed exceptions → RFC 9457 at the edge (all HTTP surfaces)
+    observability.adoc         # SecurityEventCounter events + metric identifiers
+  references.adoc              # bibliography (new sources; reuse note for shared standards)
+----
+
+Requirement IDs use `CMN-N` (per xref:../02-doc-structure/README.adoc[Plan 02]), grouped by concern.
+
+== Seed: threat catalog (with source anchors)
+
+* *SSRF via `jwks_uri` / discovery / userinfo / any IdP URL* — OWASP, https://github.com/advisories/GHSA-7vw6-5q2f-7w5r[CVE-2026-1180] → host allow-listing, egress restriction, block internal/link-local ranges. **Audit the *existing* `wellknown`/`jwks` code being moved.**
+* *Malicious endpoints advertised via discovery* — RFC 8414 / OIDC Discovery → validate `issuer`, pin/validate metadata.
+* *TLS downgrade / MITM on any fetch* — RFC 9700, RFC 8414 → enforce TLS, validate certificates.
+* *DoS via large/slow metadata, JWKS, or userinfo responses* → timeouts, response size limits, bounded retries.
+* *Internal-detail leakage in error responses* — RFC 9457 → problem documents carry a safe `type`/`title`/`detail`; never stack traces or internal identifiers.
+
+== Seed: source catalog (research 2026-06-26)
+
+.Standards new to commons (normative)
+* https://www.rfc-editor.org/rfc/rfc9457[RFC 9457] — Problem Details for HTTP APIs *(error model)*
+* https://www.rfc-editor.org/rfc/rfc8414[RFC 8414] — OAuth 2.0 Authorization Server Metadata (discovery)
+* https://openid.net/specs/openid-connect-discovery-1_0.html[OpenID Connect Discovery 1.0]
+* https://www.rfc-editor.org/rfc/rfc7009[RFC 7009] — OAuth 2.0 Token Revocation
+* https://www.rfc-editor.org/rfc/rfc7662[RFC 7662] — OAuth 2.0 Token Introspection
+* https://www.rfc-editor.org/rfc/rfc9126[RFC 9126] — Pushed Authorization Requests (PAR)
+* https://openid.net/specs/openid-connect-rpinitiated-1_0.html[OpenID Connect RP-Initiated Logout 1.0] — `end_session_endpoint`
+
+[NOTE]
+====
+*Reused from the validation bibliography — cite, don't restate*: https://www.rfc-editor.org/rfc/rfc7517[RFC 7517 (JWK/JWKS)], https://www.rfc-editor.org/rfc/rfc6749[RFC 6749 (OAuth 2.0, incl. §5.2 error responses)], https://www.rfc-editor.org/rfc/rfc9700[RFC 9700 (Security BCP)].
+====
+
+== Execution
+
+. *Scaffold + bibliography* — `doc/commons/` skeleton and `references.adoc`.
+. *Requirements* — `CMN-N`, grouped by concern (transport / error / events / metrics), each sourced.
+. *Threat model* — the catalog above; each entry → source + mitigation + covering requirement.
+. *Specifications* — `transport.adoc`, `error-model.adoc`, `observability.adoc`.
+. *Code extraction* — relocate transport + events + metrics out of validation; introduce the error model; add the RFC 9457 mapping at each Quarkus/REST edge; re-point validation; build green.
+. *Traceability + verify* — requirements ↔ threats ↔ spec ↔ code; confirm the seam (no validation/flow logic in commons).
+
+== Verification
+
+* [ ] `token-sheriff-commons` exists, depends only on `cui-http`; `validation` and `client` depend on it
+* [ ] `wellknown` + `jwks.http` + `SecurityEventCounter` + metric identifiers relocated out of validation; no functional change for `nifi-extensions` (or the break is in the migration guide)
+* [ ] Libraries throw typed exceptions only; **every HTTP edge — validation-quarkus, client-quarkus, the portal RESTEasy adapter — emits `application/problem+json` (RFC 9457)**, existing validation errors included
+* [ ] Every `CMN-N` requirement and threat entry cites a source; SSRF/TLS/DoS covered for all relocated + new endpoints
+* [ ] No token-validation or flow/state logic in commons (seam holds)
+* [ ] `doc/commons/` requirements/spec/threat-model present; `references.adoc` resolves

--- a/doc/oidc/04-client-spec/README.adoc
+++ b/doc/oidc/04-client-spec/README.adoc
@@ -1,4 +1,4 @@
-= Plan 03 — Token Retrieval, OIDC Fetching & BFF Groundwork: Requirements, Specification & Security
+= Plan 04 — Token Retrieval, Flows & BFF Groundwork: Requirements, Specification & Security
 :toc: macro
 :toclevels: 3
 :sectnums:
@@ -7,15 +7,15 @@
 [cols="1,3"]
 |===
 | Status     | Ready to execute (after xref:../02-doc-structure/README.adoc[Plan 02] establishes `doc/client/`)
-| Depends on | Plan 02 (doc structure); produces the spec the future client module is built against (spec-first)
-| Focus      | Server-side *token retrieval* (token-endpoint grants incl. confidential authorization-code + PKCE), *OIDC fetching* (discovery, JWKS, userinfo), and the *token lifecycle* — the engine a *Backend-For-Frontend (BFF)* is built on. A *most-secure current subset*, security-led, every normative item source-referenced.
+| Depends on | Plan 02 (doc structure) and xref:../03-commons/README.adoc[Plan 03] (the Commons transport this builds on); produces the spec the future client module is built against (spec-first)
+| Focus      | Server-side *token retrieval* (token-endpoint grants incl. confidential authorization-code + PKCE), the *flow integrity* around it (`state`/`nonce`/PKCE, mix-up defence, step-up, RP-initiated logout), and the *token lifecycle* — the engine a *Backend-For-Frontend (BFF)* is built on. The *outbound IdP HTTP* it uses (discovery, JWKS, token, userinfo, …) belongs to xref:../03-commons/README.adoc[commons] and is referenced, not respecified. A *most-secure current subset*, security-led, every normative item source-referenced.
 |===
 
 toc::[]
 
 == Goal
 
-Produce, _before_ any client code, the document set (requirements + specification + security) for what this server-side library needs: *retrieving tokens* as a confidential client, *holding and refreshing them server-side*, and *fetching OIDC artifacts* (metadata, keys, userinfo) — designed so a BFF can be built on top. Security is the centre of gravity: a sourced threat model and a sourced best-practices catalog drawn from the standards below.
+Produce, _before_ any client code, the document set (requirements + specification + security) for what this server-side library needs: *retrieving tokens* as a confidential client, *holding and refreshing them server-side*, and driving the *flows* on top of the xref:../03-commons/README.adoc[commons] transport — designed so a BFF can be built on top. Security is the centre of gravity: a sourced threat model and a sourced best-practices catalog drawn from the standards below.
 
 == Target architecture: Backend-For-Frontend (BFF)
 
@@ -39,7 +39,7 @@ A BFF can bind the acquired tokens to the browser session two ways; *in both, th
 | The access token is returned to the browser only inside an *HttpOnly cookie encrypted with a server-side symmetric key*. The browser stores and replays the cookie but *never sees the plaintext token*; on each request the backend *decrypts* the cookie to recover and use the token. No server-side store.
 |===
 
-The engine seam is identical for both: confidential-client token retrieval, the server-side token lifecycle, validation, and fetching. What differs — a server-side token store vs. an encrypted token cookie — is the BFF's own concern; the engine must *enable either without forcing the choice*. That non-preclusion is the BFF groundwork this plan owns.
+The engine seam is identical for both: confidential-client token retrieval, the server-side token lifecycle, and validation, all over the xref:../03-commons/README.adoc[commons] transport. What differs — a server-side token store vs. an encrypted token cookie — is the BFF's own concern; the engine must *enable either without forcing the choice*. That non-preclusion is the BFF groundwork this plan owns.
 
 What the library lays groundwork for vs. what the BFF *application* (the separate project) owns:
 
@@ -48,16 +48,17 @@ What the library lays groundwork for vs. what the BFF *application* (the separat
 * Token-endpoint grants — `authorization_code`, `refresh_token`, `client_credentials`; token exchange (RFC 8693) candidate.
 * Token-endpoint *client authentication* — `client_secret_basic`/`post`, `private_key_jwt` (RFC 7523), mTLS (RFC 8705).
 * *Sender-constraining* of retrieved tokens — DPoP (RFC 9449) / mTLS (RFC 8705).
+* *Step-up authentication* — request `acr_values`/`max_age` and handle the `insufficient_user_authentication` challenge (RFC 9470).
+* *RP-initiated logout* — trigger the IdP `end_session_endpoint` with `id_token_hint`/`post_logout_redirect_uri`/`state` (OIDC RP-Initiated Logout) and revoke held tokens.
 * *Server-side token lifecycle* — storage, refresh, revocation.
-* OIDC *fetching* — discovery (`.well-known`) and JWKS (both already in the validation module), plus userinfo.
-* Validating retrieved tokens (reuse the validation module) and the security of all the above (flow integrity, TLS, SSRF, credential protection).
+* Validating retrieved tokens (reuse the validation module) and the flow security of all the above (flow integrity, credential protection). *All outbound IdP HTTP* (discovery, JWKS, token, userinfo, end-session, …) is performed by xref:../03-commons/README.adoc[commons] — referenced, not respecified here.
 
 .BFF application layer (a separate project — enabled, not built here)
 The library must *not preclude* these, but does not own them:
 
 * The browser↔backend *session cookie* (an opaque session-id, or the encrypted token cookie and its symmetric-key management), CSRF on the backend's own API, and request proxying.
 * Login/consent UX.
-* Front-/back-channel logout *receivers* and the Session-Management iframe (browser-session concerns). RP-initiated logout *triggering* and token revocation are in-scope building blocks.
+* Front-/back-channel logout *receivers* and the Session-Management iframe (browser-session concerns). RP-initiated logout *triggering* (above) and token revocation are the in-scope building blocks.
 
 Public-client / in-browser OAuth (tokens in the SPA) is explicitly *not* a goal — the BFF exists precisely to avoid it.
 
@@ -95,34 +96,33 @@ Keep these in separate documents and requirement groups — do not blend them.
 | *Token* (partly inherited)
 | Handling/validation and *server-side lifecycle* of retrieved tokens. *References the validation module* (no duplication) and adds the delta: storage, refresh, revocation, sender-constraining, and validation of ID token / userinfo responses.
 
-| *Retrieval & flow* (net-new)
-| The confidential-client *authorization-code + PKCE* flow (server-side) and the token endpoint: grants, client authentication, `state`/`nonce`/exact redirect-URI, mix-up defence (`iss`), code-injection defence, PAR, DPoP/mTLS, TLS, response validation.
-
-| *Fetch* (partly inherited)
-| Server-side retrieval/HTTP. *Already in the validation module* (reference, do not duplicate): discovery (`.well-known`, `validation.wellknown`), JWKS fetch/cache/rotation (`validation.jwks`), TLS, the HTTP client. *Net-new*: userinfo fetch. *SSRF/TLS/resilience* applies to *both* — including the existing discovery/JWKS paths.
+| *Retrieval & flow* (net-new — the focus of this plan)
+| The confidential-client *authorization-code + PKCE* flow (server-side) and the use of the token endpoint: grants, client authentication, `state`/`nonce`/exact redirect-URI, mix-up defence (`iss`), code-injection defence, PAR, DPoP/mTLS, step-up (RFC 9470), RP-initiated logout, response validation.
 |===
 
-*Retrieval & flow* is the only fully net-new aspect. *Token* and *fetch* reference the validation module and state only the delta. The SSRF/TLS analysis also re-examines the *existing* `validation.wellknown`/`validation.jwks` fetch code, which may yield hardening requirements on current code.
+*Transport is not an aspect here.* All outbound IdP HTTP — discovery, JWKS, token, userinfo, end-session, PAR — plus its TLS / SSRF / resilience hardening lives in xref:../03-commons/README.adoc[commons] (Plan 03). The client *uses* it and references its `CMN-N` requirements; it does not respecify fetching or restate SSRF/TLS. *Token* references the validation module for the delta only; *Retrieval & flow* is the genuinely net-new aspect this plan owns.
 
 == Target document set (under `doc/client/`)
 
 [source]
 ----
 doc/client/
-  requirements.adoc            # CLIENT-N, grouped by aspect
+  requirements.adoc            # CLIENT-N, grouped by aspect (Token / Retrieval & flow)
   architecture.adoc            # Client/BFF component & sequence overview
   threat-model.adoc            # attack catalog per aspect, each entry sourced
   best-practices.adoc          # normative checklist, each item sourced
   references.adoc              # the source catalog / bibliography
   specification/
     retrieval-flow.adoc        # auth-code+PKCE, grants, client auth, state/nonce, mix-up, PAR
-    fetch-discovery-jwks.adoc  # discovery, JWKS, userinfo fetch, SSRF, TLS
+    step-up-and-logout.adoc    # RFC 9470 step-up; RP-initiated logout
     token-handling.adoc        # token lifecycle delta (references the validation module)
 ----
 
+(Discovery/JWKS/userinfo transport specs live under `doc/commons/`, not here.)
+
 == Requirement-ID & sourcing discipline
 
-* Client requirements use `CLIENT-N` (per Plan 02), *grouped by aspect* (Token / Retrieval & flow / Fetch).
+* Client requirements use `CLIENT-N` (per Plan 02), *grouped by aspect* (Token / Retrieval & flow). Transport requirements are `CMN-N` (Plan 03) and are cited, not duplicated.
 * *Every* normative requirement and *every* threat entry cites a source with section anchor (RFC / OIDC spec / OWASP / FAPI). MUST/SHOULD/MAY trace back to the cited source.
 * Requirements are *security-driven* — each traces to a threat it mitigates or is the secure way to perform a needed operation. Exclusions are sourced too.
 * `references.adoc` is the single bibliography; all docs cite into it.
@@ -133,15 +133,16 @@ doc/client/
 . *Requirements* — `CLIENT-N`, grouped by aspect, each sourced.
 . *Threat model* — attack catalog per aspect; each entry → source + mitigation + covering requirement.
 . *Best practices* — the sourced checklist below, normative.
-. *Specifications* — `retrieval-flow.adoc`, `fetch-discovery-jwks.adoc`, `token-handling.adoc`.
+. *Specifications* — `retrieval-flow.adoc`, `step-up-and-logout.adoc`, `token-handling.adoc`.
 . *Traceability + verify* — cross-link requirements ↔ threats ↔ best practices ↔ spec; confirm aspect separation, BFF-groundwork coverage, and full sourcing.
 
 == Verification
 
 * [ ] Every requirement and threat entry cites a normative source with section anchor
-* [ ] Aspects cleanly separated; token & fetch reference (not duplicate) the validation module
-* [ ] Retrieval & flow covers confidential auth-code+PKCE, client auth, `state`/`nonce`/redirect-URI, mix-up (`iss`), and sender-constraining
+* [ ] Aspects cleanly separated; token references the validation module and transport references `commons` (`CMN-N`) — neither duplicated
+* [ ] Retrieval & flow covers confidential auth-code+PKCE, client auth, `state`/`nonce`/redirect-URI, mix-up (`iss`), sender-constraining, step-up (RFC 9470) and RP-initiated logout
 * [ ] BFF groundwork is sufficient (server-side token lifecycle) without owning the browser session/cookie layer
+* [ ] HTTP-surfaced client errors conform to the commons RFC 9457 error model (Plan 03) — the client engine throws typed exceptions; `client-quarkus` / the portal adapter emit problem+json
 * [ ] Each security exclusion is documented and sourced; every requirement is threat-driven
 * [ ] `CLIENT-N` IDs grouped by aspect; traceability matrix complete; `references.adoc` resolves
 
@@ -167,7 +168,7 @@ doc/client/
 * Offer *`private_key_jwt` / mTLS* client authentication (RFC 7523 / 8705) beyond `client_secret`.
 * Add *PAR* (RFC 9126) and *DPoP/mTLS sender-constraining* (RFC 9449 / 8705).
 * Strengthen *`nonce`* binding (currently light).
-* Replace bespoke RESTEasy fetching with the validation module's hardened HTTP + *SSRF* defences (fetch aspect).
+* Replace bespoke RESTEasy fetching with xref:../03-commons/README.adoc[commons]'s hardened HTTP + *SSRF* defences.
 
 === Relationship to the other consumer
 `nifi-extensions` consumes the *validation module*; `portal-authentication-oauth` is an *RP* that the Token-Sheriff client module *replaces* (engine swap + portal adapter). It is the concrete reference implementation for this plan's BFF-engine scope.
@@ -181,24 +182,22 @@ Input for the spec authors — authoritative, citable sources. To avoid duplicat
 * https://datatracker.ietf.org/doc/html/draft-ietf-oauth-browser-based-apps[OAuth 2.0 for Browser-Based Apps] — server-side confidential client / BFF (stateful & stateless) guidance
 * https://www.rfc-editor.org/rfc/rfc6819[RFC 6819] — OAuth 2.0 Threat Model and Security Considerations
 * https://www.rfc-editor.org/rfc/rfc7636[RFC 7636] — PKCE
-* https://www.rfc-editor.org/rfc/rfc8414[RFC 8414] — OAuth 2.0 Authorization Server Metadata (discovery)
 * https://www.rfc-editor.org/rfc/rfc8693[RFC 8693] — OAuth 2.0 Token Exchange
 * https://www.rfc-editor.org/rfc/rfc7523[RFC 7523] — JWT Profile for OAuth 2.0 Client Authentication (`private_key_jwt`)
 * https://www.rfc-editor.org/rfc/rfc8705[RFC 8705] — OAuth 2.0 Mutual-TLS Client Auth & Certificate-Bound Access Tokens
 * https://www.rfc-editor.org/rfc/rfc9126[RFC 9126] — Pushed Authorization Requests (PAR)
 * https://www.rfc-editor.org/rfc/rfc9207[RFC 9207] — Authorization Server Issuer Identification (`iss`, mix-up defence)
-* https://openid.net/specs/openid-connect-discovery-1_0.html[OpenID Connect Discovery 1.0]
+* https://www.rfc-editor.org/rfc/rfc9470[RFC 9470] — OAuth 2.0 Step-Up Authentication Challenge Protocol
+* https://openid.net/specs/openid-connect-rpinitiated-1_0.html[OpenID Connect RP-Initiated Logout 1.0]
 
 [NOTE]
 ====
-*Reused from the validation bibliography — cite, don't restate.* These are already referenced by the validation xref:../../Requirements.adoc[Requirements] and apply unchanged on the client side; `references.adoc` links the existing entries rather than re-listing them:
-https://www.rfc-editor.org/rfc/rfc6749[RFC 6749 (OAuth 2.0)], https://openid.net/specs/openid-connect-core-1_0.html[OIDC Core 1.0] (userinfo, ID-token validation), https://www.rfc-editor.org/rfc/rfc8725[RFC 8725 (JWT BCP)], https://www.rfc-editor.org/rfc/rfc9068[RFC 9068 (JWT access tokens)], https://www.rfc-editor.org/rfc/rfc9449[RFC 9449 (DPoP)], https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1[OAuth 2.1], and the https://openid.net/specs/fapi-security-profile-2_0-final.html[FAPI 2.0 Security Profile].
+*Reused — cite, don't restate.* Already referenced by the validation xref:../../Requirements.adoc[Requirements] (and apply unchanged here): https://www.rfc-editor.org/rfc/rfc6749[RFC 6749 (OAuth 2.0)], https://openid.net/specs/openid-connect-core-1_0.html[OIDC Core 1.0] (userinfo, ID-token validation), https://www.rfc-editor.org/rfc/rfc8725[RFC 8725 (JWT BCP)], https://www.rfc-editor.org/rfc/rfc9068[RFC 9068 (JWT access tokens)], https://www.rfc-editor.org/rfc/rfc9449[RFC 9449 (DPoP)], https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1[OAuth 2.1], https://openid.net/specs/fapi-security-profile-2_0-final.html[FAPI 2.0]. Owned by `commons` (xref:../03-commons/README.adoc[Plan 03]): the *outbound transport* standards (RFC 8414 discovery, OIDC Discovery, RFC 7009/7662, SSRF case study CVE-2026-1180) *and* the *RFC 9457 error model* — the client engine throws typed exceptions; its Quarkus/RESTEasy edges emit problem+json.
 ====
 
 .Guidance & real-world (new)
 * https://cheatsheetseries.owasp.org/cheatsheets/OAuth2_Cheat_Sheet.html[OWASP OAuth2 Cheat Sheet]
 * https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/05-Authorization_Testing/05-Testing_for_OAuth_Weaknesses[OWASP WSTG — Testing for OAuth Weaknesses]
-* https://github.com/advisories/GHSA-7vw6-5q2f-7w5r[CVE-2026-1180] — Keycloak `jwks_uri` SSRF (fetch-aspect case study)
 
 == Seed: threat catalog by aspect (with source anchors)
 
@@ -212,7 +211,9 @@ Minimum coverage for `threat-model.adoc`. Each → mitigation + covering require
 * CSRF on the callback — RFC 9700 §4.7 → session-bound `state` or PKCE or `nonce`
 * Weak/leaked client credentials — RFC 9700, RFC 7523, RFC 8705 → `private_key_jwt`/mTLS; protect secrets; TLS only
 * Token replay / lack of sender-constraining — RFC 9700 §4.10, RFC 9449, RFC 8705, FAPI 2.0 → DPoP or mTLS-bound tokens
-* Token-endpoint TLS downgrade / MITM — RFC 9700, RFC 6749 §10 → enforce TLS, validate certificates
+* Insufficient authentication assurance for a sensitive operation — RFC 9470 → honour `insufficient_user_authentication`, re-drive with `acr_values`/`max_age`, verify resulting `acr`/`auth_time`
+* Logout that leaves tokens live / open-redirect on `post_logout_redirect_uri` — OIDC RP-Initiated Logout → send `id_token_hint`, exact-match the registered `post_logout_redirect_uri`, bind `state`, revoke held tokens
+* Token-endpoint TLS downgrade / MITM — *covered by* xref:../03-commons/README.adoc[commons] (transport TLS); the flow relies on it
 
 .Token aspect
 * Refresh-token theft (server-side) — RFC 9700 §4.14 → rotation, revoke on misuse, sender-constraining; protect at-rest storage
@@ -220,16 +221,12 @@ Minimum coverage for `threat-model.adoc`. Each → mitigation + covering require
 * ID-token / userinfo integrity — OIDC Core §3.1.3.7, §5.3 → signature + claim validation; bind userinfo `sub`
 * Sender-constraint loss in storage/forwarding — RFC 9449, RFC 8705 → keep tokens bound; minimal storage
 
-.Fetch aspect
-* SSRF via `jwks_uri` / discovery / userinfo URLs — OWASP, CVE-2026-1180 → host allow-listing, egress restriction, block internal/link-local ranges. *Audit the existing `validation.wellknown`/`validation.jwks` code, not only new endpoints.*
-* Malicious endpoints advertised via discovery — RFC 8414 / OIDC Discovery → validate `issuer`, pin/validate metadata
-* TLS downgrade / MITM on fetches — RFC 9700, RFC 8414 → enforce TLS, validate certificates
-* DoS via large/slow metadata, JWKS or userinfo responses → timeouts, size limits
+NOTE: *Transport threats — SSRF, TLS downgrade, response DoS on discovery/JWKS/token/userinfo — live in xref:../03-commons/README.adoc[commons]'s threat model (`CMN-N`), not here.* The flow inherits them; it does not restate them.
 
 == Seed: best-practices checklist by aspect (sourced)
 
 Normative basis for `best-practices.adoc`.
 
-* *Retrieval & flow:* confidential-client authorization-code + PKCE (`S256`); never implicit/hybrid (RFC 9700 §2.1.2, Browser-Based Apps draft). Exact redirect-URI match (§4.1). CSRF via session-bound `state` / PKCE / `nonce` (§4.7). Mix-up defence via `iss` (RFC 9207, §4.4). Prefer PAR (RFC 9126, FAPI 2.0). Strongest available client auth — `private_key_jwt` (RFC 7523) or mTLS (RFC 8705) over `client_secret`. Sender-constrain tokens with DPoP/mTLS (RFC 9449, RFC 8705, FAPI 2.0). TLS on the token endpoint; validate `iss`/`aud` of the response.
+* *Retrieval & flow:* confidential-client authorization-code + PKCE (`S256`); never implicit/hybrid (RFC 9700 §2.1.2, Browser-Based Apps draft). Exact redirect-URI match (§4.1). CSRF via session-bound `state` / PKCE / `nonce` (§4.7). Mix-up defence via `iss` (RFC 9207, §4.4). Prefer PAR (RFC 9126, FAPI 2.0). Strongest available client auth — `private_key_jwt` (RFC 7523) or mTLS (RFC 8705) over `client_secret`. Sender-constrain tokens with DPoP/mTLS (RFC 9449, RFC 8705, FAPI 2.0). Step-up via `acr_values`/`max_age` and honour the `insufficient_user_authentication` challenge (RFC 9470). RP-initiated logout with `id_token_hint`, exact-matched `post_logout_redirect_uri`, bound `state`, plus token revocation (OIDC RP-Initiated Logout). Validate `iss`/`aud` of the token response.
 * *Token:* validate every retrieved token via the validation pipeline — `iss`/`aud`/`exp`/`iat`/signature (RFC 9068, OIDC Core §3.1.3.7); for userinfo, verify signature and bind `sub`. Hold tokens server-side; rotate refresh tokens and revoke on misuse (§4.14); protect at-rest; keep sender-constraint intact; short-lived access tokens.
-* *Fetch:* enforce TLS on all fetches. Defend against SSRF on `jwks_uri`/discovery/userinfo — allow-list hosts, restrict egress, block internal ranges (OWASP, CVE-2026-1180). Timeouts and response size limits. Reuse the validation module's JWKS cache/rotation.
+* *Transport:* enforced TLS, SSRF defence, timeouts/size-limits, JWKS cache/rotation — *owned by xref:../03-commons/README.adoc[commons]*; the client uses it and adds none of its own HTTP.

--- a/doc/oidc/05-client-module/README.adoc
+++ b/doc/oidc/05-client-module/README.adoc
@@ -1,4 +1,4 @@
-= Plan 04 — Add the Client Module, Extension, Assembly & IT (wired, empty)
+= Plan 05 — Add the Client Module, Extension, Assembly & IT (wired, empty)
 :toc: macro
 :toclevels: 3
 :sectnums:
@@ -7,7 +7,7 @@
 [cols="1,3"]
 |===
 | Status     | Ready to execute (after xref:../01-restructure/README.adoc[Plan 01])
-| Depends on | Plan 01 (rename → `token-sheriff-*`). Independent of Plan 03 (structure, not content).
+| Depends on | Plan 01 (rename → `token-sheriff-*`) + Plan 03 (the `token-sheriff-commons` base module it builds on). Independent of Plan 04 (structure, not content).
 | Outcome    | Everything in place — *module, extension, assembly* (in this repo) and the *integration-test home* (in `cui-portal-core`) — fully wired, building green, with *no functional content yet*.
 | Cross-repo | Yes — `module`/`extension`/`assembly` land in OAuthSheriff (→ Token-Sheriff); `it` lands in `cui-portal-core` `portal-authentication-oauth`.
 |===
@@ -16,13 +16,13 @@ toc::[]
 
 == Goal
 
-Stand up the complete skeleton the client work will fill: the engine module, a Quarkus extension for it, the build assembly (BOM + reactor), and the integration-test home in the real consumer. After Plan 04 a developer only adds content (per xref:../03-client-spec/README.adoc[Plan 03]); no structural work remains.
+Stand up the complete skeleton the client work will fill: the engine module, a Quarkus extension for it, the build assembly (BOM + reactor), and the integration-test home in the real consumer. After Plan 05 a developer only adds content (per xref:../04-client-spec/README.adoc[Plan 04]); no structural work remains.
 
 == Decision: standalone engine, dedicated Quarkus extension, ITs in the consumer
 
-. *Engine — standalone, modelled on `token-sheriff-validation`.* Pure Java, HTTP via `cui-http`, depends on `token-sheriff-validation`. *Not* inside the Quarkus extension.
+. *Engine — standalone, modelled on `token-sheriff-validation`.* Pure Java, depends on `token-sheriff-commons` (transport, error model, events, metrics) and `token-sheriff-validation` (verify retrieved tokens). *Not* inside the Quarkus extension.
 +
-Why: the replacement target `portal-authentication-oauth` is *CDI / RESTEasy / portal, not Quarkus* — the engine must be framework-agnostic. It mirrors the proven `validation` + `quarkus` split; the validation module is already pure Java + `cui-http` (the client's HTTP foundation). Opt-in stays clean.
+Why: the replacement target `portal-authentication-oauth` is *CDI / RESTEasy / portal, not Quarkus* — the engine must be framework-agnostic. It mirrors the proven `validation` + `quarkus` split; the transport foundation is `commons` (which wraps `cui-http`), so the client adds flows, not HTTP. Opt-in stays clean.
 
 . *Quarkus — a new extension that depends on the existing one.* `token-sheriff-client-quarkus` (runtime + deployment), depending on the existing `token-sheriff-validation-quarkus` extension *and* the engine. A separate extension (not folded in) preserves opt-in and reuses the existing validation CDI wiring. Verified by the build assembly.
 
@@ -34,11 +34,11 @@ The portal adapter (preserving `Oauth2Service` / `AuthenticatedUserInfo`) and th
 
 [cols="1,1,3"]
 |===
-| Piece | Repo | What lands in Plan 04 (no functional content)
+| Piece | Repo | What lands in Plan 05 (no functional content)
 
 | *module*
 | OAuthSheriff
-| `token-sheriff-client` — top-level, validation-like. `package-info.java` in `de.cuioss.sheriff.token.client`; deps `token-sheriff-validation` + `cui-http`.
+| `token-sheriff-client` — top-level, validation-like. `package-info.java` in `de.cuioss.sheriff.token.client`; deps `token-sheriff-commons` + `token-sheriff-validation`.
 
 | *extension*
 | OAuthSheriff
@@ -53,12 +53,13 @@ The portal adapter (preserving `Oauth2Service` / `AuthenticatedUserInfo`) and th
 | In `portal-authentication-oauth`: a *test dependency* on `token-sheriff-client` and an *own-package* client integration-test scaffold (separated from the existing OAuth tests), reusing the module's OIDC test setup. Scaffold only — real tests arrive with the replacement.
 |===
 
-== Target module tree (post Plan 04)
+== Target module tree (post Plan 05)
 
 [source]
 ----
 # OAuthSheriff (→ Token-Sheriff)
-token-sheriff-client/                          # NEW engine (top-level, validation-like, cui-http)
+token-sheriff-commons/                      # base module: transport + error + events + metrics (Plan 03; extracted from validation)
+token-sheriff-client/                          # NEW engine (top-level, validation-like) -> deps: commons + validation
 token-sheriff-quarkus-parent/
   token-sheriff-validation-quarkus/                   # existing runtime
   token-sheriff-validation-quarkus-deployment/        # existing deployment
@@ -77,7 +78,7 @@ modules/authentication/portal-authentication-oauth/
 
 [cols="1,2"]
 |===
-| Engine         | `de.cuioss.sheriff.token:token-sheriff-client`, package `de.cuioss.sheriff.token.client`, deps `token-sheriff-validation` + `cui-http`
+| Engine         | `de.cuioss.sheriff.token:token-sheriff-client`, package `de.cuioss.sheriff.token.client`, deps `token-sheriff-commons` + `token-sheriff-validation`
 | Client runtime     | `de.cuioss.sheriff.token:token-sheriff-client-quarkus`, package `…token.client.quarkus`, deps `token-sheriff-validation-quarkus` + `token-sheriff-client`
 | Client deployment  | `de.cuioss.sheriff.token:token-sheriff-client-quarkus-deployment`, deps `token-sheriff-validation-quarkus-deployment` + the Client runtime
 | Quarkus feature| `token-sheriff-client`

--- a/doc/oidc/06-implement/README.adoc
+++ b/doc/oidc/06-implement/README.adoc
@@ -1,4 +1,4 @@
-= Plan 05 — Implement the Client (protocol by protocol)
+= Plan 06 — Implement the Client (protocol by protocol)
 :toc: macro
 :toclevels: 3
 :sectnums:
@@ -6,8 +6,8 @@
 
 [cols="1,3"]
 |===
-| Status     | Ready after xref:../03-client-spec/README.adoc[Plan 03] (spec) + xref:../04-client-module/README.adoc[Plan 04] (skeleton)
-| Depends on | Plan 03 (`CLIENT-N` requirements + threat model), Plan 04 (`token-sheriff-client` module/extension/IT home)
+| Status     | Ready after xref:../04-client-spec/README.adoc[Plan 04] (spec) + xref:../05-client-module/README.adoc[Plan 05] (skeleton)
+| Depends on | Plan 03 (`token-sheriff-commons` extracted + `CMN-N` spec), Plan 04 (`CLIENT-N` requirements + threat model), Plan 05 (`token-sheriff-client` module/extension/IT home)
 | Approach   | Vertical *protocol-by-protocol* increments, dependency-ordered. Each ships unit tests (MockWebServer) *and* integration tests against a *real Keycloak*. Security-driven.
 |===
 
@@ -18,7 +18,7 @@ toc::[]
 Implement one *protocol/flow at a time* as a vertical slice — production code + unit tests + integration tests — not horizontally by layer. Why:
 
 * Each protocol (grant, flow, endpoint) is a coherent unit that can be verified *end-to-end against a real OP*.
-* Plan 03's threat model maps to *adversarial unit tests* (only a controllable mock can produce malicious responses).
+* Plan 04's threat model maps to *adversarial unit tests* (only a controllable mock can produce malicious responses).
 * You ship working, tested capability incrementally — no big-bang.
 
 == Testing model: MockWebServer (unit) + real Keycloak (integration)
@@ -26,13 +26,13 @@ Implement one *protocol/flow at a time* as a vertical slice — production code 
 Two distinct layers — do not conflate them:
 
 * *Unit tests* — in `token-sheriff-client` `src/test`, using *MockWebServer* to simulate the OP (discovery/JWKS/token/userinfo). Vital, but *unit*: this is where the *adversarial* coverage lives — malicious metadata, SSRF, wrong `iss`, code injection, PKCE downgrade, tampered/replayed tokens — because only a controllable mock can emit those. Use the CUI MockWebServer standards (`@ModuleDispatcher`, HTTPS/TLS, generator-driven *attack-database*).
-* *Integration tests* — Failsafe `*IT` against a *real Keycloak* (testcontainers / the existing Keycloak harness), verifying each protocol *actually interoperates* with a real OP end-to-end. Primary home: the replacement consumer `portal-authentication-oauth` (Plan 04). Protocols the portal login flow cannot exercise on their own (`client_credentials`, DPoP, token exchange) get a Keycloak-backed `*IT` harness in the Token-Sheriff repo.
+* *Integration tests* — Failsafe `*IT` against a *real Keycloak* (testcontainers / the existing Keycloak harness), verifying each protocol *actually interoperates* with a real OP end-to-end. Primary home: the replacement consumer `portal-authentication-oauth` (Plan 05). Protocols the portal login flow cannot exercise on their own (`client_credentials`, DPoP, token exchange) get a Keycloak-backed `*IT` harness in the Token-Sheriff repo.
 
 The user-facing rule: *MockWebServer proves the mechanics and the attacks; Keycloak proves it really works.* Both are required per increment.
 
 == Per-increment definition of done
 
-* Production code in `token-sheriff-client`, reusing `cui-http` and the validation pipeline.
+* Production code in `token-sheriff-client`, reusing the `commons` transport and the validation pipeline.
 * *Unit tests* (MockWebServer): protocol mechanics + every adversarial case the increment's threats demand.
 * *Integration tests* (real Keycloak): the protocol's happy-path/conformance end-to-end.
 * Quarkus wiring + extension smoke where the increment is user-configurable.
@@ -45,7 +45,7 @@ The user-facing rule: *MockWebServer proves the mechanics and the attacks; Keycl
 |===
 | # | Protocol / capability | Unit (MockWebServer — incl. adversarial) | Integration (real Keycloak)
 
-| 1 | *Client config + discovery* — config (issuer, client id, auth method, scopes), resolve endpoints via the validation module's discovery; TLS + SSRF guard
+| 1 | *Client config + discovery* — config (issuer, client id, auth method, scopes), resolve endpoints via `commons` discovery; TLS + SSRF guard (provided by `commons`)
 | Altered metadata; SSRF to internal/link-local; non-TLS rejected
 | Discovery against Keycloak's `.well-known`
 
@@ -61,9 +61,9 @@ The user-facing rule: *MockWebServer proves the mechanics and the attacks; Keycl
 | Rotation reuse-detection; expired
 | Refresh cycle against Keycloak
 
-| 5 | *`authorization_code` + PKCE (S256)* — BFF flow: `state`/`nonce`/exact redirect-URI, code exchange, ID-token validation
-| Code injection; PKCE downgrade; `state`/`nonce` mismatch; wrong `iss`
-| Full login + code exchange via Keycloak
+| 5 | *`authorization_code` + PKCE (S256)* — BFF flow: `state`/`nonce`/exact redirect-URI, code exchange, ID-token validation; *step-up* (`acr_values`/`max_age` + `insufficient_user_authentication` challenge, RFC 9470)
+| Code injection; PKCE downgrade; `state`/`nonce` mismatch; wrong `iss`; step-up challenge ignored/forged
+| Full login + code exchange via Keycloak; step-up re-auth
 
 | 6 | *Mix-up defence (`iss`, RFC 9207) + PAR (RFC 9126)*
 | `iss` mismatch rejected
@@ -77,11 +77,11 @@ The user-facing rule: *MockWebServer proves the mechanics and the attacks; Keycl
 | Proof replay / `jti` reuse rejected
 | DPoP-bound token against Keycloak
 
-| 9 | *Token lifecycle* — server-side storage, refresh scheduling, revocation
-| Lifecycle transitions; storage isolation
-| Revocation against Keycloak
+| 9 | *Token lifecycle + RP-initiated logout* — server-side storage, refresh scheduling, revocation; `end_session_endpoint` trigger (`id_token_hint`/`post_logout_redirect_uri`/`state`)
+| Lifecycle transitions; storage isolation; logout open-redirect / stale-token
+| Revocation + RP-initiated logout against Keycloak
 
-| 10 | *Hardening sweep* — audit existing `validation.wellknown`/`validation.jwks` for SSRF/TLS; close threat-model gaps
+| 10 | *Hardening sweep* — audit the `commons` transport (incl. the relocated `wellknown`/`jwks`) for SSRF/TLS; close `CMN-N` + `CLIENT-N` threat-model gaps
 | Full attack-database across all fetch/retrieval paths
 | —
 
@@ -95,8 +95,8 @@ Increments 1–2 prove the whole retrieve→validate loop; 5 is the BFF core; 11
 == Verification
 
 * [ ] Every `CLIENT-N` requirement is implemented and traced to code + tests
-* [ ] Every threat in Plan 03's model has an adversarial *unit* test (MockWebServer) that fails closed
+* [ ] Every threat in Plan 04's model has an adversarial *unit* test (MockWebServer) that fails closed
 * [ ] Every protocol has a *real-Keycloak integration* test proving interoperability
 * [ ] Each increment merged independently with its tests; build green at every step
-* [ ] No legacy/discouraged mechanism implemented (Plan 03 exclusions hold)
+* [ ] No legacy/discouraged mechanism implemented (Plan 04 exclusions hold)
 * [ ] E2E: `portal-authentication-oauth` passes against Keycloak using `token-sheriff-client`

--- a/doc/oidc/06-implement/README.adoc
+++ b/doc/oidc/06-implement/README.adoc
@@ -63,7 +63,7 @@ The user-facing rule: *MockWebServer proves the mechanics and the attacks; Keycl
 
 | 5 | *`authorization_code` + PKCE (S256)* — BFF flow: `state`/`nonce`/exact redirect-URI, code exchange, ID-token validation; *step-up* (`acr_values`/`max_age` + `insufficient_user_authentication` challenge, RFC 9470)
 | Code injection; PKCE downgrade; `state`/`nonce` mismatch; wrong `iss`; step-up challenge ignored/forged
-| Full login + code exchange via Keycloak; step-up re-auth
+| Full login + code exchange via Keycloak; assert `insufficient_user_authentication`, retry with `acr_values` / `max_age`, and verify resulting `acr` / `auth_time`
 
 | 6 | *Mix-up defence (`iss`, RFC 9207) + PAR (RFC 9126)*
 | `iss` mismatch rejected
@@ -78,10 +78,10 @@ The user-facing rule: *MockWebServer proves the mechanics and the attacks; Keycl
 | DPoP-bound token against Keycloak
 
 | 9 | *Token lifecycle + RP-initiated logout* — server-side storage, refresh scheduling, revocation; `end_session_endpoint` trigger (`id_token_hint`/`post_logout_redirect_uri`/`state`)
-| Lifecycle transitions; storage isolation; logout open-redirect / stale-token
-| Revocation + RP-initiated logout against Keycloak
+| Lifecycle transitions; storage isolation; logout open-redirect via unmatched `post_logout_redirect_uri`, missing `id_token_hint`/`state`, stale token after logout (must be revoked)
+| Revocation + RP-initiated logout against Keycloak (`id_token_hint`, exact-matched `post_logout_redirect_uri`, `state`)
 
-| 10 | *Hardening sweep* — audit the `commons` transport (incl. the relocated `wellknown`/`jwks`) for SSRF/TLS; close `CMN-N` + `CLIENT-N` threat-model gaps
+| 10 | *Hardening sweep* — verify the `commons` transport (incl. the relocated `wellknown`/`jwks`) is in use; close remaining `CLIENT-N` threat-model gaps (transport hardening itself is owned by `CMN-N`, Plan 03)
 | Full attack-database across all fetch/retrieval paths
 | —
 

--- a/doc/oidc/README.adoc
+++ b/doc/oidc/README.adoc
@@ -12,31 +12,39 @@ implementation plans plus the standing design decisions behind them.
   migration. Includes the
   xref:01-restructure/migration-nifi-extensions.adoc[nifi-extensions migration guide].
 * xref:02-doc-structure/README.adoc[02 — Documentation Structure] -
-  modularize `doc/` into peer capabilities (validation, client) so the
-  coming client docs have a clean home; runs after Plan 01.
-* xref:03-client-spec/README.adoc[03 — Client Requirements, Specification & Security] -
+  modularize `doc/` into one-per-module peer capabilities (commons, validation,
+  client) plus a small shared glossary; runs after Plan 01.
+* xref:03-commons/README.adoc[03 — Commons: the Shared Base Module] -
+  gather the base-layer cross-cutting concerns into a `token-sheriff-commons`
+  module: IdP transport (discovery, JWKS, token, userinfo, revocation,
+  end-session, PAR) + the error model (typed exceptions → RFC 9457 at the edge)
+  + security events + metrics. Spec (`CMN-N`) plus the code extraction of these
+  out of validation. Layering `commons ← validation ← client`.
+* xref:04-client-spec/README.adoc[04 — Client Requirements, Specification & Security] -
   produce the full client document set (requirements, specification,
-  threat model, best practices) — modular by aspect (token / retrieval / fetch),
-  every normative item source-referenced; spec-first, before client code. Engine
-  for a Backend-For-Frontend; replacement target `portal-authentication-oauth`.
-* xref:04-client-module/README.adoc[04 — Add the Client Module, Extension, Assembly & IT (wired, empty)] -
+  threat model, best practices) — modular by aspect (token / retrieval & flow),
+  incl. step-up (RFC 9470) and RP-initiated logout; transport referenced from
+  commons, not respecified. Spec-first; engine for a Backend-For-Frontend;
+  replacement target `portal-authentication-oauth`.
+* xref:05-client-module/README.adoc[05 — Add the Client Module, Extension, Assembly & IT (wired, empty)] -
   stand up the full skeleton: standalone validation-like engine `token-sheriff-client`
-  (pure Java, `cui-http`), a dedicated `token-sheriff-client-quarkus` extension
-  depending on the existing one, and BOM/reactor assembly — plus the client
-  integration-test home (own package) in `cui-portal-core`
-  `portal-authentication-oauth`, the real consumer. Cross-repo; no content.
-  Runs after Plan 01.
-* xref:05-implement/README.adoc[05 — Implement the Client (protocol by protocol)] -
+  (pure Java, deps `token-sheriff-commons` + `token-sheriff-validation`), a dedicated
+  `token-sheriff-client-quarkus` extension depending on the existing one, and
+  BOM/reactor assembly — plus the client integration-test home (own package) in
+  `cui-portal-core` `portal-authentication-oauth`, the real consumer. Cross-repo;
+  no content. Runs after Plans 01 + 03.
+* xref:06-implement/README.adoc[06 — Implement the Client (protocol by protocol)] -
   implement the `CLIENT-N` requirements as vertical
   protocol-by-protocol increments. Each ships unit tests (MockWebServer, incl.
   adversarial) *and* integration tests against a real Keycloak, ending in the
-  portal E2E replacement. After Plans 03 + 04.
+  portal E2E replacement. After Plans 03 + 04 + 05.
 
 == Design decisions
 
-* xref:decision-oidc-module.adoc[OIDC Client as an Additional Module] -
-  house the active OIDC client functionality as a new module in this repository,
-  depending on the validation module. Basis for a later plan.
+* xref:decision-oidc-module.adoc[Module Architecture — commons, validation, client] -
+  keep everything in this repository (no separate project) split into three layered
+  modules: `commons` (transport + error model + events + metrics) ← `validation` ←
+  `client`. Basis for Plans 03–05.
 
 == Status
 

--- a/doc/oidc/decision-oidc-module.adoc
+++ b/doc/oidc/decision-oidc-module.adoc
@@ -1,4 +1,4 @@
-= Design Decision: OIDC Client as an Additional Module
+= Design Decision: Module Architecture — commons, validation, client
 :toc: macro
 :toclevels: 3
 :sectnums:
@@ -7,10 +7,10 @@
 [cols="1,3"]
 |===
 | Status    | Accepted
-| Date      | 2026-06-24
-| Decides   | Where the planned OIDC client (relying-party) functionality lives
+| Date      | 2026-06-24 (revised 2026-06-26: three-module layering)
+| Decides   | How the OIDC capabilities are split into Maven modules in this repository, and that they are *not* a separate Git project
 | Supersedes| —
-| Related   | xref:01-restructure/README.adoc[Plan 01 — Restructure], xref:04-client-module/README.adoc[Plan 04 — Add the Client Module], xref:../../README.md[Project README]
+| Related   | xref:01-restructure/README.adoc[Plan 01 — Restructure], xref:03-commons/README.adoc[Plan 03 — Commons], xref:05-client-module/README.adoc[Plan 05 — Add the Client Module], xref:../../README.md[Project README]
 |===
 
 toc::[]
@@ -22,27 +22,45 @@ The library is, today, a *passive multi-issuer JWT validation library*. It delib
 A survey of the validation module confirms it already covers the *validation-side* of OpenID Connect:
 
 * OIDC Discovery — a dedicated `wellknown` package (`HttpWellKnownResolver`, `WellKnownConfig`, `WellKnownConfigurationConverter`)
+* JWKS retrieval — a `jwks.http` package (fetch, cache, rotation)
 * ID token validation — `IdTokenValidationPipeline`, `IdTokenContent`, `IdTokenRequest`
 * No userinfo endpoint, authorization-code/PKCE flow, token-endpoint exchange, session, or logout (0 references in the validation module)
 
-The goal is to add the *active* OIDC capabilities — the client (relying-party) side: authorization-code / PKCE flows, token-endpoint exchange, the userinfo endpoint, and `nonce`/`state` handling. (The exact secure subset — and what stays out, e.g. browser sessions and front-/back-channel logout receivers — is scoped in xref:03-client-spec/README.adoc[Plan 03].)
+Two distinct additions are in view:
 
-The question is **where** that code lives: a separate Git project (the original "OIDC-Sheriff" idea) or a new module inside this repository.
+. The *active* OIDC capabilities — the client (relying-party) side: authorization-code / PKCE flows, token-endpoint exchange, userinfo, `nonce`/`state`. (Secure subset scoped in xref:04-client-spec/README.adoc[Plan 04].)
+. A realization that a whole *class of base-layer concerns* belongs to neither validation nor client but to *both*: the outbound IdP HTTP (discovery + JWKS today, token/userinfo/… tomorrow), the *error model* (typed exceptions → RFC 9457 at the HTTP edge), *security events* (`SecurityEventCounter`), and *metrics*. Today these sit in validation; they should be a shared base so the client reuses them rather than duplicating them.
+
+The question is **where** this code lives: a separate Git project (the original "OIDC-Sheriff" idea) or modules inside this repository — and how many modules.
 
 == Decision
 
-Add a **`token-sheriff-client` Maven module to this multi-module repository**, publishing its own artifact and depending on `token-sheriff-validation`. Do **not** create a separate Git project at this time.
+Keep everything in **this multi-module repository** (no separate Git project) and split into **three layered Maven modules**, each its own artifact:
 
-The seam between the two is *not* "OAuth vs OIDC" (the validation module already does OIDC discovery and ID tokens). The real seam is:
+[source]
+----
+token-sheriff-commons      (base — transport + error model + events + metrics)
+        ▲                ▲
+token-sheriff-validation      │   (validate tokens; uses commons transport + events + error model)
+        ▲                ▲
+token-sheriff-client ─────────┘   (run flows; uses commons + validation)
+----
 
-* **Passive validation + issuer discovery → stays in the validation module** (`token-sheriff-validation`)
-* **Active client / token acquisition → the new module**
+* **`token-sheriff-commons`** — the shared base: *transport* (discovery, JWKS, token, userinfo, revocation, introspection, end-session, PAR; TLS, SSRF defence, resilience, IdP-error normalization), the *error model* (typed exceptions the HTTP edges map to RFC 9457), *security events*, and *metrics*. Depends on `cui-http` only. *Today's `wellknown` + `jwks.http` + `SecurityEventCounter` + metric identifiers are extracted from validation into it* (xref:03-commons/README.adoc[Plan 03]).
+* **`token-sheriff-validation`** — token validation (signatures, claims, pipeline). Depends on `commons`.
+* **`token-sheriff-client`** — flows / token acquisition / lifecycle. Depends on `commons` + `validation`.
+
+The seams are *not* "OAuth vs OIDC" (validation already does OIDC discovery and ID tokens). They are:
+
+* **Shared base — transport, error model, events, metrics → `commons`** (hardened substrate; never interprets trust)
+* **Passive validation of tokens → `validation`**
+* **Active acquisition / flows → `client`**
 
 == Rationale
 
 The stated goal of separation — "users choose the dependency that matches their requirements" — is satisfied by a separate *artifact*. It does **not** require a separate *repository*. A second repo only buys a repo boundary; it costs a version-compatibility matrix, two release trains, duplicated CI/SonarCloud/release/BOM infrastructure, and cross-repo pull requests every time the seam shifts.
 
-The dependency direction (`token-sheriff-client` → `token-sheriff-validation`) is the natural, clean layering: the client builds on validation, never the reverse.
+The dependency direction is the natural, clean layering — `client → validation → commons`, transport at the base — and never reverses. A consumer that needs only validation (e.g. `nifi-extensions`) still pulls just `validation` (+ its `commons` transitive); a consumer that needs acquisition adds `client`.
 
 The validation module's public API is still pre-1.0 (Maven Central `v0.8.x`) and actively evolving (a recent 1.0 cleanup renamed `well_known → wellknown`, etc.). The client layer will exercise validation-module APIs in ways that are hard to predict; that co-evolution is *trivial in one repo* and *painful across two*.
 
@@ -75,13 +93,14 @@ Until one of these bites, the module is strictly better.
 
 == Resolved by later plans
 
-* *Module/artifact name* — `token-sheriff-client` (engine), `token-sheriff-client-quarkus` (extension). See xref:04-client-module/README.adoc[Plan 04].
-* *Quarkus integration* — a dedicated `token-sheriff-client-quarkus` extension depending on the existing one (not folded in). See xref:04-client-module/README.adoc[Plan 04].
-* *API surface / first flows* — secure-subset scope and the protocol-by-protocol order (`client_credentials` first, then auth-code + PKCE) are in xref:03-client-spec/README.adoc[Plan 03] and xref:05-implement/README.adoc[Plan 05].
+* *Commons extraction* — the `token-sheriff-commons` base module, the relocation of `wellknown`/`jwks.http` + `SecurityEventCounter` + metric identifiers out of validation, the error model, and its requirements/spec/threat-model under `doc/commons/`. See xref:03-commons/README.adoc[Plan 03].
+* *Module/artifact name* — `token-sheriff-client` (engine), `token-sheriff-client-quarkus` (extension). See xref:05-client-module/README.adoc[Plan 05].
+* *Quarkus integration* — a dedicated `token-sheriff-client-quarkus` extension depending on the existing one (not folded in). See xref:05-client-module/README.adoc[Plan 05].
+* *API surface / first flows* — secure-subset scope and the protocol-by-protocol order (`client_credentials` first, then auth-code + PKCE) are in xref:04-client-spec/README.adoc[Plan 04] and xref:06-implement/README.adoc[Plan 06].
 
 == Still open
 
-* Session/state storage abstraction and its dependency footprint (addressed in the Plan 05 token-lifecycle increment).
+* Session/state storage abstraction and its dependency footprint (addressed in the Plan 06 token-lifecycle increment).
 
 == Alternatives considered
 


### PR DESCRIPTION
Follow-up to #505. Introduces a third, base-layer module and three cross-cutting requirements across the `doc/oidc/` planning area.

## Three-module architecture

`token-sheriff-commons` (base) ← `token-sheriff-validation` ← `token-sheriff-client`

A new **`token-sheriff-commons`** base module gathers the concerns every capability sits on (sub-packages `transport/ error/ events/ metrics/`):

- **Transport** — all outbound IdP HTTP (discovery, JWKS, token, userinfo, revocation, end-session, PAR) + TLS / SSRF / resilience. Extracts today's `wellknown` + `jwks.http` out of validation.
- **Error model** — libraries throw a typed exception hierarchy and never emit HTTP problem docs; **every HTTP edge** (`validation-quarkus`, `client-quarkus`, **and the `portal-authentication-oauth` RESTEasy adapter**) maps them to `application/problem+json` per **RFC 9457**; existing validation errors retrofit. commons also normalizes inbound IdP errors into the same model.
- **Security events** — `SecurityEventCounter` extracted from validation.
- **Metrics** — identifiers defined once; each Quarkus extension wires Micrometer.

## Three new requirements (client spec)

- **RFC 9457** error model (owned by commons, realized at every edge)
- **Step-up authentication** (RFC 9470) — `acr_values`/`max_age` + `insufficient_user_authentication` challenge
- **RP-initiated logout** — `end_session_endpoint` with `id_token_hint`/`post_logout_redirect_uri`/`state`

## Structure

- New **Plan 03 — Commons**; renumber client-spec→04, client-module→05, implement→06.
- Requirement IDs `VAL-N` / `CMN-N` / `CLIENT-N`.
- Client spec hands its "fetch" aspect to commons (references it, no longer respecifies transport).
- Decision doc broadened to the three-module architecture; Plan 02 relocates the error model into the commons capability.

Planning docs only — no code or build surface touched. All xrefs verified to resolve.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the OIDC documentation plan into a three-layer structure: **commons**, **validation**, and **client**, adding a dedicated **commons** plan for transport, typed error handling, security events, and metrics.
  * Clarified **RFC 9457** rules for exception-to-problem mapping at HTTP edges, and how inbound IdP errors are normalized into the shared typed model.
  * Updated client planning for confidential token retrieval, step-up authentication, and **RP-initiated logout**, including revised verification and threat guidance.
  * Refreshed module naming and plan structure to reflect the new capability-oriented layering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->