### PR TITLE
docs(oidc): full-word requirement IDs; scope portal out of plans; test dispatchers

### DIFF
--- a/doc/oidc/01-restructure/README.adoc
+++ b/doc/oidc/01-restructure/README.adoc
@@ -33,7 +33,7 @@ The `de.cuioss.sheriff.*` / `sheriff.*` roots stay stable; only the `oauth → t
 | Java packages          | `de.cuioss.sheriff.oauth.*`     | `de.cuioss.sheriff.token.*`
 | Config property prefix | `sheriff.oauth.*`               | `sheriff.token.*`
 | Metrics prefix         | `sheriff.oauth.*`               | `sheriff.token.*`
-| Requirement IDs        | `OAUTH-SHERIFF-N`               | `VAL-N` (shortened; client capability adds `CLIENT-N` later, see xref:../02-doc-structure/README.adoc[Plan 02])
+| Requirement IDs        | `OAUTH-SHERIFF-N`               | `VALIDATION-N` (capability-scoped; commons + client add `COMMONS-N` / `CLIENT-N` later, see xref:../02-doc-structure/README.adoc[Plan 02])
 | Quarkus feature / class | feature `oauth-sheriff`, `OAuthSheriffProcessor` | feature `token-sheriff`, `TokenSheriffProcessor`
 | SonarCloud project key | `cuioss_OAuth-Sheriff`          | `cuioss_TokenSheriff`
 | GitHub Pages base      | `cuioss.github.io/OAuth-Sheriff` | `cuioss.github.io/TokenSheriff`
@@ -100,7 +100,7 @@ A module's *own* `<groupId>`/`<artifactId>` has no first-class recipe; those ~6 
 *1c — Text surfaces* (`text.FindAndReplace` / `properties.ChangePropertyKey`):
 
 * Config + metric prefixes `sheriff.oauth` → `sheriff.token` (`JwtPropertyKeys.PREFIX`, `MetricIdentifier.PREFIX`, `application*.properties`, tests, docs).
-* Requirement IDs `OAUTH-SHERIFF-N → VAL-N` (xref:../../Requirements.adoc[Requirements] anchors + all references).
+* Requirement IDs `OAUTH-SHERIFF-N → VALIDATION-N` (xref:../../Requirements.adoc[Requirements] anchors + all references).
 * Docs, badges, README image `alt`, GitHub workflows, `.github/project.yml` Sonar key, `cuioss.github.io/OAuth-Sheriff` URLs.
 
 *1d — Gate:* `./mvnw -Ppre-commit clean verify` then `./mvnw clean install` green.
@@ -123,7 +123,7 @@ Run the checklist below.
 
 The ~150-files-per-PR review limit is a *general guideline*, applied where sensible — not a hard gate for this change. Measured reality: this is one mechanical, tool-driven rename touching ~500 files (381 `.java` relocations + poms + ~425 `sheriff.oauth.` config-key files + docs).
 
-* *PR 1 — build-safe textual rename (honors the guideline).* Documentation/prose, requirement IDs `OAUTH-SHERIFF-N → VAL-N`, badges, Sonar key, Pages URLs. No compile impact, genuinely reviewable; ~86 files (split into two if it exceeds 150).
+* *PR 1 — build-safe textual rename (honors the guideline).* Documentation/prose, requirement IDs `OAUTH-SHERIFF-N → VALIDATION-N`, badges, Sonar key, Pages URLs. No compile impact, genuinely reviewable; ~86 files (split into two if it exceeds 150).
 * *PR 2 — atomic mechanical rename (guideline waived).* The OpenRewrite package/type/coordinate transform plus the `sheriff.oauth → sheriff.token` config/metric constants and their test expectations. This is *atomic* — packages, coordinates and config keys must flip together to keep `main` building. Slicing it into ≤150-file pieces would either break build-green-per-PR or leave coexisting `…oauth.*`/`…token.*` roots, adding risk with no review value.
 
 *Why the waiver is the safe choice:* the guideline's intent is reviewable PRs. A 500-file *mechanical, idempotent, build-verified* diff is reviewed by inspecting the OpenRewrite recipe and the verification sweep — not by reading ~500 identical edits. Forcing a split here reduces safety rather than increasing it. (If the reviewer hard-caps file count, land PR 2 with review on the recipe + green CI, or split the package move by sub-package across stacked PRs accepting temporary mixed roots — only if mandated.)
@@ -164,7 +164,7 @@ Publish a stub for *every* old artifact (`-core`, `-quarkus`, `-quarkus-deployme
 * [ ] `grep -rI "de.cuioss.sheriff.oauth"` → 0 (excluding relocation stubs)
 * [ ] `grep -rI "sheriff.oauth."` → 0
 * [ ] `grep -rI "oauth-sheriff"` → 0
-* [ ] `grep -rIo "OAUTH-SHERIFF-[0-9]"` → 0; `VAL-N` count matches the 51 prior IDs
+* [ ] `grep -rIo "OAUTH-SHERIFF-[0-9]"` → 0; `VALIDATION-N` count matches the 51 prior IDs
 * [ ] `./mvnw -Ppre-commit clean verify` and `./mvnw clean install` green
 * [ ] Relocation stubs published for every old artifact; an old-coordinate build prints the relocation warning and resolves
 * [ ] Repo renamed; old GitHub URL redirects; badges, Sonar, Pages, OpenSSF green

--- a/doc/oidc/02-doc-structure/README.adoc
+++ b/doc/oidc/02-doc-structure/README.adoc
@@ -89,7 +89,7 @@ The IDs are capability-scoped, self-documenting, and greppable — no shared bra
 
 * Validation uses `VALIDATION-N` (Plan 01 renames the existing `OAUTH-SHERIFF-N → VALIDATION-N`).
 * Commons uses `COMMONS-N`, grouped by concern — transport / error / events / metrics (xref:../03-commons/README.adoc[Plan 03]).
-* Client requirements use `CLIENT-N` — distinct capability namespace, unambiguous and greppable (`VALIDATION-[0-9]` vs `COMMONS-[0-9]` vs `CLIENT-[0-9]`).
+* Client requirements use `CLIENT-N` — distinct capability namespace, unambiguous and greppable (`VALIDATION-[0-9.]+` vs `COMMONS-[0-9.]+` vs `CLIENT-[0-9.]+`, matching dotted IDs like `VALIDATION-1.3`).
 
 == Cross-cutting realization: the RFC 9457 error model
 

--- a/doc/oidc/02-doc-structure/README.adoc
+++ b/doc/oidc/02-doc-structure/README.adoc
@@ -50,7 +50,7 @@ doc/
   LogMessages.adoc                  # GLOBAL log registry — all capabilities, stays at root
   commons/                # NEW base capability (Plan 03) — a package layer in token-sheriff-validation, not its own module
     architecture.adoc
-    requirements.adoc               # IDs: CMN-N (transport / error / events / metrics)
+    requirements.adoc               # IDs: COMMONS-N (transport / error / events / metrics)
     threat-model.adoc               # SSRF / TLS / response-DoS / error-detail-leakage
     references.adoc                 # bibliography / shared standards
     specification/
@@ -59,7 +59,7 @@ doc/
       observability.adoc            # SecurityEventCounter events + metric identifiers
   validation/                       # existing capability (relocated)
     architecture.adoc
-    requirements.adoc               # IDs: VAL-N  (per Plan 01)
+    requirements.adoc               # IDs: VALIDATION-N  (per Plan 01)
     threat-model.adoc
     security-reference.adoc
     specification/
@@ -85,18 +85,18 @@ The `doc/oidc/` planning area (this folder) is transient — it holds the plans,
 
 == Requirement-ID namespacing
 
-The IDs are short, capability-scoped, and greppable — no shared brand prefix to repeat on every reference.
+The IDs are capability-scoped, self-documenting, and greppable — no shared brand prefix to repeat on every reference.
 
-* Validation uses `VAL-N` (Plan 01 shortens the existing `OAUTH-SHERIFF-N → VAL-N`).
-* Commons uses `CMN-N`, grouped by concern — transport / error / events / metrics (xref:../03-commons/README.adoc[Plan 03]).
-* Client requirements use `CLIENT-N` — distinct capability namespace, unambiguous and greppable (`VAL-[0-9]` vs `CMN-[0-9]` vs `CLIENT-[0-9]`).
+* Validation uses `VALIDATION-N` (Plan 01 renames the existing `OAUTH-SHERIFF-N → VALIDATION-N`).
+* Commons uses `COMMONS-N`, grouped by concern — transport / error / events / metrics (xref:../03-commons/README.adoc[Plan 03]).
+* Client requirements use `CLIENT-N` — distinct capability namespace, unambiguous and greppable (`VALIDATION-[0-9]` vs `COMMONS-[0-9]` vs `CLIENT-[0-9]`).
 
 == Cross-cutting realization: the RFC 9457 error model
 
-The error model is *owned by `commons`* (`doc/commons/specification/error-model.adoc`, `CMN-N`), but its *realization spans modules*, so it is called out here. The contract:
+The error model is *owned by `commons`* (`doc/commons/specification/error-model.adoc`, `COMMONS-N`), but its *realization spans modules*, so it is called out here. The contract:
 
 * *Libraries throw typed exceptions* — `commons`, `validation`, the `client` engine — and MUST NOT produce HTTP problem documents. That is correct for a library.
-* *Every HTTP edge MUST emit `application/problem+json`* per https://www.rfc-editor.org/rfc/rfc9457[RFC 9457] — the Quarkus extensions (`token-sheriff-validation-quarkus`, `token-sheriff-client-quarkus`) *and* the `portal-authentication-oauth` RESTEasy adapter. The exception→problem mapping lives at each edge.
+* *Every HTTP edge MUST emit `application/problem+json`* per https://www.rfc-editor.org/rfc/rfc9457[RFC 9457] — the Quarkus extensions (`token-sheriff-validation-quarkus`, `token-sheriff-client-quarkus`) *and* any non-Quarkus (RESTEasy) edge, e.g. the future portal adapter. The exception→problem mapping lives at each edge.
 * *Existing errors conform*: the current validation rejection responses retrofit to problem+json as part of this work.
 * *Inbound side*: `commons` normalizes IdP error responses (OAuth `error`/`error_description`, RFC 6749 §5.2) into the same typed model — one contract, both directions.
 

--- a/doc/oidc/03-commons/README.adoc
+++ b/doc/oidc/03-commons/README.adoc
@@ -99,7 +99,7 @@ Since `commons` adds the *other* IdP endpoints, *extend this same artifact* with
 
 * `TokenDispatcher` — token endpoint: grants, error responses (RFC 6749 §5.2), malformed/oversized bodies.
 * `UserInfoDispatcher` — userinfo: valid, tampered, `sub` mismatch.
-* `RevocationDispatcher` / `IntrospectionDispatcher` — RFC 7009 / 7662.
+* `RevocationDispatcher` / `IntrospectionDispatcher` — token revocation / introspection endpoints (RFC 7009 / 7662).
 * `EndSessionDispatcher` — RP-initiated logout endpoint.
 * `ParDispatcher` — pushed authorization requests (RFC 9126).
 

--- a/doc/oidc/03-commons/README.adoc
+++ b/doc/oidc/03-commons/README.adoc
@@ -9,7 +9,7 @@
 | Status     | Ready to execute (spec after xref:../02-doc-structure/README.adoc[Plan 02]; re-packaging after xref:../01-restructure/README.adoc[Plan 01])
 | Depends on | Plan 01 (rename → `token-sheriff-*`), Plan 02 (doc structure — establishes `doc/commons/`)
 | Focus      | Gather the *cross-cutting concerns every capability sits on* into one *base layer* — the `de.cuioss.sheriff.token.commons.*` packages *inside* `token-sheriff-validation`: *IdP transport*, the *error model* (typed exceptions → RFC 9457 at the edge), *security events*, and *metrics*. *Not a separate artifact* — ArchUnit enforces the layering. Spec-first plus the *re-packaging* of these out of the validation packages.
-| Outcome    | The `commons` base packages + ArchUnit rules living in `token-sheriff-validation`; its requirements/spec/threat-model under `doc/commons/` (`CMN-N`).
+| Outcome    | The `commons` base packages + ArchUnit rules living in `token-sheriff-validation`; its requirements/spec/threat-model under `doc/commons/` (`COMMONS-N`).
 |===
 
 toc::[]
@@ -59,7 +59,7 @@ All outbound IdP HTTP: discovery (`.well-known`, RFC 8414 / OIDC Discovery), JWK
 | *Libraries* (`commons` + `validation` packages, the `client` engine — pure Java)
 | Throw a *typed exception hierarchy* (defined in `commons.error`). They MUST NOT produce HTTP problem documents — that is not their layer.
 
-| *HTTP edges* (`token-sheriff-validation-quarkus`, `token-sheriff-client-quarkus`, **and the `portal-authentication-oauth` RESTEasy adapter**)
+| *HTTP edges* (`token-sheriff-validation-quarkus`, `token-sheriff-client-quarkus`, **and any future non-Quarkus/RESTEasy edge such as the portal adapter**)
 | MUST map those exceptions to `application/problem+json` per https://www.rfc-editor.org/rfc/rfc9457[RFC 9457], without leaking internal detail. *Existing validation rejection responses retrofit to this.*
 |===
 
@@ -91,6 +91,20 @@ Layer rules live in `token-sheriff-validation`'s test sources:
 
 These give the same guarantee a module boundary would (base stays dependency-light, never depends "up") with one fewer artifact.
 
+== Test support: extend the dispatcher artifact
+
+The existing `generators`-classifier test artifact (today `oauth-sheriff-core`, post-rename `token-sheriff-validation`) already ships MockWebServer dispatchers for the endpoints validation talks to — `WellKnownDispatcher`, `JwksResolveDispatcher` in `…test.dispatcher`, implementing `ModuleDispatcherElement` from `cui-test-mockwebserver-junit5` (see xref:../../../oauth-sheriff-core/doc/UnitTesting.adoc[Core Test Utilities]).
+
+Since `commons` adds the *other* IdP endpoints, *extend this same artifact* with dispatchers for them — so commons, validation and (later) client tests all share one OP simulation:
+
+* `TokenDispatcher` — token endpoint: grants, error responses (RFC 6749 §5.2), malformed/oversized bodies.
+* `UserInfoDispatcher` — userinfo: valid, tampered, `sub` mismatch.
+* `RevocationDispatcher` / `IntrospectionDispatcher` — RFC 7009 / 7662.
+* `EndSessionDispatcher` — RP-initiated logout endpoint.
+* `ParDispatcher` — pushed authorization requests (RFC 9126).
+
+Each follows the existing pattern (`returnDefault()`/`returnError()`/… configuration + `assertCallsAnswered(int)` verification) and adds an *adversarial* mode for the threat catalog (SSRF redirects, slow/oversized responses, wrong `iss`). These dispatchers are the unit-test doubles xref:../06-implement/README.adoc[Plan 06] drives for its MockWebServer (adversarial) coverage.
+
 == Target document set (under `doc/commons/`)
 
 The *doc-level* `commons` capability is kept (separate from the code being one module):
@@ -98,7 +112,7 @@ The *doc-level* `commons` capability is kept (separate from the code being one m
 [source]
 ----
 doc/commons/
-  requirements.adoc            # CMN-N, grouped by concern (transport / error / events / metrics)
+  requirements.adoc            # COMMONS-N, grouped by concern (transport / error / events / metrics)
   architecture.adoc            # the base layer + ArchUnit boundary; who depends on what
   threat-model.adoc            # SSRF / TLS / response-DoS / error-detail-leakage — each sourced
   specification/
@@ -108,7 +122,7 @@ doc/commons/
   references.adoc              # bibliography (new sources; reuse note for shared standards)
 ----
 
-Requirement IDs use `CMN-N` (per xref:../02-doc-structure/README.adoc[Plan 02]), grouped by concern — a doc-level identity even though the code is a layer of `token-sheriff-validation`.
+Requirement IDs use `COMMONS-N` (per xref:../02-doc-structure/README.adoc[Plan 02]), grouped by concern — a doc-level identity even though the code is a layer of `token-sheriff-validation`.
 
 == Seed: threat catalog (with source anchors)
 
@@ -137,7 +151,7 @@ Requirement IDs use `CMN-N` (per xref:../02-doc-structure/README.adoc[Plan 02]),
 == Execution
 
 . *Scaffold + bibliography* — `doc/commons/` skeleton and `references.adoc`.
-. *Requirements* — `CMN-N`, grouped by concern (transport / error / events / metrics), each sourced.
+. *Requirements* — `COMMONS-N`, grouped by concern (transport / error / events / metrics), each sourced.
 . *Threat model* — the catalog above; each entry → source + mitigation + covering requirement.
 . *Specifications* — `transport.adoc`, `error-model.adoc`, `observability.adoc`.
 . *Re-packaging* — move transport + events + metrics into the `commons` packages; introduce the error model; add the RFC 9457 mapping at each Quarkus/REST edge; add the ArchUnit rules; build green.
@@ -148,6 +162,7 @@ Requirement IDs use `CMN-N` (per xref:../02-doc-structure/README.adoc[Plan 02]),
 * [ ] `de.cuioss.sheriff.token.commons.*` packages exist in `token-sheriff-validation`, depend only on `cui-http` + `cui-tooling`; *no new artifact*
 * [ ] ArchUnit rules pass: `commons` never depends on `…validation..`; no cross-boundary cycles
 * [ ] `wellknown` + `jwks.http` + `SecurityEventCounter` + metric identifiers re-packaged into `commons`; no functional change for `nifi-extensions` (or the break is in the migration guide)
-* [ ] Libraries throw typed exceptions only; **every HTTP edge — validation-quarkus, client-quarkus, the portal RESTEasy adapter — emits `application/problem+json` (RFC 9457)**, existing validation errors included
-* [ ] Every `CMN-N` requirement and threat entry cites a source; SSRF/TLS/DoS covered for all relocated + new endpoints
+* [ ] Libraries throw typed exceptions only; **every HTTP edge — validation-quarkus, client-quarkus (and any future RESTEasy edge) — emits `application/problem+json` (RFC 9457)**, existing validation errors included
+* [ ] Every `COMMONS-N` requirement and threat entry cites a source; SSRF/TLS/DoS covered for all relocated + new endpoints
+* [ ] The `generators` test artifact gains dispatchers for the new endpoints (token / userinfo / revocation / introspection / end-session / PAR), with default + adversarial modes, alongside the existing `WellKnownDispatcher`/`JwksResolveDispatcher`
 * [ ] `doc/commons/` requirements/spec/threat-model present; `references.adoc` resolves

--- a/doc/oidc/04-client-spec/README.adoc
+++ b/doc/oidc/04-client-spec/README.adoc
@@ -83,7 +83,7 @@ Sourced non-goals *specific to the client capability*. The library MUST NOT requ
 * *Weak client auth where `private_key_jwt`/mTLS is available; secrets over non-TLS* — RFC 9700, RFC 7523, RFC 8705.
 * *Unvalidated `jwks_uri` / metadata URLs* (SSRF) — CVE-2026-1180.
 
-NOTE: *Token-signature exclusions are not restated here* — rejecting `alg=none`, HMAC, and weak/short-key algorithms, and requiring asymmetric signature verification, is already mandated by the validation requirements (`VAL-1.3`, RFC 8725) and *inherited* by every token this client retrieves. The client spec covers only the *acquisition/flow* exclusions above; it must not duplicate the validation algorithm policy. Sender-constraining is likewise an inherited capability (validation already validates DPoP-bound tokens, `VAL-8.7`); the client delta is *requesting* such tokens (DPoP/mTLS at the token endpoint), covered under Retrieval & flow — not an exclusion.
+NOTE: *Token-signature exclusions are not restated here* — rejecting `alg=none`, HMAC, and weak/short-key algorithms, and requiring asymmetric signature verification, is already mandated by the validation requirements (`VALIDATION-1.3`, RFC 8725) and *inherited* by every token this client retrieves. The client spec covers only the *acquisition/flow* exclusions above; it must not duplicate the validation algorithm policy. Sender-constraining is likewise an inherited capability (validation already validates DPoP-bound tokens, `VALIDATION-8.7`); the client delta is *requesting* such tokens (DPoP/mTLS at the token endpoint), covered under Retrieval & flow — not an exclusion.
 
 == Organizing principle: separate the aspects
 
@@ -100,7 +100,7 @@ Keep these in separate documents and requirement groups — do not blend them.
 | The confidential-client *authorization-code + PKCE* flow (server-side) and the use of the token endpoint: grants, client authentication, `state`/`nonce`/exact redirect-URI, mix-up defence (`iss`), code-injection defence, PAR, DPoP/mTLS, step-up (RFC 9470), RP-initiated logout, response validation.
 |===
 
-*Transport is not an aspect here.* All outbound IdP HTTP — discovery, JWKS, token, userinfo, end-session, PAR — plus its TLS / SSRF / resilience hardening lives in xref:../03-commons/README.adoc[commons] (Plan 03). The client *uses* it and references its `CMN-N` requirements; it does not respecify fetching or restate SSRF/TLS. *Token* references the validation module for the delta only; *Retrieval & flow* is the genuinely net-new aspect this plan owns.
+*Transport is not an aspect here.* All outbound IdP HTTP — discovery, JWKS, token, userinfo, end-session, PAR — plus its TLS / SSRF / resilience hardening lives in xref:../03-commons/README.adoc[commons] (Plan 03). The client *uses* it and references its `COMMONS-N` requirements; it does not respecify fetching or restate SSRF/TLS. *Token* references the validation module for the delta only; *Retrieval & flow* is the genuinely net-new aspect this plan owns.
 
 == Target document set (under `doc/client/`)
 
@@ -122,7 +122,7 @@ doc/client/
 
 == Requirement-ID & sourcing discipline
 
-* Client requirements use `CLIENT-N` (per Plan 02), *grouped by aspect* (Token / Retrieval & flow). Transport requirements are `CMN-N` (Plan 03) and are cited, not duplicated.
+* Client requirements use `CLIENT-N` (per Plan 02), *grouped by aspect* (Token / Retrieval & flow). Transport requirements are `COMMONS-N` (Plan 03) and are cited, not duplicated.
 * *Every* normative requirement and *every* threat entry cites a source with section anchor (RFC / OIDC spec / OWASP / FAPI). MUST/SHOULD/MAY trace back to the cited source.
 * Requirements are *security-driven* — each traces to a threat it mitigates or is the secure way to perform a needed operation. Exclusions are sourced too.
 * `references.adoc` is the single bibliography; all docs cite into it.
@@ -139,16 +139,21 @@ doc/client/
 == Verification
 
 * [ ] Every requirement and threat entry cites a normative source with section anchor
-* [ ] Aspects cleanly separated; token references the validation module and transport references `commons` (`CMN-N`) — neither duplicated
+* [ ] Aspects cleanly separated; token references the validation module and transport references `commons` (`COMMONS-N`) — neither duplicated
 * [ ] Retrieval & flow covers confidential auth-code+PKCE, client auth, `state`/`nonce`/redirect-URI, mix-up (`iss`), sender-constraining, step-up (RFC 9470) and RP-initiated logout
 * [ ] BFF groundwork is sufficient (server-side token lifecycle) without owning the browser session/cookie layer
-* [ ] HTTP-surfaced client errors conform to the commons RFC 9457 error model (Plan 03) — the client engine throws typed exceptions; `client-quarkus` / the portal adapter emit problem+json
+* [ ] HTTP-surfaced client errors conform to the commons RFC 9457 error model (Plan 03) — the client engine throws typed exceptions; `client-quarkus` (and any future RESTEasy edge) emits problem+json
 * [ ] Each security exclusion is documented and sourced; every requirement is threat-driven
 * [ ] `CLIENT-N` IDs grouped by aspect; traceability matrix complete; `references.adoc` resolves
 
 // ---------------------------------------------------------------------------
 
 == Reference & replacement target: portal-authentication-oauth
+
+[NOTE]
+====
+This section is a *design reference only*. The actual replacement of `portal-authentication-oauth` — the portal adapter and its integration tests — is *future work beyond Plans 01–06*; no current plan delivers it. It informs the client spec (a real-world RP that exercises the in-scope flow) and motivates the framework-agnostic engine.
+====
 
 `cui-portal-core/modules/authentication/portal-authentication-oauth` is an existing confidential server-side OIDC client (CDI + MicroProfile Config + RESTEasy/JAX-RS). It is both a *validation reference* for this spec — a real BFF-style RP that already implements most of the in-scope flow — and a *replacement target*: the Token-Sheriff client engine should supersede it, with a thin portal adapter preserving the portal contract.
 
@@ -221,7 +226,7 @@ Minimum coverage for `threat-model.adoc`. Each → mitigation + covering require
 * ID-token / userinfo integrity — OIDC Core §3.1.3.7, §5.3 → signature + claim validation; bind userinfo `sub`
 * Sender-constraint loss in storage/forwarding — RFC 9449, RFC 8705 → keep tokens bound; minimal storage
 
-NOTE: *Transport threats — SSRF, TLS downgrade, response DoS on discovery/JWKS/token/userinfo — live in xref:../03-commons/README.adoc[commons]'s threat model (`CMN-N`), not here.* The flow inherits them; it does not restate them.
+NOTE: *Transport threats — SSRF, TLS downgrade, response DoS on discovery/JWKS/token/userinfo — live in xref:../03-commons/README.adoc[commons]'s threat model (`COMMONS-N`), not here.* The flow inherits them; it does not restate them.
 
 == Seed: best-practices checklist by aspect (sourced)
 

--- a/doc/oidc/04-client-spec/README.adoc
+++ b/doc/oidc/04-client-spec/README.adoc
@@ -155,7 +155,7 @@ doc/client/
 This section is a *design reference only*. The actual replacement of `portal-authentication-oauth` — the portal adapter and its integration tests — is *future work beyond Plans 01–06*; no current plan delivers it. It informs the client spec (a real-world RP that exercises the in-scope flow) and motivates the framework-agnostic engine.
 ====
 
-`cui-portal-core/modules/authentication/portal-authentication-oauth` is an existing confidential server-side OIDC client (CDI + MicroProfile Config + RESTEasy/JAX-RS). It is both a *validation reference* for this spec — a real BFF-style RP that already implements most of the in-scope flow — and a *replacement target*: the Token-Sheriff client engine should supersede it, with a thin portal adapter preserving the portal contract.
+`cui-portal-core/modules/authentication/portal-authentication-oauth` is an existing confidential server-side OIDC client (CDI + MicroProfile Config + RESTEasy/JAX-RS). For this spec it serves only as a *real-world reference* — a BFF-style RP that already implements most of the in-scope flow. It is also the eventual *replacement target*: the Token-Sheriff client engine would, in *future work beyond Plans 01–06*, supersede it via a thin portal adapter preserving the portal contract. Nothing in the current plans touches it.
 
 === What it already does (confirms this plan's scope)
 * Authorization-code + PKCE (*S256* confirmed), `state` CSRF, light `nonce`
@@ -176,7 +176,7 @@ This section is a *design reference only*. The actual replacement of `portal-aut
 * Replace bespoke RESTEasy fetching with xref:../03-commons/README.adoc[commons]'s hardened HTTP + *SSRF* defences.
 
 === Relationship to the other consumer
-`nifi-extensions` consumes the *validation module*; `portal-authentication-oauth` is an *RP* that the Token-Sheriff client module *replaces* (engine swap + portal adapter). It is the concrete reference implementation for this plan's BFF-engine scope.
+`nifi-extensions` consumes the *validation module*; `portal-authentication-oauth` is an *RP* that the Token-Sheriff client module *would eventually replace* (engine swap + portal adapter — future work). It is the concrete reference implementation that grounds this plan's BFF-engine scope.
 
 == Seed: source catalog (research 2026-06-24)
 

--- a/doc/oidc/05-client-module/README.adoc
+++ b/doc/oidc/05-client-module/README.adoc
@@ -1,4 +1,4 @@
-= Plan 05 — Add the Client Module, Extension, Assembly & IT (wired, empty)
+= Plan 05 — Add the Client Module, Extension & Assembly (wired, empty)
 :toc: macro
 :toclevels: 3
 :sectnums:
@@ -8,17 +8,17 @@
 |===
 | Status     | Ready to execute (after xref:../01-restructure/README.adoc[Plan 01])
 | Depends on | Plan 01 (rename → `token-sheriff-*`) + Plan 03 (the `commons` base layer inside `token-sheriff-validation` it builds on). Independent of Plan 04 (structure, not content).
-| Outcome    | Everything in place — *module, extension, assembly* (in this repo) and the *integration-test home* (in `cui-portal-core`) — fully wired, building green, with *no functional content yet*.
-| Cross-repo | Yes — `module`/`extension`/`assembly` land in OAuthSheriff (→ Token-Sheriff); `it` lands in `cui-portal-core` `portal-authentication-oauth`.
+| Outcome    | The three in-repo pieces — *module, extension, assembly* — fully wired, building green, with *no functional content yet*.
+| Scope      | In-repo only. `portal-authentication-oauth` (`cui-portal-core`) is the *replacement target* — a design reference (xref:../decision-oidc-module.adoc[decision], xref:../04-client-spec/README.adoc[Plan 04]), *not* a deliverable of this plan. The portal adapter and the integration tests against it are *future work beyond Plans 01–06*.
 |===
 
 toc::[]
 
 == Goal
 
-Stand up the complete skeleton the client work will fill: the engine module, a Quarkus extension for it, the build assembly (BOM + reactor), and the integration-test home in the real consumer. After Plan 05 a developer only adds content (per xref:../04-client-spec/README.adoc[Plan 04]); no structural work remains.
+Stand up the complete in-repo skeleton the client work will fill: the engine module, a Quarkus extension for it, and the build assembly (BOM + reactor). After Plan 05 a developer only adds content (per xref:../04-client-spec/README.adoc[Plan 04]); no structural work remains.
 
-== Decision: standalone engine, dedicated Quarkus extension, ITs in the consumer
+== Decision: standalone engine, dedicated Quarkus extension
 
 . *Engine — standalone, modelled on `token-sheriff-validation`.* Pure Java, depends on `token-sheriff-validation` — which provides both the `commons` base layer (transport, error model, events, metrics) and token validation. *Not* inside the Quarkus extension.
 +
@@ -26,31 +26,24 @@ Why: the replacement target `portal-authentication-oauth` is *CDI / RESTEasy / p
 
 . *Quarkus — a new extension that depends on the existing one.* `token-sheriff-client-quarkus` (runtime + deployment), depending on the existing `token-sheriff-validation-quarkus` extension *and* the engine. A separate extension (not folded in) preserves opt-in and reuses the existing validation CDI wiring. Verified by the build assembly.
 
-. *Integration tests live in the real consumer — `portal-authentication-oauth`.* The client is verified end-to-end where it actually replaces the legacy OAuth implementation, reusing that module's existing OIDC test infrastructure. The new client integration tests go in *their own package*, separated from the existing OAuth tests. (Own package, not own module.)
+Why no integration-test piece here: `portal-authentication-oauth` is the *replacement target* that motivates the framework-agnostic engine (above) — a design reference, not a deliverable. Wiring the engine into the portal is *future work beyond Plans 01–06*; the in-repo client integration tests (real Keycloak) belong to xref:../06-implement/README.adoc[Plan 06]. This plan stays *in-repo* and structure-only.
 
-The portal adapter (preserving `Oauth2Service` / `AuthenticatedUserInfo`) and these ITs both live in `cui-portal-core`; the engine + extension live here.
+== Deliverables (the three pieces)
 
-== Deliverables (the four pieces)
+All in OAuthSheriff (→ Token-Sheriff); no functional content.
 
-[cols="1,1,3"]
+[cols="1,3"]
 |===
-| Piece | Repo | What lands in Plan 05 (no functional content)
+| Piece | What lands in Plan 05
 
 | *module*
-| OAuthSheriff
 | `token-sheriff-client` — top-level, validation-like. `package-info.java` in `de.cuioss.sheriff.token.client`; deps `token-sheriff-validation` (which carries the `commons` base layer).
 
 | *extension*
-| OAuthSheriff
 | `token-sheriff-client-quarkus` (runtime) + `…-deployment`, under `token-sheriff-quarkus-parent`. Minimal extension registering a `token-sheriff-client` feature. Deps: existing `token-sheriff-validation-quarkus`(`-deployment`) + `token-sheriff-client`.
 
 | *assembly*
-| OAuthSheriff
 | Build wiring assembling the set: root `<modules>`, `token-sheriff-quarkus-parent` `<modules>`, BOM entries for `token-sheriff-client` + `token-sheriff-client-quarkus`. Build green proves the extension assembles.
-
-| *it*
-| cui-portal-core
-| In `portal-authentication-oauth`: a *test dependency* on `token-sheriff-client` and an *own-package* client integration-test scaffold (separated from the existing OAuth tests), reusing the module's OIDC test setup. Scaffold only — real tests arrive with the replacement.
 |===
 
 == Target module tree (post Plan 05)
@@ -68,10 +61,6 @@ token-sheriff-quarkus-parent/
   token-sheriff-quarkus-integration-tests/ # existing (unchanged)
   e-2-e-playwright/
 bom/                                       # + token-sheriff-client, token-sheriff-client-quarkus
-
-# cui-portal-core
-modules/authentication/portal-authentication-oauth/
-  src/test/java/.../client/                     # NEW own-package client IT scaffold (test dep: token-sheriff-client)
 ----
 
 == Module identity
@@ -87,8 +76,6 @@ modules/authentication/portal-authentication-oauth/
 
 == Wiring checklist ("link it everywhere")
 
-*OAuthSheriff (module + extension + assembly):*
-
 * `pom.xml` (root) — add `<module>token-sheriff-client</module>`.
 * `token-sheriff-quarkus-parent/pom.xml` — add `<module>token-sheriff-client-quarkus</module>` and `…-deployment`.
 * `bom/pom.xml` — add `token-sheriff-client` and `token-sheriff-client-quarkus`.
@@ -96,11 +83,6 @@ modules/authentication/portal-authentication-oauth/
 * Client extension descriptor — `quarkus-extension.yaml` (name "Token-Sheriff Client"); deployment `*Processor` registering the `token-sheriff-client` feature.
 * Source skeletons — `package-info.java` per new package; engine `doc/` stub per xref:../02-doc-structure/README.adoc[Plan 02].
 * CI/quality — reactor builds the new modules; confirm `.github/project.yml` (Sonar) scans them and empty modules don't fail the gate; `.github/dependabot.yml` covers them. List the new module + extension in the root README and `doc/README.adoc`.
-
-*cui-portal-core (it):*
-
-* `portal-authentication-oauth/pom.xml` — add a *test* dependency on `token-sheriff-client` (later also the validation module / config).
-* Create the own-package client IT scaffold under `src/test/java/.../oauth/client/` (or similar), separated from the existing OAuth tests; no test bodies yet.
 
 == "Builds empty" concern
 
@@ -114,6 +96,6 @@ Empty modules can fail quality gates (JaCoCo on zero classes, PMD, Sonar new-cod
 
 * [ ] `token-sheriff-client`, `token-sheriff-client-quarkus`, `…-deployment` appear in the reactor; engine + runtime in the BOM; full build green
 * [ ] client extension registers the `token-sheriff-client` feature and depends on the existing extension + engine; engine has *no* Quarkus dependency
-* [ ] `portal-authentication-oauth` has the `token-sheriff-client` test dependency and an own-package client IT scaffold, separated from the existing OAuth tests; its build is green
+* [ ] Nothing landed in `cui-portal-core` (out of scope — the portal replacement is future work beyond Plans 01–06)
 * [ ] No client functional content and no real test bodies introduced (structure only)
 * [ ] Root README and `doc/README.adoc` list the new module + extension

--- a/doc/oidc/06-implement/README.adoc
+++ b/doc/oidc/06-implement/README.adoc
@@ -7,7 +7,7 @@
 [cols="1,3"]
 |===
 | Status     | Ready after xref:../04-client-spec/README.adoc[Plan 04] (spec) + xref:../05-client-module/README.adoc[Plan 05] (skeleton)
-| Depends on | Plan 03 (the `commons` base layer in validation + `CMN-N` spec), Plan 04 (`CLIENT-N` requirements + threat model), Plan 05 (`token-sheriff-client` module/extension/IT home)
+| Depends on | Plan 03 (the `commons` base layer + `COMMONS-N` spec + the extended MockWebServer dispatchers), Plan 04 (`CLIENT-N` requirements + threat model), Plan 05 (`token-sheriff-client` module/extension/assembly)
 | Approach   | Vertical *protocol-by-protocol* increments, dependency-ordered. Each ships unit tests (MockWebServer) *and* integration tests against a *real Keycloak*. Security-driven.
 |===
 
@@ -25,8 +25,8 @@ Implement one *protocol/flow at a time* as a vertical slice — production code 
 
 Two distinct layers — do not conflate them:
 
-* *Unit tests* — in `token-sheriff-client` `src/test`, using *MockWebServer* to simulate the OP (discovery/JWKS/token/userinfo). Vital, but *unit*: this is where the *adversarial* coverage lives — malicious metadata, SSRF, wrong `iss`, code injection, PKCE downgrade, tampered/replayed tokens — because only a controllable mock can emit those. Use the CUI MockWebServer standards (`@ModuleDispatcher`, HTTPS/TLS, generator-driven *attack-database*).
-* *Integration tests* — Failsafe `*IT` against a *real Keycloak* (testcontainers / the existing Keycloak harness), verifying each protocol *actually interoperates* with a real OP end-to-end. Primary home: the replacement consumer `portal-authentication-oauth` (Plan 05). Protocols the portal login flow cannot exercise on their own (`client_credentials`, DPoP, token exchange) get a Keycloak-backed `*IT` harness in the Token-Sheriff repo.
+* *Unit tests* — in `token-sheriff-client` `src/test`, using *MockWebServer* to simulate the OP (discovery/JWKS/token/userinfo/…), driven by the dispatcher artifact *extended in xref:../03-commons/README.adoc[Plan 03]* (`TokenDispatcher`, `UserInfoDispatcher`, … alongside the existing `WellKnownDispatcher`/`JwksResolveDispatcher`). Vital, but *unit*: this is where the *adversarial* coverage lives — malicious metadata, SSRF, wrong `iss`, code injection, PKCE downgrade, tampered/replayed tokens — because only a controllable mock can emit those. Use the CUI MockWebServer standards (`@ModuleDispatcher`, HTTPS/TLS, generator-driven *attack-database*).
+* *Integration tests* — Failsafe `*IT` against a *real Keycloak* (testcontainers / the existing Keycloak harness) *in the Token-Sheriff repo*, verifying each protocol *actually interoperates* with a real OP end-to-end. Every protocol — `client_credentials`, DPoP, auth-code, token exchange — gets its Keycloak-backed `*IT` here. (The eventual `portal-authentication-oauth` replacement is a *design reference* and *future work beyond these plans* — see xref:../04-client-spec/README.adoc[Plan 04]; it is **not** an integration-test home for this plan.)
 
 The user-facing rule: *MockWebServer proves the mechanics and the attacks; Keycloak proves it really works.* Both are required per increment.
 
@@ -81,16 +81,16 @@ The user-facing rule: *MockWebServer proves the mechanics and the attacks; Keycl
 | Lifecycle transitions; storage isolation; logout open-redirect via unmatched `post_logout_redirect_uri`, missing `id_token_hint`/`state`, stale token after logout (must be revoked)
 | Revocation + RP-initiated logout against Keycloak (`id_token_hint`, exact-matched `post_logout_redirect_uri`, `state`)
 
-| 10 | *Hardening sweep* — verify the `commons` transport (incl. the relocated `wellknown`/`jwks`) is in use; close remaining `CLIENT-N` threat-model gaps (transport hardening itself is owned by `CMN-N`, Plan 03)
+| 10 | *Hardening sweep* — verify the `commons` transport (incl. the relocated `wellknown`/`jwks`) is in use; close remaining `CLIENT-N` threat-model gaps (transport hardening itself is owned by `COMMONS-N`, Plan 03)
 | Full attack-database across all fetch/retrieval paths
 | —
 
-| 11 | *E2E replacement* — wire `token-sheriff-client` into `portal-authentication-oauth` (own package)
+| 11 | *Full-flow E2E (in-repo)* — the complete confidential-client flow wired together in the Token-Sheriff integration tests
 | —
-| Keycloak login + token + userinfo + refresh + logout, as the legacy module did
+| Keycloak login + token + userinfo + refresh + logout, end-to-end
 |===
 
-Increments 1–2 prove the whole retrieve→validate loop; 5 is the BFF core; 11 closes the replacement loop.
+Increments 1–2 prove the whole retrieve→validate loop; 5 is the BFF core; 11 ties the full flow together end-to-end.
 
 == Verification
 
@@ -99,4 +99,4 @@ Increments 1–2 prove the whole retrieve→validate loop; 5 is the BFF core; 11
 * [ ] Every protocol has a *real-Keycloak integration* test proving interoperability
 * [ ] Each increment merged independently with its tests; build green at every step
 * [ ] No legacy/discouraged mechanism implemented (Plan 04 exclusions hold)
-* [ ] E2E: `portal-authentication-oauth` passes against Keycloak using `token-sheriff-client`
+* [ ] E2E: the full confidential-client flow passes against a real Keycloak, in-repo

--- a/doc/oidc/README.adoc
+++ b/doc/oidc/README.adoc
@@ -19,25 +19,26 @@ implementation plans plus the standing design decisions behind them.
   package layer *inside* `token-sheriff-validation` (ArchUnit-enforced, not a separate
   artifact): IdP transport (discovery, JWKS, token, userinfo, revocation, end-session,
   PAR) + the error model (typed exceptions → RFC 9457 at the edge) + security events +
-  metrics. Spec (`CMN-N`) plus the re-packaging of these out of the validation packages.
+  metrics. Spec (`COMMONS-N`) plus the re-packaging of these out of the validation packages,
+  and extending the `generators` test artifact with MockWebServer dispatchers for the new endpoints.
 * xref:04-client-spec/README.adoc[04 — Client Requirements, Specification & Security] -
   produce the full client document set (requirements, specification,
   threat model, best practices) — modular by aspect (token / retrieval & flow),
   incl. step-up (RFC 9470) and RP-initiated logout; transport referenced from
   commons, not respecified. Spec-first; engine for a Backend-For-Frontend;
   replacement target `portal-authentication-oauth`.
-* xref:05-client-module/README.adoc[05 — Add the Client Module, Extension, Assembly & IT (wired, empty)] -
-  stand up the full skeleton: standalone validation-like engine `token-sheriff-client`
+* xref:05-client-module/README.adoc[05 — Add the Client Module, Extension & Assembly (wired, empty)] -
+  stand up the in-repo skeleton: standalone validation-like engine `token-sheriff-client`
   (pure Java, deps `token-sheriff-validation`, which carries the commons base layer), a dedicated
-  `token-sheriff-client-quarkus` extension depending on the existing one, and
-  BOM/reactor assembly — plus the client integration-test home (own package) in
-  `cui-portal-core` `portal-authentication-oauth`, the real consumer. Cross-repo;
-  no content. Runs after Plans 01 + 03.
+  `token-sheriff-client-quarkus` extension depending on the existing one, and BOM/reactor
+  assembly — no functional content. The portal (`portal-authentication-oauth`) is the
+  replacement target (design reference only); its adapter + ITs are future work beyond
+  these plans. Runs after Plans 01 + 03.
 * xref:06-implement/README.adoc[06 — Implement the Client (protocol by protocol)] -
   implement the `CLIENT-N` requirements as vertical
   protocol-by-protocol increments. Each ships unit tests (MockWebServer, incl.
-  adversarial) *and* integration tests against a real Keycloak, ending in the
-  portal E2E replacement. After Plans 03 + 04 + 05.
+  adversarial) *and* integration tests against a real Keycloak in-repo, ending in a
+  full-flow Keycloak E2E. After Plans 03 + 04 + 05.
 
 == Design decisions
 

--- a/doc/oidc/decision-oidc-module.adoc
+++ b/doc/oidc/decision-oidc-module.adoc
@@ -51,7 +51,7 @@ token-sheriff-client                      flows / token acquisition / lifecycle 
 * **`token-sheriff-validation`** — the artifact; ships the `commons` base packages + the validation packages. Today's `wellknown`/`jwks.http`/`SecurityEventCounter`/metric identifiers are re-packaged into the `commons` layer (xref:03-commons/README.adoc[Plan 03]).
 * **`token-sheriff-client`** — a *separate* module/artifact: flows / token acquisition / lifecycle. Depends on `validation` (which transitively provides the `commons` base).
 
-*Why no separate `commons` artifact:* **no consumer wants the base without validation** — the client validates the tokens it retrieves, so it pulls `validation` anyway and gets the base transitively; `nifi-extensions` wants `validation`. A third artifact would add a POM/release/BOM surface for a dependency nobody picks alone. ArchUnit gives the layering guarantee (base stays dependency-light, never depends up) without the packaging overhead. `commons` keeps a *doc-level* identity (`doc/commons/`, `CMN-N`).
+*Why no separate `commons` artifact:* **no consumer wants the base without validation** — the client validates the tokens it retrieves, so it pulls `validation` anyway and gets the base transitively; `nifi-extensions` wants `validation`. A third artifact would add a POM/release/BOM surface for a dependency nobody picks alone. ArchUnit gives the layering guarantee (base stays dependency-light, never depends up) without the packaging overhead. `commons` keeps a *doc-level* identity (`doc/commons/`, `COMMONS-N`).
 
 The seams are *not* "OAuth vs OIDC" (validation already does OIDC discovery and ID tokens). They are:
 


### PR DESCRIPTION
Follow-up to #507. Three planning-doc refinements.

## 1. Full-word requirement IDs
`VAL-N → VALIDATION-N`, `CMN-N → COMMONS-N` (`CLIENT-N` unchanged). Consistent and self-documenting — `CMN` wasn't obvious. The original "too long" concern was the `TOKEN-SHERIFF-` brand prefix, not the capability word, so full words don't reintroduce it. Cleaned up the now-inaccurate "shortened/short" wording.

## 2. `portal-authentication-oauth` scoped out of all current plans
It's future work, kept only as a **design reference** (decision doc + Plan 04's reference section, now prefixed with a future-work NOTE):
- **Plan 05** — removed the `cui-portal-core` deliverable: **four pieces → three in-repo pieces** (module, extension, assembly). Portal kept as the rationale for the framework-agnostic engine.
- **Plan 06** — integration tests run **in-repo against real Keycloak** (every protocol gets its `*IT` here); increment 11 reframed from "portal E2E replacement" to **"Full-flow E2E (in-repo)"**.
- Error-model edges (Plans 02/03/04) now phrase the portal RESTEasy adapter as a *future example* edge, not a current one.

## 3. Test dispatchers (Plan 03)
New "Test support" section: extend the existing `generators` test artifact with MockWebServer dispatchers for the new endpoints (`TokenDispatcher`, `UserInfoDispatcher`, `RevocationDispatcher`, `IntrospectionDispatcher`, `EndSessionDispatcher`, `ParDispatcher`) alongside the existing `WellKnownDispatcher`/`JwksResolveDispatcher`. Plan 06's unit tests drive them.

Planning docs only; all xrefs verified to resolve.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized OIDC planning requirement ID namespaces to `VALIDATION-*` and `COMMONS-*`, including removing `OAUTH-SHERIFF-*` references and updating related verification/checklists.
  * Updated the OIDC doc structure and commons plan scope, along with broadened RFC 9457 error-model guidance for typed exceptions across relevant HTTP edges.
  * Refined client and implement plans: clarified deliverables, tightened “future work” boundaries for portal-related pieces, and revised full-flow E2E guidance to use real in-repo Keycloak coverage.
  * Expanded MockWebServer dispatcher coverage guidance (additional IdP endpoints and adversarial modes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->