### PR TITLE
docs(brand): rename product name OAuth-Sheriff → Token-Sheriff in prose

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ This file contains:
 - OpenRewrite marker handling
 - Custom commands
 
-Please refer to `agents.md` for complete guidance when working on this OAuth Sheriff project.
+Please refer to `agents.md` for complete guidance when working on this Token-Sheriff project.
 
 - Use `.plan/temp/` for ALL temporary files (covered by `Write(.plan/**)` permission - avoids permission prompts)
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# OAuth-Sheriff
+# Token-Sheriff
 
 ## Status
 
-<img align="right" width="300" src="doc/resources/Sheriff.png" alt="OAuth Sheriff">
+<img align="right" width="300" src="doc/resources/Sheriff.png" alt="Token-Sheriff">
 
 **Build & Quality**
 
@@ -178,7 +178,7 @@ For detailed architectural information, see:
 - [MicroProfile JWT Compatibility](doc/specification/microprofile-jwt-compatibility.adoc) - MP-JWT 2.1 integration and rationale
 - [Multi-IDP Testing](doc/specification/multi-idp-testing.adoc) - Testing with multiple OIDC providers
 
-For configuration details including runtime dependencies and test support, see the [OAuth Sheriff Core documentation](oauth-sheriff-core/README.adoc).
+For configuration details including runtime dependencies and test support, see the [Token-Sheriff Core documentation](oauth-sheriff-core/README.adoc).
 
 ## Performance
 

--- a/agents.md
+++ b/agents.md
@@ -1,6 +1,6 @@
-# OAuth Sheriff - AI Agent Guidance
+# Token-Sheriff - AI Agent Guidance
 
-OAuth Sheriff is a high-performance OAuth 2.0 and OpenID Connect token validation library for Java/Quarkus applications. This document guides AI coding agents when working with the codebase.
+Token-Sheriff is a high-performance OAuth 2.0 and OpenID Connect token validation library for Java/Quarkus applications. This document guides AI coding agents when working with the codebase.
 
 ## Dev Environment Tips
 
@@ -11,7 +11,7 @@ OAuth Sheriff is a high-performance OAuth 2.0 and OpenID Connect token validatio
 
 ### Project Structure
 Multi-module Maven project:
-- `oauth-sheriff-core/` - The core OAuth Sheriff validation library
+- `oauth-sheriff-core/` - The core Token-Sheriff validation library
 - `oauth-sheriff-quarkus-parent/` - Quarkus framework integration
 - `benchmarking/` - Performance benchmarking modules
 - `bom/` - Bill of Materials for dependency management

--- a/benchmarking/README.adoc
+++ b/benchmarking/README.adoc
@@ -1,4 +1,4 @@
-= OAuth Sheriff Benchmarking
+= Token-Sheriff Benchmarking
 :toc:
 :toclevels: 2
 :toc-title: Table of Contents

--- a/benchmarking/benchmarking-common/README.adoc
+++ b/benchmarking/benchmarking-common/README.adoc
@@ -66,7 +66,7 @@ de.cuioss.benchmarking.common/
 === Constants (`constants/`)
 
 * **BenchmarkConstants** - Consolidated constants using DSL-Style Nested Constants Pattern
-  - Metrics prefixes and paths for OAuth Sheriff measurements
+  - Metrics prefixes and paths for Token-Sheriff measurements
   - JMH system property keys
   - Integration configuration property keys
 

--- a/benchmarking/doc/Architecture.adoc
+++ b/benchmarking/doc/Architecture.adoc
@@ -8,12 +8,12 @@
 
 [NOTE]
 ====
-This document defines the architecture, responsibilities, and boundaries of the OAuth Sheriff benchmark modules. All content has been verified against the actual codebase.
+This document defines the architecture, responsibilities, and boundaries of the Token-Sheriff benchmark modules. All content has been verified against the actual codebase.
 ====
 
 == Overview
 
-The OAuth Sheriff benchmarking infrastructure consists of three specialized modules:
+The Token-Sheriff benchmarking infrastructure consists of three specialized modules:
 
 [cols="1,3", options="header"]
 |===

--- a/benchmarking/doc/workflow.adoc
+++ b/benchmarking/doc/workflow.adoc
@@ -43,7 +43,7 @@ The benchmark processing is automatically triggered in GitHub Actions:
 
 5. **Deployment**
    - Deploy combined results to cuioss.github.io
-   - Results available at `TokenSheriff/benchmarks`
+   - Results available at `OAuthSheriff/benchmarks`
 
 == Local Development
 

--- a/benchmarking/doc/workflow.adoc
+++ b/benchmarking/doc/workflow.adoc
@@ -43,7 +43,7 @@ The benchmark processing is automatically triggered in GitHub Actions:
 
 5. **Deployment**
    - Deploy combined results to cuioss.github.io
-   - Results available at `OAuthSheriff/benchmarks`
+   - Results available at `TokenSheriff/benchmarks`
 
 == Local Development
 

--- a/doc/LogMessages.adoc
+++ b/doc/LogMessages.adoc
@@ -1,4 +1,4 @@
-= Log Messages for OAuth Sheriff
+= Log Messages for Token-Sheriff
 :toc: left
 :toclevels: 3
 :toc-title: Table of Contents
@@ -19,7 +19,7 @@ This document provides a reference for all log messages used in the JWT Token Va
 
 === Log Message Format
 
-All messages follow the format: OAuthSheriff-[identifier]: [message]
+All messages follow the format: TokenSheriff-[identifier]: [message]
 
 The log message levels follow these identifier ranges:
 
@@ -40,15 +40,15 @@ For more details about security events related to these log messages, see the Se
 [cols="1,1,2,2", options="header"]
 |===
 |ID |Component |Message |Description
-|OAuthSheriff-001 |TOKEN |TokenValidator initialized with %s |Logged when TokenValidator is initialized with issuer configurations
-|OAuthSheriff-002 |JWKS |Keys updated due to data change - load state: %s |Logged when JWKS keys are updated due to data changes from the endpoint
-|OAuthSheriff-003 |JWKS |Background JWKS refresh started with interval: %s seconds |Logged when background JWKS refresh is started with specified interval
-|OAuthSheriff-004 |TOKEN |Skipping disabled issuer configuration %s |Logged when an issuer configuration is skipped because it's disabled
-|OAuthSheriff-005 |JWKS |Successfully resolved JWKS URI from well-known endpoint: %s |Logged when JWKS URI is successfully resolved via well-known discovery
-|OAuthSheriff-006 |RETRY |Retry operation '%s' completed successfully after %s attempts in %sms |Logged when a retry operation completes successfully with timing information
-|OAuthSheriff-007 |JWKS |JWKS loaded successfully for issuer: %s |Logged when JWKS is successfully loaded for a specific issuer
-|OAuthSheriff-008 |ISSUER |Issuer configuration loaded successfully: %s |Logged when an issuer configuration is successfully loaded
-|OAuthSheriff-009 |JWE |JWE decryption enabled with %s decryption key(s) |Logged when JWE decryption is configured on TokenValidator with the number of available decryption keys
+|TokenSheriff-001 |TOKEN |TokenValidator initialized with %s |Logged when TokenValidator is initialized with issuer configurations
+|TokenSheriff-002 |JWKS |Keys updated due to data change - load state: %s |Logged when JWKS keys are updated due to data changes from the endpoint
+|TokenSheriff-003 |JWKS |Background JWKS refresh started with interval: %s seconds |Logged when background JWKS refresh is started with specified interval
+|TokenSheriff-004 |TOKEN |Skipping disabled issuer configuration %s |Logged when an issuer configuration is skipped because it's disabled
+|TokenSheriff-005 |JWKS |Successfully resolved JWKS URI from well-known endpoint: %s |Logged when JWKS URI is successfully resolved via well-known discovery
+|TokenSheriff-006 |RETRY |Retry operation '%s' completed successfully after %s attempts in %sms |Logged when a retry operation completes successfully with timing information
+|TokenSheriff-007 |JWKS |JWKS loaded successfully for issuer: %s |Logged when JWKS is successfully loaded for a specific issuer
+|TokenSheriff-008 |ISSUER |Issuer configuration loaded successfully: %s |Logged when an issuer configuration is successfully loaded
+|TokenSheriff-009 |JWE |JWE decryption enabled with %s decryption key(s) |Logged when JWE decryption is configured on TokenValidator with the number of available decryption keys
 |===
 
 == WARN Level (100-167)
@@ -56,74 +56,74 @@ For more details about security events related to these log messages, see the Se
 [cols="1,1,2,2", options="header"]
 |===
 |ID |Component |Message |Description
-|OAuthSheriff-100 |TOKEN |Token exceeds maximum size limit of %s bytes, validation will be rejected |Logged when a token is rejected due to size constraints
-|OAuthSheriff-101 |TOKEN |The given validation was empty, request will be rejected |Logged when an empty or null token is provided
-|OAuthSheriff-102 |TOKEN |No key found with ID: %s |Logged when a key with the specified ID cannot be found in the JWKS
-|OAuthSheriff-103 |TOKEN |Failed to decode JWT Token |Logged when the JWT token cannot be decoded
-|OAuthSheriff-104 |TOKEN |Invalid JWT Token format: expected 3 parts (JWS) or 5 parts (JWE) but got %s |Logged when the JWT token format is invalid
-|OAuthSheriff-105 |TOKEN |Decoded part exceeds maximum size limit of %s bytes |Logged when a decoded part of the token exceeds the maximum size limit
-|OAuthSheriff-106 |TOKEN |Unsupported algorithm: %s |Logged when an unsupported algorithm is encountered
-|OAuthSheriff-107 |TOKEN |Token has a 'not before' claim that is more than 60 seconds in the future |Logged when a token has a 'not before' claim that is too far in the future
-|OAuthSheriff-108 |TOKEN |Unknown token type: %s |Logged when an unknown token type is encountered
-|OAuthSheriff-109 |TOKEN |Token is missing required claim: %s |Logged when a token is missing a required claim
-|OAuthSheriff-110 |TOKEN |Token has expired |Logged when a token has expired
-|OAuthSheriff-111 |TOKEN |Token authorized party '%s' does not match expected client ID '%s' |Logged when the azp claim in the token does not match the expected client ID
-|OAuthSheriff-112 |TOKEN |Missing recommended element: %s |Logged when a recommended element is missing from the token
-|OAuthSheriff-113 |TOKEN |Token audience %s does not match any of the expected audiences %s |Logged when the audience in the token does not match any of the expected audiences
-|OAuthSheriff-114 |TOKEN |No configuration found for issuer: %s |Logged when no configuration is found for the issuer
-|OAuthSheriff-115 |TOKEN |Algorithm %s is explicitly rejected for security reasons |Logged when an algorithm is explicitly rejected for security reasons
-|OAuthSheriff-116 |JWKS |Creating HttpJwksLoaderConfig with invalid JWKS URI. The loader will return empty results. |Logged when an invalid JWKS URI is provided to HttpJwksLoaderConfig
-|OAuthSheriff-117 |JWKS |JWK is missing required field 'kty' |Logged when a JWK key is missing the required 'kty' parameter
-|OAuthSheriff-118 |JWKS |Unsupported key type: %s |Logged when an unsupported JWK key type is encountered
-|OAuthSheriff-119 |JWKS |Key ID exceeds maximum length: %s |Logged when a JWK key ID exceeds the maximum allowed length
-|OAuthSheriff-120 |JWKS |Invalid or unsupported algorithm: %s |Logged when an invalid or unsupported algorithm is encountered in a JWK
-|OAuthSheriff-121 |TOKEN |Found unhealthy issuer config: %s |Logged when an issuer configuration is found to be unhealthy during health checks
-|OAuthSheriff-122 |JWKS |Background JWKS refresh failed: %s |Logged when background JWKS refresh operation fails
-|OAuthSheriff-123 |JWKS |Failed to resolve JWKS URI from well-known resolver |Logged when JWKS URI resolution fails from well-known discovery
-|OAuthSheriff-124 |JWKS |JWKS object is null |Logged when JWKS object validation fails due to null object
-|OAuthSheriff-125 |JWKS |JWKS keys array exceeds maximum size: %s |Logged when JWKS keys array exceeds the maximum allowed size
-|OAuthSheriff-126 |JWKS |JWKS keys array is empty |Logged when JWKS keys array is empty
-|OAuthSheriff-127 |JWKS |Failed to parse RSA key with ID %s: %s |Logged when RSA key parsing fails for a specific key ID
-|OAuthSheriff-128 |JWKS |Failed to parse EC key with ID %s: %s |Logged when EC key parsing fails for a specific key ID
-|OAuthSheriff-129 |RETRY |Retry operation '%s' failed after %s attempts in %sms |Logged when a retry operation fails after exhausting all attempts
-|OAuthSheriff-130 |JSON |Failed to parse JWKS JSON: %s |Logged when JSON parsing fails for JWKS content and an empty result is returned as fallback
-|OAuthSheriff-131 |ISSUER |IssuerConfig for issuer '%s' has claimSubOptional=true. This is not conform to RFC 7519 which requires the 'sub' claim for ACCESS_TOKEN and ID_TOKEN types. Use this setting only when necessary and ensure appropriate alternative validation mechanisms. |Logged when an issuer configuration has the subject claim marked as optional, which violates RFC 7519 requirements
-|OAuthSheriff-132 |JWKS |Invalid Base64 URL encoding detected for JWK field: %s |Logged when Base64 URL encoding validation fails for a JWK field
-|OAuthSheriff-133 |JWKS |Background refresh skipped - no HTTP handler available |Logged when background JWKS refresh is skipped because no HTTP handler is available
-|OAuthSheriff-134 |JWKS |Background refresh parse error: %s for issuer: %s |Logged when a JSON parsing error occurs during background JWKS refresh for a specific issuer
-|OAuthSheriff-135 |ISSUER |Failed to load issuer configuration for %s, status: %s |Logged when issuer configuration loading fails with a specific status
-|OAuthSheriff-136 |JWKS |Timeout waiting for JWKS to load for issuer: %s |Logged when JWKS loading times out for a specific issuer
-|OAuthSheriff-137 |JWKS |Interrupted while waiting for JWKS to load for issuer: %s |Logged when the thread is interrupted while waiting for JWKS to load
-|OAuthSheriff-138 |JWKS |Configured issuer '%s' does not match discovered issuer '%s' from well-known document |Logged when there is a mismatch between configured and discovered issuer from well-known endpoint
-|OAuthSheriff-139 |JWKS |Using insecure HTTP protocol for JWKS endpoint: %s - HTTPS should be used in production |Logged when an insecure HTTP protocol is used for JWKS endpoint instead of HTTPS
-|OAuthSheriff-140 |JWKS |DSL-JSON returned null for JWKS parsing |Logged when DSL-JSON parser returns null while parsing JWKS content
-|OAuthSheriff-141 |JWKS |Failed to parse JWKS content: %s |Logged when JWKS content parsing fails due to IO error or invalid JSON structure
-|OAuthSheriff-142 |JWKS |Failed to parse OKP key with ID %s: %s |Logged when OKP (EdDSA) key parsing fails for a specific key ID
-|OAuthSheriff-143 |TOKEN |Token type '%s' does not match expected type '%s' |Logged when the JWT typ header does not match the expected token type configured for the issuer (RFC 9068 validation)
-|OAuthSheriff-144 |DPOP |DPoP proof is required but the DPoP HTTP header is missing |Logged when a DPoP proof is expected (cnf.jkt present or dpop.required=true) but the DPoP HTTP header is absent
-|OAuthSheriff-145 |DPOP |DPoP proof has invalid format: %s |Logged when the DPoP proof JWT cannot be decoded or has structural issues (wrong typ, unsupported algorithm, missing jwk, invalid signature)
-|OAuthSheriff-146 |DPOP |DPoP proof iat claim is outside acceptable freshness window |Logged when the DPoP proof iat claim is too old or too far in the future
-|OAuthSheriff-147 |DPOP |DPoP proof JWK thumbprint '%s' does not match token cnf.jkt '%s' |Logged when the computed JWK Thumbprint (RFC 7638) of the DPoP proof's public key does not match the cnf.jkt claim in the access token
-|OAuthSheriff-148 |DPOP |DPoP proof replay detected for jti: %s |Logged when a DPoP proof with a previously seen jti value is detected (replay attack)
-|OAuthSheriff-149 |DPOP |DPoP proof is missing required claim: %s |Logged when the DPoP proof JWT body is missing a required claim (jti, iat, or ath)
-|OAuthSheriff-150 |DPOP |DPoP proof ath claim does not match access token hash |Logged when the DPoP proof ath claim (SHA-256 hash of the access token) does not match the actual access token
-|OAuthSheriff-151 |DPOP |DPoP is required but access token does not contain cnf.jkt claim |Logged when DPoP validation is required or a DPoP proof is provided but the access token lacks the cnf.jkt claim
-|OAuthSheriff-152 |JWE |Failed to decrypt JWE token: %s |Logged when JWE decryption fails due to cryptographic errors (wrong key, tampered content, etc.)
-|OAuthSheriff-153 |JWE |Unsupported JWE algorithm: alg=%s, enc=%s |Logged when a JWE token uses an unsupported or rejected algorithm combination
-|OAuthSheriff-154 |JWE |Received JWE token but no decryption configuration is available |Logged when a 5-part JWE token is received but no JweDecryptionConfig was configured on TokenValidator
-|OAuthSheriff-155 |JWE |No decryption key found for key ID: %s |Logged when the JWE header references a kid that has no matching decryption key and no default key is configured
-|OAuthSheriff-156 |JWE |Unsupported JWE compression algorithm: %s |Logged when a JWE token uses an unsupported compression algorithm (only DEF/DEFLATE is supported)
-|OAuthSheriff-157 |JWE |Nested JWE tokens are not allowed |Logged when decrypting a JWE token reveals another JWE (5-part) token instead of the expected inner JWS
-|OAuthSheriff-158 |Token Age |Token age exceeds maximum allowed age |Logged when a token's `iat` claim indicates it was issued longer ago than the configured `maxTokenAgeSeconds`
-|OAuthSheriff-159 |Custom Rule |Custom validation rule rejected token: %s |Logged when a custom `TokenValidationRule` rejects a token by throwing `TokenValidationException`
-|OAuthSheriff-160 |JWKS |JWK entry without 'kid' field skipped — kid is required for key identification |Logged when a JWK entry is skipped because it lacks a key ID
-|OAuthSheriff-161 |JWKS |RSA JWK without 'alg' field — defaulting to RS256 for key ID: %s |Logged when an RSA JWK lacks an algorithm field and defaults to RS256
-|OAuthSheriff-162 |Audience |Access token is missing required audience claim. Expected audience: %s |Logged when an access token is missing the required audience claim
-|OAuthSheriff-163 |DPOP |DPoP proof htu claim '%s' does not match request URI '%s' |Logged when the DPoP htu claim doesn't match the actual request URI
-|OAuthSheriff-164 |DPOP |DPoP proof htm claim '%s' does not match request method '%s' |Logged when the DPoP htm claim doesn't match the actual request method
-|OAuthSheriff-165 |Audience |Audience claim missing but azp claim '%s' matches expected audience — using azp as fallback |Logged when the audience (aud) claim is absent but the azp claim matches the expected audience, falling back to azp for audience validation
-|OAuthSheriff-166 |Audience |Access token audience validation skipped (accessTokenAudienceOptional=true). Expected audience: %s |Logged when audience validation is skipped for an access token because accessTokenAudienceOptional is enabled
-|OAuthSheriff-167 |Authorized Party |azp claim missing, using client_id claim '%s' for authorized party validation (RFC 9068) |Logged when the azp claim is absent but the client_id claim (per RFC 9068) matches the expected client ID
+|TokenSheriff-100 |TOKEN |Token exceeds maximum size limit of %s bytes, validation will be rejected |Logged when a token is rejected due to size constraints
+|TokenSheriff-101 |TOKEN |The given validation was empty, request will be rejected |Logged when an empty or null token is provided
+|TokenSheriff-102 |TOKEN |No key found with ID: %s |Logged when a key with the specified ID cannot be found in the JWKS
+|TokenSheriff-103 |TOKEN |Failed to decode JWT Token |Logged when the JWT token cannot be decoded
+|TokenSheriff-104 |TOKEN |Invalid JWT Token format: expected 3 parts (JWS) or 5 parts (JWE) but got %s |Logged when the JWT token format is invalid
+|TokenSheriff-105 |TOKEN |Decoded part exceeds maximum size limit of %s bytes |Logged when a decoded part of the token exceeds the maximum size limit
+|TokenSheriff-106 |TOKEN |Unsupported algorithm: %s |Logged when an unsupported algorithm is encountered
+|TokenSheriff-107 |TOKEN |Token has a 'not before' claim that is more than 60 seconds in the future |Logged when a token has a 'not before' claim that is too far in the future
+|TokenSheriff-108 |TOKEN |Unknown token type: %s |Logged when an unknown token type is encountered
+|TokenSheriff-109 |TOKEN |Token is missing required claim: %s |Logged when a token is missing a required claim
+|TokenSheriff-110 |TOKEN |Token has expired |Logged when a token has expired
+|TokenSheriff-111 |TOKEN |Token authorized party '%s' does not match expected client ID '%s' |Logged when the azp claim in the token does not match the expected client ID
+|TokenSheriff-112 |TOKEN |Missing recommended element: %s |Logged when a recommended element is missing from the token
+|TokenSheriff-113 |TOKEN |Token audience %s does not match any of the expected audiences %s |Logged when the audience in the token does not match any of the expected audiences
+|TokenSheriff-114 |TOKEN |No configuration found for issuer: %s |Logged when no configuration is found for the issuer
+|TokenSheriff-115 |TOKEN |Algorithm %s is explicitly rejected for security reasons |Logged when an algorithm is explicitly rejected for security reasons
+|TokenSheriff-116 |JWKS |Creating HttpJwksLoaderConfig with invalid JWKS URI. The loader will return empty results. |Logged when an invalid JWKS URI is provided to HttpJwksLoaderConfig
+|TokenSheriff-117 |JWKS |JWK is missing required field 'kty' |Logged when a JWK key is missing the required 'kty' parameter
+|TokenSheriff-118 |JWKS |Unsupported key type: %s |Logged when an unsupported JWK key type is encountered
+|TokenSheriff-119 |JWKS |Key ID exceeds maximum length: %s |Logged when a JWK key ID exceeds the maximum allowed length
+|TokenSheriff-120 |JWKS |Invalid or unsupported algorithm: %s |Logged when an invalid or unsupported algorithm is encountered in a JWK
+|TokenSheriff-121 |TOKEN |Found unhealthy issuer config: %s |Logged when an issuer configuration is found to be unhealthy during health checks
+|TokenSheriff-122 |JWKS |Background JWKS refresh failed: %s |Logged when background JWKS refresh operation fails
+|TokenSheriff-123 |JWKS |Failed to resolve JWKS URI from well-known resolver |Logged when JWKS URI resolution fails from well-known discovery
+|TokenSheriff-124 |JWKS |JWKS object is null |Logged when JWKS object validation fails due to null object
+|TokenSheriff-125 |JWKS |JWKS keys array exceeds maximum size: %s |Logged when JWKS keys array exceeds the maximum allowed size
+|TokenSheriff-126 |JWKS |JWKS keys array is empty |Logged when JWKS keys array is empty
+|TokenSheriff-127 |JWKS |Failed to parse RSA key with ID %s: %s |Logged when RSA key parsing fails for a specific key ID
+|TokenSheriff-128 |JWKS |Failed to parse EC key with ID %s: %s |Logged when EC key parsing fails for a specific key ID
+|TokenSheriff-129 |RETRY |Retry operation '%s' failed after %s attempts in %sms |Logged when a retry operation fails after exhausting all attempts
+|TokenSheriff-130 |JSON |Failed to parse JWKS JSON: %s |Logged when JSON parsing fails for JWKS content and an empty result is returned as fallback
+|TokenSheriff-131 |ISSUER |IssuerConfig for issuer '%s' has claimSubOptional=true. This is not conform to RFC 7519 which requires the 'sub' claim for ACCESS_TOKEN and ID_TOKEN types. Use this setting only when necessary and ensure appropriate alternative validation mechanisms. |Logged when an issuer configuration has the subject claim marked as optional, which violates RFC 7519 requirements
+|TokenSheriff-132 |JWKS |Invalid Base64 URL encoding detected for JWK field: %s |Logged when Base64 URL encoding validation fails for a JWK field
+|TokenSheriff-133 |JWKS |Background refresh skipped - no HTTP handler available |Logged when background JWKS refresh is skipped because no HTTP handler is available
+|TokenSheriff-134 |JWKS |Background refresh parse error: %s for issuer: %s |Logged when a JSON parsing error occurs during background JWKS refresh for a specific issuer
+|TokenSheriff-135 |ISSUER |Failed to load issuer configuration for %s, status: %s |Logged when issuer configuration loading fails with a specific status
+|TokenSheriff-136 |JWKS |Timeout waiting for JWKS to load for issuer: %s |Logged when JWKS loading times out for a specific issuer
+|TokenSheriff-137 |JWKS |Interrupted while waiting for JWKS to load for issuer: %s |Logged when the thread is interrupted while waiting for JWKS to load
+|TokenSheriff-138 |JWKS |Configured issuer '%s' does not match discovered issuer '%s' from well-known document |Logged when there is a mismatch between configured and discovered issuer from well-known endpoint
+|TokenSheriff-139 |JWKS |Using insecure HTTP protocol for JWKS endpoint: %s - HTTPS should be used in production |Logged when an insecure HTTP protocol is used for JWKS endpoint instead of HTTPS
+|TokenSheriff-140 |JWKS |DSL-JSON returned null for JWKS parsing |Logged when DSL-JSON parser returns null while parsing JWKS content
+|TokenSheriff-141 |JWKS |Failed to parse JWKS content: %s |Logged when JWKS content parsing fails due to IO error or invalid JSON structure
+|TokenSheriff-142 |JWKS |Failed to parse OKP key with ID %s: %s |Logged when OKP (EdDSA) key parsing fails for a specific key ID
+|TokenSheriff-143 |TOKEN |Token type '%s' does not match expected type '%s' |Logged when the JWT typ header does not match the expected token type configured for the issuer (RFC 9068 validation)
+|TokenSheriff-144 |DPOP |DPoP proof is required but the DPoP HTTP header is missing |Logged when a DPoP proof is expected (cnf.jkt present or dpop.required=true) but the DPoP HTTP header is absent
+|TokenSheriff-145 |DPOP |DPoP proof has invalid format: %s |Logged when the DPoP proof JWT cannot be decoded or has structural issues (wrong typ, unsupported algorithm, missing jwk, invalid signature)
+|TokenSheriff-146 |DPOP |DPoP proof iat claim is outside acceptable freshness window |Logged when the DPoP proof iat claim is too old or too far in the future
+|TokenSheriff-147 |DPOP |DPoP proof JWK thumbprint '%s' does not match token cnf.jkt '%s' |Logged when the computed JWK Thumbprint (RFC 7638) of the DPoP proof's public key does not match the cnf.jkt claim in the access token
+|TokenSheriff-148 |DPOP |DPoP proof replay detected for jti: %s |Logged when a DPoP proof with a previously seen jti value is detected (replay attack)
+|TokenSheriff-149 |DPOP |DPoP proof is missing required claim: %s |Logged when the DPoP proof JWT body is missing a required claim (jti, iat, or ath)
+|TokenSheriff-150 |DPOP |DPoP proof ath claim does not match access token hash |Logged when the DPoP proof ath claim (SHA-256 hash of the access token) does not match the actual access token
+|TokenSheriff-151 |DPOP |DPoP is required but access token does not contain cnf.jkt claim |Logged when DPoP validation is required or a DPoP proof is provided but the access token lacks the cnf.jkt claim
+|TokenSheriff-152 |JWE |Failed to decrypt JWE token: %s |Logged when JWE decryption fails due to cryptographic errors (wrong key, tampered content, etc.)
+|TokenSheriff-153 |JWE |Unsupported JWE algorithm: alg=%s, enc=%s |Logged when a JWE token uses an unsupported or rejected algorithm combination
+|TokenSheriff-154 |JWE |Received JWE token but no decryption configuration is available |Logged when a 5-part JWE token is received but no JweDecryptionConfig was configured on TokenValidator
+|TokenSheriff-155 |JWE |No decryption key found for key ID: %s |Logged when the JWE header references a kid that has no matching decryption key and no default key is configured
+|TokenSheriff-156 |JWE |Unsupported JWE compression algorithm: %s |Logged when a JWE token uses an unsupported compression algorithm (only DEF/DEFLATE is supported)
+|TokenSheriff-157 |JWE |Nested JWE tokens are not allowed |Logged when decrypting a JWE token reveals another JWE (5-part) token instead of the expected inner JWS
+|TokenSheriff-158 |Token Age |Token age exceeds maximum allowed age |Logged when a token's `iat` claim indicates it was issued longer ago than the configured `maxTokenAgeSeconds`
+|TokenSheriff-159 |Custom Rule |Custom validation rule rejected token: %s |Logged when a custom `TokenValidationRule` rejects a token by throwing `TokenValidationException`
+|TokenSheriff-160 |JWKS |JWK entry without 'kid' field skipped — kid is required for key identification |Logged when a JWK entry is skipped because it lacks a key ID
+|TokenSheriff-161 |JWKS |RSA JWK without 'alg' field — defaulting to RS256 for key ID: %s |Logged when an RSA JWK lacks an algorithm field and defaults to RS256
+|TokenSheriff-162 |Audience |Access token is missing required audience claim. Expected audience: %s |Logged when an access token is missing the required audience claim
+|TokenSheriff-163 |DPOP |DPoP proof htu claim '%s' does not match request URI '%s' |Logged when the DPoP htu claim doesn't match the actual request URI
+|TokenSheriff-164 |DPOP |DPoP proof htm claim '%s' does not match request method '%s' |Logged when the DPoP htm claim doesn't match the actual request method
+|TokenSheriff-165 |Audience |Audience claim missing but azp claim '%s' matches expected audience — using azp as fallback |Logged when the audience (aud) claim is absent but the azp claim matches the expected audience, falling back to azp for audience validation
+|TokenSheriff-166 |Audience |Access token audience validation skipped (accessTokenAudienceOptional=true). Expected audience: %s |Logged when audience validation is skipped for an access token because accessTokenAudienceOptional is enabled
+|TokenSheriff-167 |Authorized Party |azp claim missing, using client_id claim '%s' for authorized party validation (RFC 9068) |Logged when the azp claim is absent but the client_id claim (per RFC 9068) matches the expected client ID
 |===
 
 == ERROR Level (200-206)
@@ -131,13 +131,13 @@ For more details about security events related to these log messages, see the Se
 [cols="1,1,2,2", options="header"]
 |===
 |ID |Component |Message |Description
-|OAuthSheriff-200 |TOKEN |Failed to validate validation signature: %s |Logged when a token signature validation fails
-|OAuthSheriff-201 |JWKS |JWKS content size exceeds maximum allowed size (upperLimit=%s, actual=%s) |Logged when the JWKS content size exceeds the maximum allowed size, showing both the configured upper limit and the actual content size
-|OAuthSheriff-202 |JWKS |Failed to parse JWKS JSON: %s |Logged when there is an error parsing the JWKS JSON
-|OAuthSheriff-203 |JWKS |Failed to load JWKS |Logged when a JWKS load operation fails
-|OAuthSheriff-204 |WELLKNOWN |Failed to parse JSON from %s: %s |Logged when JSON parsing fails for a well-known discovery document
-|OAuthSheriff-205 |JWKS |JWKS initialization failed: %s for issuer: %s |Logged when JWKS initialization fails for a specific issuer with error details
-|OAuthSheriff-206 |JWKS |JWKS load execution failed: %s for issuer: %s |Logged when JWKS load execution fails for a specific issuer with error details
+|TokenSheriff-200 |TOKEN |Failed to validate validation signature: %s |Logged when a token signature validation fails
+|TokenSheriff-201 |JWKS |JWKS content size exceeds maximum allowed size (upperLimit=%s, actual=%s) |Logged when the JWKS content size exceeds the maximum allowed size, showing both the configured upper limit and the actual content size
+|TokenSheriff-202 |JWKS |Failed to parse JWKS JSON: %s |Logged when there is an error parsing the JWKS JSON
+|TokenSheriff-203 |JWKS |Failed to load JWKS |Logged when a JWKS load operation fails
+|TokenSheriff-204 |WELLKNOWN |Failed to parse JSON from %s: %s |Logged when JSON parsing fails for a well-known discovery document
+|TokenSheriff-205 |JWKS |JWKS initialization failed: %s for issuer: %s |Logged when JWKS initialization fails for a specific issuer with error details
+|TokenSheriff-206 |JWKS |JWKS load execution failed: %s for issuer: %s |Logged when JWKS load execution fails for a specific issuer with error details
 |===
 
 == Quarkus Integration Messages
@@ -149,30 +149,30 @@ This section documents log messages specific to the Quarkus integration module (
 [cols="1,1,2,2", options="header"]
 |===
 |ID |Component |Message |Description
-|OAuthSheriff_Q-001 |CONFIG |Resolving issuer configurations from properties |Indicates the start of issuer configuration resolution from application properties
-|OAuthSheriff_Q-002 |CONFIG |Resolved issuer configuration: %s |Shows a single resolved issuer configuration with its details
-|OAuthSheriff_Q-003 |CONFIG |Resolved %s enabled issuer configurations |Summary count of all enabled issuer configurations found
-|OAuthSheriff_Q-004 |CONFIG |Resolved ParserConfig: maxTokenSize=%s bytes, maxPayloadSize=%s bytes, maxStringLength=%s |Shows the resolved JWT parser configuration limits
-|OAuthSheriff_Q-005 |VALIDATION |Initializing JWT validation components from configuration |Indicates the start of JWT validation component initialization
-|OAuthSheriff_Q-006 |VALIDATION |JWT validation components initialized successfully with %s issuers |Confirms successful initialization with issuer count
-|OAuthSheriff_Q-007 |VALIDATION |Resolving access log filter configuration from properties |Indicates the start of access log filter configuration resolution
-|OAuthSheriff_Q-008 |VALIDATION |Claim mapper registry initialized with %s custom mapper(s): %s |Shows the number of custom claim mappers discovered and their names
-|OAuthSheriff_Q-009 |VALIDATION |No custom claim mappers discovered |Indicates that no custom claim mappers were found during CDI discovery
-|OAuthSheriff_Q-010 |VALIDATION |Token validation rule registry initialized with %s custom rule(s) |Shows the number of custom token validation rules discovered during CDI discovery
-|OAuthSheriff_Q-011 |VALIDATION |No custom token validation rules discovered |Indicates that no custom token validation rules were found during CDI discovery
-|OAuthSheriff_Q-012 |METRICS |Initializing JwtMetricsCollector |Indicates the start of JWT metrics collector initialization
-|OAuthSheriff_Q-013 |METRICS |JwtMetricsCollector initialized with %s event types |Confirms successful initialization with event type count
-|OAuthSheriff_Q-014 |CACHE |Resolving access token cache configuration from properties |Indicates the start of access token cache configuration resolution
-|OAuthSheriff_Q-015 |CACHE |Access token cache disabled (maxSize=0) |Indicates that the access token cache is disabled
-|OAuthSheriff_Q-016 |CACHE |Access token cache configured: maxSize=%s, evictionIntervalSeconds=%s |Shows the configured access token cache settings
-|OAuthSheriff_Q-017 |METRICS |Clearing all JWT metrics |Indicates that all JWT metrics are being cleared
-|OAuthSheriff_Q-018 |METRICS |JWT metrics cleared successfully |Confirms successful clearing of JWT metrics
-|OAuthSheriff_Q-019 |JWE |Resolving JWE decryption configuration from properties |Indicates the start of JWE decryption configuration resolution
-|OAuthSheriff_Q-020 |JWE |JWE decryption configuration resolved with %s key(s) |Shows the number of JWE decryption keys resolved
-|OAuthSheriff_Q-021 |JWE |JWE config check: singleKeyPath=%s, keystorePath=%s, multiKeys=%s |Logs the JWE configuration sources being checked
-|OAuthSheriff_Q-022 |JWE |No JWE decryption configuration found - JWE support disabled |Indicates that no JWE decryption configuration was found
-|OAuthSheriff_Q-023 |ACCESS_LOG |CustomAccessLogFilter initialized: %s |Shows the initialized access log filter configuration
-|OAuthSheriff_Q-024 |ACCESS_LOG |%s |Individual access log entry in the configured format
+|TokenSheriff_Q-001 |CONFIG |Resolving issuer configurations from properties |Indicates the start of issuer configuration resolution from application properties
+|TokenSheriff_Q-002 |CONFIG |Resolved issuer configuration: %s |Shows a single resolved issuer configuration with its details
+|TokenSheriff_Q-003 |CONFIG |Resolved %s enabled issuer configurations |Summary count of all enabled issuer configurations found
+|TokenSheriff_Q-004 |CONFIG |Resolved ParserConfig: maxTokenSize=%s bytes, maxPayloadSize=%s bytes, maxStringLength=%s |Shows the resolved JWT parser configuration limits
+|TokenSheriff_Q-005 |VALIDATION |Initializing JWT validation components from configuration |Indicates the start of JWT validation component initialization
+|TokenSheriff_Q-006 |VALIDATION |JWT validation components initialized successfully with %s issuers |Confirms successful initialization with issuer count
+|TokenSheriff_Q-007 |VALIDATION |Resolving access log filter configuration from properties |Indicates the start of access log filter configuration resolution
+|TokenSheriff_Q-008 |VALIDATION |Claim mapper registry initialized with %s custom mapper(s): %s |Shows the number of custom claim mappers discovered and their names
+|TokenSheriff_Q-009 |VALIDATION |No custom claim mappers discovered |Indicates that no custom claim mappers were found during CDI discovery
+|TokenSheriff_Q-010 |VALIDATION |Token validation rule registry initialized with %s custom rule(s) |Shows the number of custom token validation rules discovered during CDI discovery
+|TokenSheriff_Q-011 |VALIDATION |No custom token validation rules discovered |Indicates that no custom token validation rules were found during CDI discovery
+|TokenSheriff_Q-012 |METRICS |Initializing JwtMetricsCollector |Indicates the start of JWT metrics collector initialization
+|TokenSheriff_Q-013 |METRICS |JwtMetricsCollector initialized with %s event types |Confirms successful initialization with event type count
+|TokenSheriff_Q-014 |CACHE |Resolving access token cache configuration from properties |Indicates the start of access token cache configuration resolution
+|TokenSheriff_Q-015 |CACHE |Access token cache disabled (maxSize=0) |Indicates that the access token cache is disabled
+|TokenSheriff_Q-016 |CACHE |Access token cache configured: maxSize=%s, evictionIntervalSeconds=%s |Shows the configured access token cache settings
+|TokenSheriff_Q-017 |METRICS |Clearing all JWT metrics |Indicates that all JWT metrics are being cleared
+|TokenSheriff_Q-018 |METRICS |JWT metrics cleared successfully |Confirms successful clearing of JWT metrics
+|TokenSheriff_Q-019 |JWE |Resolving JWE decryption configuration from properties |Indicates the start of JWE decryption configuration resolution
+|TokenSheriff_Q-020 |JWE |JWE decryption configuration resolved with %s key(s) |Shows the number of JWE decryption keys resolved
+|TokenSheriff_Q-021 |JWE |JWE config check: singleKeyPath=%s, keystorePath=%s, multiKeys=%s |Logs the JWE configuration sources being checked
+|TokenSheriff_Q-022 |JWE |No JWE decryption configuration found - JWE support disabled |Indicates that no JWE decryption configuration was found
+|TokenSheriff_Q-023 |ACCESS_LOG |CustomAccessLogFilter initialized: %s |Shows the initialized access log filter configuration
+|TokenSheriff_Q-024 |ACCESS_LOG |%s |Individual access log entry in the configured format
 |===
 
 === Quarkus WARN Level (100-104)
@@ -180,11 +180,11 @@ This section documents log messages specific to the Quarkus integration module (
 [cols="1,1,2,2", options="header"]
 |===
 |ID |Component |Message |Description
-|OAuthSheriff_Q-100 |HEALTH |Error checking JWKS loader for issuer %s: %s |Indicates an error occurred while checking JWKS loader status in health check
-|OAuthSheriff_Q-101 |BEARER |Bearer token does not meet requirements. Missing scopes: %s, Missing roles: %s, Missing groups: %s |Details about which requirements are missing from a bearer token
-|OAuthSheriff_Q-102 |BEARER |Bearer token validation failed: %s (eventType=%s) |Token validation failed with a specific event type (e.g., expired, invalid signature)
-|OAuthSheriff_Q-103 |METRICS |No Micrometer counter found for event type %s, delta %s lost |Indicates that a metrics counter was not found and a delta value was lost
-|OAuthSheriff_Q-104 |JWE |JWE keystore configured at %s but no key-alias specified — skipping keystore key loading |Indicates that a JWE keystore was configured but no key alias was specified
+|TokenSheriff_Q-100 |HEALTH |Error checking JWKS loader for issuer %s: %s |Indicates an error occurred while checking JWKS loader status in health check
+|TokenSheriff_Q-101 |BEARER |Bearer token does not meet requirements. Missing scopes: %s, Missing roles: %s, Missing groups: %s |Details about which requirements are missing from a bearer token
+|TokenSheriff_Q-102 |BEARER |Bearer token validation failed: %s (eventType=%s) |Token validation failed with a specific event type (e.g., expired, invalid signature)
+|TokenSheriff_Q-103 |METRICS |No Micrometer counter found for event type %s, delta %s lost |Indicates that a metrics counter was not found and a delta value was lost
+|TokenSheriff_Q-104 |JWE |JWE keystore configured at %s but no key-alias specified — skipping keystore key loading |Indicates that a JWE keystore was configured but no key alias was specified
 |===
 
 === Quarkus ERROR Level (200)
@@ -192,5 +192,5 @@ This section documents log messages specific to the Quarkus integration module (
 [cols="1,1,2,2", options="header"]
 |===
 |ID |Component |Message |Description
-|OAuthSheriff_Q-200 |VERTX |Vertx HttpServerRequest context is unavailable - no active request context found |Indicates that the Vertx HTTP server request context could not be resolved
+|TokenSheriff_Q-200 |VERTX |Vertx HttpServerRequest context is unavailable - no active request context found |Indicates that the Vertx HTTP server request context could not be resolved
 |===

--- a/doc/LogMessages.adoc
+++ b/doc/LogMessages.adoc
@@ -19,7 +19,7 @@ This document provides a reference for all log messages used in the JWT Token Va
 
 === Log Message Format
 
-All messages follow the format: TokenSheriff-[identifier]: [message]
+All messages follow the format: OAuthSheriff-[identifier]: [message]
 
 The log message levels follow these identifier ranges:
 
@@ -40,15 +40,15 @@ For more details about security events related to these log messages, see the Se
 [cols="1,1,2,2", options="header"]
 |===
 |ID |Component |Message |Description
-|TokenSheriff-001 |TOKEN |TokenValidator initialized with %s |Logged when TokenValidator is initialized with issuer configurations
-|TokenSheriff-002 |JWKS |Keys updated due to data change - load state: %s |Logged when JWKS keys are updated due to data changes from the endpoint
-|TokenSheriff-003 |JWKS |Background JWKS refresh started with interval: %s seconds |Logged when background JWKS refresh is started with specified interval
-|TokenSheriff-004 |TOKEN |Skipping disabled issuer configuration %s |Logged when an issuer configuration is skipped because it's disabled
-|TokenSheriff-005 |JWKS |Successfully resolved JWKS URI from well-known endpoint: %s |Logged when JWKS URI is successfully resolved via well-known discovery
-|TokenSheriff-006 |RETRY |Retry operation '%s' completed successfully after %s attempts in %sms |Logged when a retry operation completes successfully with timing information
-|TokenSheriff-007 |JWKS |JWKS loaded successfully for issuer: %s |Logged when JWKS is successfully loaded for a specific issuer
-|TokenSheriff-008 |ISSUER |Issuer configuration loaded successfully: %s |Logged when an issuer configuration is successfully loaded
-|TokenSheriff-009 |JWE |JWE decryption enabled with %s decryption key(s) |Logged when JWE decryption is configured on TokenValidator with the number of available decryption keys
+|OAuthSheriff-001 |TOKEN |TokenValidator initialized with %s |Logged when TokenValidator is initialized with issuer configurations
+|OAuthSheriff-002 |JWKS |Keys updated due to data change - load state: %s |Logged when JWKS keys are updated due to data changes from the endpoint
+|OAuthSheriff-003 |JWKS |Background JWKS refresh started with interval: %s seconds |Logged when background JWKS refresh is started with specified interval
+|OAuthSheriff-004 |TOKEN |Skipping disabled issuer configuration %s |Logged when an issuer configuration is skipped because it's disabled
+|OAuthSheriff-005 |JWKS |Successfully resolved JWKS URI from well-known endpoint: %s |Logged when JWKS URI is successfully resolved via well-known discovery
+|OAuthSheriff-006 |RETRY |Retry operation '%s' completed successfully after %s attempts in %sms |Logged when a retry operation completes successfully with timing information
+|OAuthSheriff-007 |JWKS |JWKS loaded successfully for issuer: %s |Logged when JWKS is successfully loaded for a specific issuer
+|OAuthSheriff-008 |ISSUER |Issuer configuration loaded successfully: %s |Logged when an issuer configuration is successfully loaded
+|OAuthSheriff-009 |JWE |JWE decryption enabled with %s decryption key(s) |Logged when JWE decryption is configured on TokenValidator with the number of available decryption keys
 |===
 
 == WARN Level (100-167)
@@ -56,74 +56,74 @@ For more details about security events related to these log messages, see the Se
 [cols="1,1,2,2", options="header"]
 |===
 |ID |Component |Message |Description
-|TokenSheriff-100 |TOKEN |Token exceeds maximum size limit of %s bytes, validation will be rejected |Logged when a token is rejected due to size constraints
-|TokenSheriff-101 |TOKEN |The given validation was empty, request will be rejected |Logged when an empty or null token is provided
-|TokenSheriff-102 |TOKEN |No key found with ID: %s |Logged when a key with the specified ID cannot be found in the JWKS
-|TokenSheriff-103 |TOKEN |Failed to decode JWT Token |Logged when the JWT token cannot be decoded
-|TokenSheriff-104 |TOKEN |Invalid JWT Token format: expected 3 parts (JWS) or 5 parts (JWE) but got %s |Logged when the JWT token format is invalid
-|TokenSheriff-105 |TOKEN |Decoded part exceeds maximum size limit of %s bytes |Logged when a decoded part of the token exceeds the maximum size limit
-|TokenSheriff-106 |TOKEN |Unsupported algorithm: %s |Logged when an unsupported algorithm is encountered
-|TokenSheriff-107 |TOKEN |Token has a 'not before' claim that is more than 60 seconds in the future |Logged when a token has a 'not before' claim that is too far in the future
-|TokenSheriff-108 |TOKEN |Unknown token type: %s |Logged when an unknown token type is encountered
-|TokenSheriff-109 |TOKEN |Token is missing required claim: %s |Logged when a token is missing a required claim
-|TokenSheriff-110 |TOKEN |Token has expired |Logged when a token has expired
-|TokenSheriff-111 |TOKEN |Token authorized party '%s' does not match expected client ID '%s' |Logged when the azp claim in the token does not match the expected client ID
-|TokenSheriff-112 |TOKEN |Missing recommended element: %s |Logged when a recommended element is missing from the token
-|TokenSheriff-113 |TOKEN |Token audience %s does not match any of the expected audiences %s |Logged when the audience in the token does not match any of the expected audiences
-|TokenSheriff-114 |TOKEN |No configuration found for issuer: %s |Logged when no configuration is found for the issuer
-|TokenSheriff-115 |TOKEN |Algorithm %s is explicitly rejected for security reasons |Logged when an algorithm is explicitly rejected for security reasons
-|TokenSheriff-116 |JWKS |Creating HttpJwksLoaderConfig with invalid JWKS URI. The loader will return empty results. |Logged when an invalid JWKS URI is provided to HttpJwksLoaderConfig
-|TokenSheriff-117 |JWKS |JWK is missing required field 'kty' |Logged when a JWK key is missing the required 'kty' parameter
-|TokenSheriff-118 |JWKS |Unsupported key type: %s |Logged when an unsupported JWK key type is encountered
-|TokenSheriff-119 |JWKS |Key ID exceeds maximum length: %s |Logged when a JWK key ID exceeds the maximum allowed length
-|TokenSheriff-120 |JWKS |Invalid or unsupported algorithm: %s |Logged when an invalid or unsupported algorithm is encountered in a JWK
-|TokenSheriff-121 |TOKEN |Found unhealthy issuer config: %s |Logged when an issuer configuration is found to be unhealthy during health checks
-|TokenSheriff-122 |JWKS |Background JWKS refresh failed: %s |Logged when background JWKS refresh operation fails
-|TokenSheriff-123 |JWKS |Failed to resolve JWKS URI from well-known resolver |Logged when JWKS URI resolution fails from well-known discovery
-|TokenSheriff-124 |JWKS |JWKS object is null |Logged when JWKS object validation fails due to null object
-|TokenSheriff-125 |JWKS |JWKS keys array exceeds maximum size: %s |Logged when JWKS keys array exceeds the maximum allowed size
-|TokenSheriff-126 |JWKS |JWKS keys array is empty |Logged when JWKS keys array is empty
-|TokenSheriff-127 |JWKS |Failed to parse RSA key with ID %s: %s |Logged when RSA key parsing fails for a specific key ID
-|TokenSheriff-128 |JWKS |Failed to parse EC key with ID %s: %s |Logged when EC key parsing fails for a specific key ID
-|TokenSheriff-129 |RETRY |Retry operation '%s' failed after %s attempts in %sms |Logged when a retry operation fails after exhausting all attempts
-|TokenSheriff-130 |JSON |Failed to parse JWKS JSON: %s |Logged when JSON parsing fails for JWKS content and an empty result is returned as fallback
-|TokenSheriff-131 |ISSUER |IssuerConfig for issuer '%s' has claimSubOptional=true. This is not conform to RFC 7519 which requires the 'sub' claim for ACCESS_TOKEN and ID_TOKEN types. Use this setting only when necessary and ensure appropriate alternative validation mechanisms. |Logged when an issuer configuration has the subject claim marked as optional, which violates RFC 7519 requirements
-|TokenSheriff-132 |JWKS |Invalid Base64 URL encoding detected for JWK field: %s |Logged when Base64 URL encoding validation fails for a JWK field
-|TokenSheriff-133 |JWKS |Background refresh skipped - no HTTP handler available |Logged when background JWKS refresh is skipped because no HTTP handler is available
-|TokenSheriff-134 |JWKS |Background refresh parse error: %s for issuer: %s |Logged when a JSON parsing error occurs during background JWKS refresh for a specific issuer
-|TokenSheriff-135 |ISSUER |Failed to load issuer configuration for %s, status: %s |Logged when issuer configuration loading fails with a specific status
-|TokenSheriff-136 |JWKS |Timeout waiting for JWKS to load for issuer: %s |Logged when JWKS loading times out for a specific issuer
-|TokenSheriff-137 |JWKS |Interrupted while waiting for JWKS to load for issuer: %s |Logged when the thread is interrupted while waiting for JWKS to load
-|TokenSheriff-138 |JWKS |Configured issuer '%s' does not match discovered issuer '%s' from well-known document |Logged when there is a mismatch between configured and discovered issuer from well-known endpoint
-|TokenSheriff-139 |JWKS |Using insecure HTTP protocol for JWKS endpoint: %s - HTTPS should be used in production |Logged when an insecure HTTP protocol is used for JWKS endpoint instead of HTTPS
-|TokenSheriff-140 |JWKS |DSL-JSON returned null for JWKS parsing |Logged when DSL-JSON parser returns null while parsing JWKS content
-|TokenSheriff-141 |JWKS |Failed to parse JWKS content: %s |Logged when JWKS content parsing fails due to IO error or invalid JSON structure
-|TokenSheriff-142 |JWKS |Failed to parse OKP key with ID %s: %s |Logged when OKP (EdDSA) key parsing fails for a specific key ID
-|TokenSheriff-143 |TOKEN |Token type '%s' does not match expected type '%s' |Logged when the JWT typ header does not match the expected token type configured for the issuer (RFC 9068 validation)
-|TokenSheriff-144 |DPOP |DPoP proof is required but the DPoP HTTP header is missing |Logged when a DPoP proof is expected (cnf.jkt present or dpop.required=true) but the DPoP HTTP header is absent
-|TokenSheriff-145 |DPOP |DPoP proof has invalid format: %s |Logged when the DPoP proof JWT cannot be decoded or has structural issues (wrong typ, unsupported algorithm, missing jwk, invalid signature)
-|TokenSheriff-146 |DPOP |DPoP proof iat claim is outside acceptable freshness window |Logged when the DPoP proof iat claim is too old or too far in the future
-|TokenSheriff-147 |DPOP |DPoP proof JWK thumbprint '%s' does not match token cnf.jkt '%s' |Logged when the computed JWK Thumbprint (RFC 7638) of the DPoP proof's public key does not match the cnf.jkt claim in the access token
-|TokenSheriff-148 |DPOP |DPoP proof replay detected for jti: %s |Logged when a DPoP proof with a previously seen jti value is detected (replay attack)
-|TokenSheriff-149 |DPOP |DPoP proof is missing required claim: %s |Logged when the DPoP proof JWT body is missing a required claim (jti, iat, or ath)
-|TokenSheriff-150 |DPOP |DPoP proof ath claim does not match access token hash |Logged when the DPoP proof ath claim (SHA-256 hash of the access token) does not match the actual access token
-|TokenSheriff-151 |DPOP |DPoP is required but access token does not contain cnf.jkt claim |Logged when DPoP validation is required or a DPoP proof is provided but the access token lacks the cnf.jkt claim
-|TokenSheriff-152 |JWE |Failed to decrypt JWE token: %s |Logged when JWE decryption fails due to cryptographic errors (wrong key, tampered content, etc.)
-|TokenSheriff-153 |JWE |Unsupported JWE algorithm: alg=%s, enc=%s |Logged when a JWE token uses an unsupported or rejected algorithm combination
-|TokenSheriff-154 |JWE |Received JWE token but no decryption configuration is available |Logged when a 5-part JWE token is received but no JweDecryptionConfig was configured on TokenValidator
-|TokenSheriff-155 |JWE |No decryption key found for key ID: %s |Logged when the JWE header references a kid that has no matching decryption key and no default key is configured
-|TokenSheriff-156 |JWE |Unsupported JWE compression algorithm: %s |Logged when a JWE token uses an unsupported compression algorithm (only DEF/DEFLATE is supported)
-|TokenSheriff-157 |JWE |Nested JWE tokens are not allowed |Logged when decrypting a JWE token reveals another JWE (5-part) token instead of the expected inner JWS
-|TokenSheriff-158 |Token Age |Token age exceeds maximum allowed age |Logged when a token's `iat` claim indicates it was issued longer ago than the configured `maxTokenAgeSeconds`
-|TokenSheriff-159 |Custom Rule |Custom validation rule rejected token: %s |Logged when a custom `TokenValidationRule` rejects a token by throwing `TokenValidationException`
-|TokenSheriff-160 |JWKS |JWK entry without 'kid' field skipped — kid is required for key identification |Logged when a JWK entry is skipped because it lacks a key ID
-|TokenSheriff-161 |JWKS |RSA JWK without 'alg' field — defaulting to RS256 for key ID: %s |Logged when an RSA JWK lacks an algorithm field and defaults to RS256
-|TokenSheriff-162 |Audience |Access token is missing required audience claim. Expected audience: %s |Logged when an access token is missing the required audience claim
-|TokenSheriff-163 |DPOP |DPoP proof htu claim '%s' does not match request URI '%s' |Logged when the DPoP htu claim doesn't match the actual request URI
-|TokenSheriff-164 |DPOP |DPoP proof htm claim '%s' does not match request method '%s' |Logged when the DPoP htm claim doesn't match the actual request method
-|TokenSheriff-165 |Audience |Audience claim missing but azp claim '%s' matches expected audience — using azp as fallback |Logged when the audience (aud) claim is absent but the azp claim matches the expected audience, falling back to azp for audience validation
-|TokenSheriff-166 |Audience |Access token audience validation skipped (accessTokenAudienceOptional=true). Expected audience: %s |Logged when audience validation is skipped for an access token because accessTokenAudienceOptional is enabled
-|TokenSheriff-167 |Authorized Party |azp claim missing, using client_id claim '%s' for authorized party validation (RFC 9068) |Logged when the azp claim is absent but the client_id claim (per RFC 9068) matches the expected client ID
+|OAuthSheriff-100 |TOKEN |Token exceeds maximum size limit of %s bytes, validation will be rejected |Logged when a token is rejected due to size constraints
+|OAuthSheriff-101 |TOKEN |The given validation was empty, request will be rejected |Logged when an empty or null token is provided
+|OAuthSheriff-102 |TOKEN |No key found with ID: %s |Logged when a key with the specified ID cannot be found in the JWKS
+|OAuthSheriff-103 |TOKEN |Failed to decode JWT Token |Logged when the JWT token cannot be decoded
+|OAuthSheriff-104 |TOKEN |Invalid JWT Token format: expected 3 parts (JWS) or 5 parts (JWE) but got %s |Logged when the JWT token format is invalid
+|OAuthSheriff-105 |TOKEN |Decoded part exceeds maximum size limit of %s bytes |Logged when a decoded part of the token exceeds the maximum size limit
+|OAuthSheriff-106 |TOKEN |Unsupported algorithm: %s |Logged when an unsupported algorithm is encountered
+|OAuthSheriff-107 |TOKEN |Token has a 'not before' claim that is more than 60 seconds in the future |Logged when a token has a 'not before' claim that is too far in the future
+|OAuthSheriff-108 |TOKEN |Unknown token type: %s |Logged when an unknown token type is encountered
+|OAuthSheriff-109 |TOKEN |Token is missing required claim: %s |Logged when a token is missing a required claim
+|OAuthSheriff-110 |TOKEN |Token has expired |Logged when a token has expired
+|OAuthSheriff-111 |TOKEN |Token authorized party '%s' does not match expected client ID '%s' |Logged when the azp claim in the token does not match the expected client ID
+|OAuthSheriff-112 |TOKEN |Missing recommended element: %s |Logged when a recommended element is missing from the token
+|OAuthSheriff-113 |TOKEN |Token audience %s does not match any of the expected audiences %s |Logged when the audience in the token does not match any of the expected audiences
+|OAuthSheriff-114 |TOKEN |No configuration found for issuer: %s |Logged when no configuration is found for the issuer
+|OAuthSheriff-115 |TOKEN |Algorithm %s is explicitly rejected for security reasons |Logged when an algorithm is explicitly rejected for security reasons
+|OAuthSheriff-116 |JWKS |Creating HttpJwksLoaderConfig with invalid JWKS URI. The loader will return empty results. |Logged when an invalid JWKS URI is provided to HttpJwksLoaderConfig
+|OAuthSheriff-117 |JWKS |JWK is missing required field 'kty' |Logged when a JWK key is missing the required 'kty' parameter
+|OAuthSheriff-118 |JWKS |Unsupported key type: %s |Logged when an unsupported JWK key type is encountered
+|OAuthSheriff-119 |JWKS |Key ID exceeds maximum length: %s |Logged when a JWK key ID exceeds the maximum allowed length
+|OAuthSheriff-120 |JWKS |Invalid or unsupported algorithm: %s |Logged when an invalid or unsupported algorithm is encountered in a JWK
+|OAuthSheriff-121 |TOKEN |Found unhealthy issuer config: %s |Logged when an issuer configuration is found to be unhealthy during health checks
+|OAuthSheriff-122 |JWKS |Background JWKS refresh failed: %s |Logged when background JWKS refresh operation fails
+|OAuthSheriff-123 |JWKS |Failed to resolve JWKS URI from well-known resolver |Logged when JWKS URI resolution fails from well-known discovery
+|OAuthSheriff-124 |JWKS |JWKS object is null |Logged when JWKS object validation fails due to null object
+|OAuthSheriff-125 |JWKS |JWKS keys array exceeds maximum size: %s |Logged when JWKS keys array exceeds the maximum allowed size
+|OAuthSheriff-126 |JWKS |JWKS keys array is empty |Logged when JWKS keys array is empty
+|OAuthSheriff-127 |JWKS |Failed to parse RSA key with ID %s: %s |Logged when RSA key parsing fails for a specific key ID
+|OAuthSheriff-128 |JWKS |Failed to parse EC key with ID %s: %s |Logged when EC key parsing fails for a specific key ID
+|OAuthSheriff-129 |RETRY |Retry operation '%s' failed after %s attempts in %sms |Logged when a retry operation fails after exhausting all attempts
+|OAuthSheriff-130 |JSON |Failed to parse JWKS JSON: %s |Logged when JSON parsing fails for JWKS content and an empty result is returned as fallback
+|OAuthSheriff-131 |ISSUER |IssuerConfig for issuer '%s' has claimSubOptional=true. This is not conform to RFC 7519 which requires the 'sub' claim for ACCESS_TOKEN and ID_TOKEN types. Use this setting only when necessary and ensure appropriate alternative validation mechanisms. |Logged when an issuer configuration has the subject claim marked as optional, which violates RFC 7519 requirements
+|OAuthSheriff-132 |JWKS |Invalid Base64 URL encoding detected for JWK field: %s |Logged when Base64 URL encoding validation fails for a JWK field
+|OAuthSheriff-133 |JWKS |Background refresh skipped - no HTTP handler available |Logged when background JWKS refresh is skipped because no HTTP handler is available
+|OAuthSheriff-134 |JWKS |Background refresh parse error: %s for issuer: %s |Logged when a JSON parsing error occurs during background JWKS refresh for a specific issuer
+|OAuthSheriff-135 |ISSUER |Failed to load issuer configuration for %s, status: %s |Logged when issuer configuration loading fails with a specific status
+|OAuthSheriff-136 |JWKS |Timeout waiting for JWKS to load for issuer: %s |Logged when JWKS loading times out for a specific issuer
+|OAuthSheriff-137 |JWKS |Interrupted while waiting for JWKS to load for issuer: %s |Logged when the thread is interrupted while waiting for JWKS to load
+|OAuthSheriff-138 |JWKS |Configured issuer '%s' does not match discovered issuer '%s' from well-known document |Logged when there is a mismatch between configured and discovered issuer from well-known endpoint
+|OAuthSheriff-139 |JWKS |Using insecure HTTP protocol for JWKS endpoint: %s - HTTPS should be used in production |Logged when an insecure HTTP protocol is used for JWKS endpoint instead of HTTPS
+|OAuthSheriff-140 |JWKS |DSL-JSON returned null for JWKS parsing |Logged when DSL-JSON parser returns null while parsing JWKS content
+|OAuthSheriff-141 |JWKS |Failed to parse JWKS content: %s |Logged when JWKS content parsing fails due to IO error or invalid JSON structure
+|OAuthSheriff-142 |JWKS |Failed to parse OKP key with ID %s: %s |Logged when OKP (EdDSA) key parsing fails for a specific key ID
+|OAuthSheriff-143 |TOKEN |Token type '%s' does not match expected type '%s' |Logged when the JWT typ header does not match the expected token type configured for the issuer (RFC 9068 validation)
+|OAuthSheriff-144 |DPOP |DPoP proof is required but the DPoP HTTP header is missing |Logged when a DPoP proof is expected (cnf.jkt present or dpop.required=true) but the DPoP HTTP header is absent
+|OAuthSheriff-145 |DPOP |DPoP proof has invalid format: %s |Logged when the DPoP proof JWT cannot be decoded or has structural issues (wrong typ, unsupported algorithm, missing jwk, invalid signature)
+|OAuthSheriff-146 |DPOP |DPoP proof iat claim is outside acceptable freshness window |Logged when the DPoP proof iat claim is too old or too far in the future
+|OAuthSheriff-147 |DPOP |DPoP proof JWK thumbprint '%s' does not match token cnf.jkt '%s' |Logged when the computed JWK Thumbprint (RFC 7638) of the DPoP proof's public key does not match the cnf.jkt claim in the access token
+|OAuthSheriff-148 |DPOP |DPoP proof replay detected for jti: %s |Logged when a DPoP proof with a previously seen jti value is detected (replay attack)
+|OAuthSheriff-149 |DPOP |DPoP proof is missing required claim: %s |Logged when the DPoP proof JWT body is missing a required claim (jti, iat, or ath)
+|OAuthSheriff-150 |DPOP |DPoP proof ath claim does not match access token hash |Logged when the DPoP proof ath claim (SHA-256 hash of the access token) does not match the actual access token
+|OAuthSheriff-151 |DPOP |DPoP is required but access token does not contain cnf.jkt claim |Logged when DPoP validation is required or a DPoP proof is provided but the access token lacks the cnf.jkt claim
+|OAuthSheriff-152 |JWE |Failed to decrypt JWE token: %s |Logged when JWE decryption fails due to cryptographic errors (wrong key, tampered content, etc.)
+|OAuthSheriff-153 |JWE |Unsupported JWE algorithm: alg=%s, enc=%s |Logged when a JWE token uses an unsupported or rejected algorithm combination
+|OAuthSheriff-154 |JWE |Received JWE token but no decryption configuration is available |Logged when a 5-part JWE token is received but no JweDecryptionConfig was configured on TokenValidator
+|OAuthSheriff-155 |JWE |No decryption key found for key ID: %s |Logged when the JWE header references a kid that has no matching decryption key and no default key is configured
+|OAuthSheriff-156 |JWE |Unsupported JWE compression algorithm: %s |Logged when a JWE token uses an unsupported compression algorithm (only DEF/DEFLATE is supported)
+|OAuthSheriff-157 |JWE |Nested JWE tokens are not allowed |Logged when decrypting a JWE token reveals another JWE (5-part) token instead of the expected inner JWS
+|OAuthSheriff-158 |Token Age |Token age exceeds maximum allowed age |Logged when a token's `iat` claim indicates it was issued longer ago than the configured `maxTokenAgeSeconds`
+|OAuthSheriff-159 |Custom Rule |Custom validation rule rejected token: %s |Logged when a custom `TokenValidationRule` rejects a token by throwing `TokenValidationException`
+|OAuthSheriff-160 |JWKS |JWK entry without 'kid' field skipped — kid is required for key identification |Logged when a JWK entry is skipped because it lacks a key ID
+|OAuthSheriff-161 |JWKS |RSA JWK without 'alg' field — defaulting to RS256 for key ID: %s |Logged when an RSA JWK lacks an algorithm field and defaults to RS256
+|OAuthSheriff-162 |Audience |Access token is missing required audience claim. Expected audience: %s |Logged when an access token is missing the required audience claim
+|OAuthSheriff-163 |DPOP |DPoP proof htu claim '%s' does not match request URI '%s' |Logged when the DPoP htu claim doesn't match the actual request URI
+|OAuthSheriff-164 |DPOP |DPoP proof htm claim '%s' does not match request method '%s' |Logged when the DPoP htm claim doesn't match the actual request method
+|OAuthSheriff-165 |Audience |Audience claim missing but azp claim '%s' matches expected audience — using azp as fallback |Logged when the audience (aud) claim is absent but the azp claim matches the expected audience, falling back to azp for audience validation
+|OAuthSheriff-166 |Audience |Access token audience validation skipped (accessTokenAudienceOptional=true). Expected audience: %s |Logged when audience validation is skipped for an access token because accessTokenAudienceOptional is enabled
+|OAuthSheriff-167 |Authorized Party |azp claim missing, using client_id claim '%s' for authorized party validation (RFC 9068) |Logged when the azp claim is absent but the client_id claim (per RFC 9068) matches the expected client ID
 |===
 
 == ERROR Level (200-206)
@@ -131,13 +131,13 @@ For more details about security events related to these log messages, see the Se
 [cols="1,1,2,2", options="header"]
 |===
 |ID |Component |Message |Description
-|TokenSheriff-200 |TOKEN |Failed to validate validation signature: %s |Logged when a token signature validation fails
-|TokenSheriff-201 |JWKS |JWKS content size exceeds maximum allowed size (upperLimit=%s, actual=%s) |Logged when the JWKS content size exceeds the maximum allowed size, showing both the configured upper limit and the actual content size
-|TokenSheriff-202 |JWKS |Failed to parse JWKS JSON: %s |Logged when there is an error parsing the JWKS JSON
-|TokenSheriff-203 |JWKS |Failed to load JWKS |Logged when a JWKS load operation fails
-|TokenSheriff-204 |WELLKNOWN |Failed to parse JSON from %s: %s |Logged when JSON parsing fails for a well-known discovery document
-|TokenSheriff-205 |JWKS |JWKS initialization failed: %s for issuer: %s |Logged when JWKS initialization fails for a specific issuer with error details
-|TokenSheriff-206 |JWKS |JWKS load execution failed: %s for issuer: %s |Logged when JWKS load execution fails for a specific issuer with error details
+|OAuthSheriff-200 |TOKEN |Failed to validate validation signature: %s |Logged when a token signature validation fails
+|OAuthSheriff-201 |JWKS |JWKS content size exceeds maximum allowed size (upperLimit=%s, actual=%s) |Logged when the JWKS content size exceeds the maximum allowed size, showing both the configured upper limit and the actual content size
+|OAuthSheriff-202 |JWKS |Failed to parse JWKS JSON: %s |Logged when there is an error parsing the JWKS JSON
+|OAuthSheriff-203 |JWKS |Failed to load JWKS |Logged when a JWKS load operation fails
+|OAuthSheriff-204 |WELLKNOWN |Failed to parse JSON from %s: %s |Logged when JSON parsing fails for a well-known discovery document
+|OAuthSheriff-205 |JWKS |JWKS initialization failed: %s for issuer: %s |Logged when JWKS initialization fails for a specific issuer with error details
+|OAuthSheriff-206 |JWKS |JWKS load execution failed: %s for issuer: %s |Logged when JWKS load execution fails for a specific issuer with error details
 |===
 
 == Quarkus Integration Messages
@@ -149,30 +149,30 @@ This section documents log messages specific to the Quarkus integration module (
 [cols="1,1,2,2", options="header"]
 |===
 |ID |Component |Message |Description
-|TokenSheriff_Q-001 |CONFIG |Resolving issuer configurations from properties |Indicates the start of issuer configuration resolution from application properties
-|TokenSheriff_Q-002 |CONFIG |Resolved issuer configuration: %s |Shows a single resolved issuer configuration with its details
-|TokenSheriff_Q-003 |CONFIG |Resolved %s enabled issuer configurations |Summary count of all enabled issuer configurations found
-|TokenSheriff_Q-004 |CONFIG |Resolved ParserConfig: maxTokenSize=%s bytes, maxPayloadSize=%s bytes, maxStringLength=%s |Shows the resolved JWT parser configuration limits
-|TokenSheriff_Q-005 |VALIDATION |Initializing JWT validation components from configuration |Indicates the start of JWT validation component initialization
-|TokenSheriff_Q-006 |VALIDATION |JWT validation components initialized successfully with %s issuers |Confirms successful initialization with issuer count
-|TokenSheriff_Q-007 |VALIDATION |Resolving access log filter configuration from properties |Indicates the start of access log filter configuration resolution
-|TokenSheriff_Q-008 |VALIDATION |Claim mapper registry initialized with %s custom mapper(s): %s |Shows the number of custom claim mappers discovered and their names
-|TokenSheriff_Q-009 |VALIDATION |No custom claim mappers discovered |Indicates that no custom claim mappers were found during CDI discovery
-|TokenSheriff_Q-010 |VALIDATION |Token validation rule registry initialized with %s custom rule(s) |Shows the number of custom token validation rules discovered during CDI discovery
-|TokenSheriff_Q-011 |VALIDATION |No custom token validation rules discovered |Indicates that no custom token validation rules were found during CDI discovery
-|TokenSheriff_Q-012 |METRICS |Initializing JwtMetricsCollector |Indicates the start of JWT metrics collector initialization
-|TokenSheriff_Q-013 |METRICS |JwtMetricsCollector initialized with %s event types |Confirms successful initialization with event type count
-|TokenSheriff_Q-014 |CACHE |Resolving access token cache configuration from properties |Indicates the start of access token cache configuration resolution
-|TokenSheriff_Q-015 |CACHE |Access token cache disabled (maxSize=0) |Indicates that the access token cache is disabled
-|TokenSheriff_Q-016 |CACHE |Access token cache configured: maxSize=%s, evictionIntervalSeconds=%s |Shows the configured access token cache settings
-|TokenSheriff_Q-017 |METRICS |Clearing all JWT metrics |Indicates that all JWT metrics are being cleared
-|TokenSheriff_Q-018 |METRICS |JWT metrics cleared successfully |Confirms successful clearing of JWT metrics
-|TokenSheriff_Q-019 |JWE |Resolving JWE decryption configuration from properties |Indicates the start of JWE decryption configuration resolution
-|TokenSheriff_Q-020 |JWE |JWE decryption configuration resolved with %s key(s) |Shows the number of JWE decryption keys resolved
-|TokenSheriff_Q-021 |JWE |JWE config check: singleKeyPath=%s, keystorePath=%s, multiKeys=%s |Logs the JWE configuration sources being checked
-|TokenSheriff_Q-022 |JWE |No JWE decryption configuration found - JWE support disabled |Indicates that no JWE decryption configuration was found
-|TokenSheriff_Q-023 |ACCESS_LOG |CustomAccessLogFilter initialized: %s |Shows the initialized access log filter configuration
-|TokenSheriff_Q-024 |ACCESS_LOG |%s |Individual access log entry in the configured format
+|OAuthSheriff_Q-001 |CONFIG |Resolving issuer configurations from properties |Indicates the start of issuer configuration resolution from application properties
+|OAuthSheriff_Q-002 |CONFIG |Resolved issuer configuration: %s |Shows a single resolved issuer configuration with its details
+|OAuthSheriff_Q-003 |CONFIG |Resolved %s enabled issuer configurations |Summary count of all enabled issuer configurations found
+|OAuthSheriff_Q-004 |CONFIG |Resolved ParserConfig: maxTokenSize=%s bytes, maxPayloadSize=%s bytes, maxStringLength=%s |Shows the resolved JWT parser configuration limits
+|OAuthSheriff_Q-005 |VALIDATION |Initializing JWT validation components from configuration |Indicates the start of JWT validation component initialization
+|OAuthSheriff_Q-006 |VALIDATION |JWT validation components initialized successfully with %s issuers |Confirms successful initialization with issuer count
+|OAuthSheriff_Q-007 |VALIDATION |Resolving access log filter configuration from properties |Indicates the start of access log filter configuration resolution
+|OAuthSheriff_Q-008 |VALIDATION |Claim mapper registry initialized with %s custom mapper(s): %s |Shows the number of custom claim mappers discovered and their names
+|OAuthSheriff_Q-009 |VALIDATION |No custom claim mappers discovered |Indicates that no custom claim mappers were found during CDI discovery
+|OAuthSheriff_Q-010 |VALIDATION |Token validation rule registry initialized with %s custom rule(s) |Shows the number of custom token validation rules discovered during CDI discovery
+|OAuthSheriff_Q-011 |VALIDATION |No custom token validation rules discovered |Indicates that no custom token validation rules were found during CDI discovery
+|OAuthSheriff_Q-012 |METRICS |Initializing JwtMetricsCollector |Indicates the start of JWT metrics collector initialization
+|OAuthSheriff_Q-013 |METRICS |JwtMetricsCollector initialized with %s event types |Confirms successful initialization with event type count
+|OAuthSheriff_Q-014 |CACHE |Resolving access token cache configuration from properties |Indicates the start of access token cache configuration resolution
+|OAuthSheriff_Q-015 |CACHE |Access token cache disabled (maxSize=0) |Indicates that the access token cache is disabled
+|OAuthSheriff_Q-016 |CACHE |Access token cache configured: maxSize=%s, evictionIntervalSeconds=%s |Shows the configured access token cache settings
+|OAuthSheriff_Q-017 |METRICS |Clearing all JWT metrics |Indicates that all JWT metrics are being cleared
+|OAuthSheriff_Q-018 |METRICS |JWT metrics cleared successfully |Confirms successful clearing of JWT metrics
+|OAuthSheriff_Q-019 |JWE |Resolving JWE decryption configuration from properties |Indicates the start of JWE decryption configuration resolution
+|OAuthSheriff_Q-020 |JWE |JWE decryption configuration resolved with %s key(s) |Shows the number of JWE decryption keys resolved
+|OAuthSheriff_Q-021 |JWE |JWE config check: singleKeyPath=%s, keystorePath=%s, multiKeys=%s |Logs the JWE configuration sources being checked
+|OAuthSheriff_Q-022 |JWE |No JWE decryption configuration found - JWE support disabled |Indicates that no JWE decryption configuration was found
+|OAuthSheriff_Q-023 |ACCESS_LOG |CustomAccessLogFilter initialized: %s |Shows the initialized access log filter configuration
+|OAuthSheriff_Q-024 |ACCESS_LOG |%s |Individual access log entry in the configured format
 |===
 
 === Quarkus WARN Level (100-104)
@@ -180,11 +180,11 @@ This section documents log messages specific to the Quarkus integration module (
 [cols="1,1,2,2", options="header"]
 |===
 |ID |Component |Message |Description
-|TokenSheriff_Q-100 |HEALTH |Error checking JWKS loader for issuer %s: %s |Indicates an error occurred while checking JWKS loader status in health check
-|TokenSheriff_Q-101 |BEARER |Bearer token does not meet requirements. Missing scopes: %s, Missing roles: %s, Missing groups: %s |Details about which requirements are missing from a bearer token
-|TokenSheriff_Q-102 |BEARER |Bearer token validation failed: %s (eventType=%s) |Token validation failed with a specific event type (e.g., expired, invalid signature)
-|TokenSheriff_Q-103 |METRICS |No Micrometer counter found for event type %s, delta %s lost |Indicates that a metrics counter was not found and a delta value was lost
-|TokenSheriff_Q-104 |JWE |JWE keystore configured at %s but no key-alias specified — skipping keystore key loading |Indicates that a JWE keystore was configured but no key alias was specified
+|OAuthSheriff_Q-100 |HEALTH |Error checking JWKS loader for issuer %s: %s |Indicates an error occurred while checking JWKS loader status in health check
+|OAuthSheriff_Q-101 |BEARER |Bearer token does not meet requirements. Missing scopes: %s, Missing roles: %s, Missing groups: %s |Details about which requirements are missing from a bearer token
+|OAuthSheriff_Q-102 |BEARER |Bearer token validation failed: %s (eventType=%s) |Token validation failed with a specific event type (e.g., expired, invalid signature)
+|OAuthSheriff_Q-103 |METRICS |No Micrometer counter found for event type %s, delta %s lost |Indicates that a metrics counter was not found and a delta value was lost
+|OAuthSheriff_Q-104 |JWE |JWE keystore configured at %s but no key-alias specified — skipping keystore key loading |Indicates that a JWE keystore was configured but no key alias was specified
 |===
 
 === Quarkus ERROR Level (200)
@@ -192,5 +192,5 @@ This section documents log messages specific to the Quarkus integration module (
 [cols="1,1,2,2", options="header"]
 |===
 |ID |Component |Message |Description
-|TokenSheriff_Q-200 |VERTX |Vertx HttpServerRequest context is unavailable - no active request context found |Indicates that the Vertx HTTP server request context could not be resolved
+|OAuthSheriff_Q-200 |VERTX |Vertx HttpServerRequest context is unavailable - no active request context found |Indicates that the Vertx HTTP server request context could not be resolved
 |===

--- a/doc/README.adoc
+++ b/doc/README.adoc
@@ -1,7 +1,7 @@
 = Documentation Hub
 :sectnums:
 
-This is the central navigation for OAuthSheriff documentation.
+This is the central navigation for TokenSheriff documentation.
 
 == Core
 

--- a/doc/Requirements.adoc
+++ b/doc/Requirements.adoc
@@ -36,11 +36,11 @@ The following standards and specifications are referenced in this document:
 
 == OAuth 2.1 Compatibility
 
-OAuthSheriff is a **resource server token validation library**. It validates JWT tokens passed as strings and does not handle authorization flows, token issuance, redirect URIs, or HTTP transport.
+TokenSheriff is a **resource server token validation library**. It validates JWT tokens passed as strings and does not handle authorization flows, token issuance, redirect URIs, or HTTP transport.
 
-The major changes in https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1[OAuth 2.1] (mandatory PKCE, removal of implicit and ROPC grants, exact redirect URI matching, refresh token rotation) target **authorization servers and clients**, not resource servers. **Tokens issued by OAuth 2.1 compliant servers validate correctly with OAuthSheriff as-is**, since OAuth 2.1 does not change the JWT structure or introduce new mandatory claims for access tokens.
+The major changes in https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1[OAuth 2.1] (mandatory PKCE, removal of implicit and ROPC grants, exact redirect URI matching, refresh token rotation) target **authorization servers and clients**, not resource servers. **Tokens issued by OAuth 2.1 compliant servers validate correctly with TokenSheriff as-is**, since OAuth 2.1 does not change the JWT structure or introduce new mandatory claims for access tokens.
 
-OAuthSheriff already satisfies the OAuth 2.1 resource server requirements:
+TokenSheriff already satisfies the OAuth 2.1 resource server requirements:
 
 * **Scope enforcement** - `scope` claim accessible via `AccessTokenContent.getScopes()` for application-level validation; enforced declaratively via Quarkus `@BearerAuth`
 * **Audience validation** - Supported via `expected-audience` configuration; mandatory for ID tokens

--- a/doc/architecture.adoc
+++ b/doc/architecture.adoc
@@ -6,7 +6,7 @@
 
 == Overview
 
-OAuth-Sheriff validates JWT tokens through a multi-stage pipeline. This document describes the core components, their interactions, and key design decisions.
+Token-Sheriff validates JWT tokens through a multi-stage pipeline. This document describes the core components, their interactions, and key design decisions.
 
 image::plantuml/component-overview.png[Component Overview]
 

--- a/doc/faq/keycloak.adoc
+++ b/doc/faq/keycloak.adoc
@@ -21,7 +21,7 @@ Common issues and solutions when integrating the Token-Sheriff library with Keyc
 
 === Problem: Missing 'sub' Claim
 
-*Warning:* `TokenSheriff-109: Token is missing required claim: sub`
+*Warning:* `OAuthSheriff-109: Token is missing required claim: sub`
 
 *Cause:* Some Keycloak configurations or custom client scopes may exclude the `sub` claim from access tokens. While Keycloak includes `sub` by default, certain service account configurations or custom protocol mappers can remove it. The `sub` claim is mandatory for ACCESS_TOKEN and ID_TOKEN types per RFC 7519.
 
@@ -42,7 +42,7 @@ sheriff.oauth.issuers.keycloak.claim-sub-optional=true
 - Maintains RFC compliance warnings for awareness
 - Per-issuer configuration allows mixed environments
 
-*Warning:* This relaxes RFC 7519 compliance. The library will log a warning (`TokenSheriff-134`) when this setting is enabled.
+*Warning:* This relaxes RFC 7519 compliance. The library will log a warning (`OAuthSheriff-134`) when this setting is enabled.
 
 === Solution 2: Add Subject Protocol Mapper
 

--- a/doc/faq/keycloak.adoc
+++ b/doc/faq/keycloak.adoc
@@ -6,7 +6,7 @@
 :toc-title: Table of Contents
 
 
-Common issues and solutions when integrating the OAuth Sheriff library with Keycloak.
+Common issues and solutions when integrating the Token-Sheriff library with Keycloak.
 
 == Document Navigation
 
@@ -21,13 +21,13 @@ Common issues and solutions when integrating the OAuth Sheriff library with Keyc
 
 === Problem: Missing 'sub' Claim
 
-*Warning:* `OAuthSheriff-109: Token is missing required claim: sub`
+*Warning:* `TokenSheriff-109: Token is missing required claim: sub`
 
 *Cause:* Some Keycloak configurations or custom client scopes may exclude the `sub` claim from access tokens. While Keycloak includes `sub` by default, certain service account configurations or custom protocol mappers can remove it. The `sub` claim is mandatory for ACCESS_TOKEN and ID_TOKEN types per RFC 7519.
 
 === Solution 1: Configure claimSubOptional (For Specific Edge Cases)
 
-If your Keycloak setup legitimately excludes the `sub` claim (e.g., certain service account configurations), you can configure the OAuth Sheriff library to make the `sub` claim optional:
+If your Keycloak setup legitimately excludes the `sub` claim (e.g., certain service account configurations), you can configure the Token-Sheriff library to make the `sub` claim optional:
 
 [source,properties]
 ----
@@ -42,7 +42,7 @@ sheriff.oauth.issuers.keycloak.claim-sub-optional=true
 - Maintains RFC compliance warnings for awareness
 - Per-issuer configuration allows mixed environments
 
-*Warning:* This relaxes RFC 7519 compliance. The library will log a warning (`OAuthSheriff-134`) when this setting is enabled.
+*Warning:* This relaxes RFC 7519 compliance. The library will log a warning (`TokenSheriff-134`) when this setting is enabled.
 
 === Solution 2: Add Subject Protocol Mapper
 
@@ -184,9 +184,9 @@ Expected token structure after configuration:
 
 Adding the group membership mapper with `"full.path": "false"` to your Keycloak realm configuration resolves this issue completely. The integration tests confirm that tokens now contain group names without leading slashes, making them compatible with `@BearerToken` annotations.
 
-== Alternative: OAuth Sheriff Default Mappers
+== Alternative: Token-Sheriff Default Mappers
 
-Use built-in mappers instead of custom protocol mappers (OAuth Sheriff v1.0+):
+Use built-in mappers instead of custom protocol mappers (Token-Sheriff v1.0+):
 
 [source,properties]
 ----

--- a/doc/security/security-reference.adoc
+++ b/doc/security/security-reference.adoc
@@ -8,7 +8,7 @@
 
 _See Requirement xref:../Requirements.adoc#VALIDATION-8[VALIDATION-8: Security]_
 
-This document consolidates JWT attack mitigations, security controls, and best practices for the OAuth-Sheriff library.
+This document consolidates JWT attack mitigations, security controls, and best practices for the Token-Sheriff library.
 
 [[security-controls]]
 == Security Controls

--- a/doc/specification/microprofile-jwt-compatibility.adoc
+++ b/doc/specification/microprofile-jwt-compatibility.adoc
@@ -9,7 +9,7 @@ xref:../architecture.adoc[Back to Architecture Reference]
 
 == Overview
 
-This document describes OAuthSheriff's relationship to the https://download.eclipse.org/microprofile/microprofile-jwt-auth-2.1/microprofile-jwt-auth-spec-2.1.html[Eclipse MicroProfile JWT Auth 2.1] specification. OAuthSheriff implements select MP-JWT 2.1 primitives as a compatibility layer while retaining its advanced multi-issuer, multi-token-type architecture.
+This document describes TokenSheriff's relationship to the https://download.eclipse.org/microprofile/microprofile-jwt-auth-2.1/microprofile-jwt-auth-spec-2.1.html[Eclipse MicroProfile JWT Auth 2.1] specification. TokenSheriff implements select MP-JWT 2.1 primitives as a compatibility layer while retaining its advanced multi-issuer, multi-token-type architecture.
 
 === Document Navigation
 
@@ -24,14 +24,14 @@ This document describes OAuthSheriff's relationship to the https://download.ecli
 
 == Design Rationale
 
-OAuthSheriff is **not** an MP-JWT implementation. It is a purpose-built, production-grade JWT/OAuth 2.0/OpenID Connect token validation library that provides capabilities beyond what MP-JWT defines. Rather than conforming to the MP-JWT specification's single-issuer, single-token-type model, OAuthSheriff adopts **select primitives** from the spec where they provide value.
+TokenSheriff is **not** an MP-JWT implementation. It is a purpose-built, production-grade JWT/OAuth 2.0/OpenID Connect token validation library that provides capabilities beyond what MP-JWT defines. Rather than conforming to the MP-JWT specification's single-issuer, single-token-type model, TokenSheriff adopts **select primitives** from the spec where they provide value.
 
 The approach is:
 
 * **Core types**: `TokenContent` is framework-agnostic — no dependency on `JsonWebToken`
 * **Quarkus adapter**: `JsonWebTokenAdapter` wraps `TokenContent` to provide the `JsonWebToken` interface for CDI injection
 * **Clean API separation**: Core uses `Optional`-returning accessors; the adapter bridges to MP-JWT's nullable contract
-* **OAuthSheriff extensions**: Multi-issuer support, DPoP, custom claim mappers, sealed token hierarchy, security event tracking — all preserved as additional API surface
+* **TokenSheriff extensions**: Multi-issuer support, DPoP, custom claim mappers, sealed token hierarchy, security event tracking — all preserved as additional API surface
 
 == Adopted Features
 
@@ -45,7 +45,7 @@ The Quarkus module provides a `JsonWebTokenAdapter` that wraps `TokenContent` an
 @Inject Principal principal;            // Jakarta Security standard injection
 ----
 
-The adapter bridges between OAuthSheriff's clean API and the MP-JWT spec signatures:
+The adapter bridges between TokenSheriff's clean API and the MP-JWT spec signatures:
 
 [cols="3,2,2"]
 |===
@@ -86,7 +86,7 @@ The adapter bridges between OAuthSheriff's clean API and the MP-JWT spec signatu
 
 === `upn` Claim (User Principal Name)
 
-The `upn` claim is MP-JWT's standardized human-readable principal identifier. OAuthSheriff's `ClaimName` enum includes `UPN` with the spec-defined fallback chain for `Principal.getName()`:
+The `upn` claim is MP-JWT's standardized human-readable principal identifier. TokenSheriff's `ClaimName` enum includes `UPN` with the spec-defined fallback chain for `Principal.getName()`:
 
 1. `upn` claim (if present)
 2. `preferred_username` claim (fallback)
@@ -134,25 +134,25 @@ When `sheriff.oauth.token.header=Cookie`, the token is extracted from the named 
 |MP-JWT Feature |Rationale
 
 |`@RolesAllowed` annotation
-|OAuthSheriff uses `@BearerAuth` which provides superior multi-dimensional authorization (scopes AND roles AND groups). The standard `@RolesAllowed` only checks one dimension.
+|TokenSheriff uses `@BearerAuth` which provides superior multi-dimensional authorization (scopes AND roles AND groups). The standard `@RolesAllowed` only checks one dimension.
 
 |`@Claim` CDI qualifier injection
-|OAuthSheriff's programmatic `getClaimOption(ClaimName)` with custom `ClaimMapper` pipeline provides type-safe, extensible claim access. `@Claim` injection is less flexible for custom claim types and multi-issuer scenarios.
+|TokenSheriff's programmatic `getClaimOption(ClaimName)` with custom `ClaimMapper` pipeline provides type-safe, extensible claim access. `@Claim` injection is less flexible for custom claim types and multi-issuer scenarios.
 
 |`@LoginConfig` annotation
-|Not applicable to Quarkus extension model. OAuthSheriff activates via `@BearerAuth` interceptor binding and configuration properties.
+|Not applicable to Quarkus extension model. TokenSheriff activates via `@BearerAuth` interceptor binding and configuration properties.
 
 |`mp.jwt.*` config namespace
-|`sheriff.oauth.*` is the established convention. OAuthSheriff's per-issuer configuration model (`sheriff.oauth.issuers.<name>.*`) has no equivalent in the single-issuer `mp.jwt.*` namespace.
+|`sheriff.oauth.*` is the established convention. TokenSheriff's per-issuer configuration model (`sheriff.oauth.issuers.<name>.*`) has no equivalent in the single-issuer `mp.jwt.*` namespace.
 
 |`ClaimValue<T>` (MP-JWT version)
-|OAuthSheriff's `ClaimValue` with `ClaimMapper` pipeline (e.g., `ScopeMapper`, `KeycloakDefaultRolesMapper`) is more powerful. MP-JWT's `ClaimValue` is a simple typed wrapper.
+|TokenSheriff's `ClaimValue` with `ClaimMapper` pipeline (e.g., `ScopeMapper`, `KeycloakDefaultRolesMapper`) is more powerful. MP-JWT's `ClaimValue` is a simple typed wrapper.
 
 |Single-issuer model
-|OAuthSheriff's multi-issuer `IssuerConfigCache` with per-issuer JWKS loading, algorithm constraints, and claim validation is a core differentiator. MP-JWT assumes one issuer per application.
+|TokenSheriff's multi-issuer `IssuerConfigCache` with per-issuer JWKS loading, algorithm constraints, and claim validation is a core differentiator. MP-JWT assumes one issuer per application.
 |===
 
-== OAuthSheriff Advantages Beyond MP-JWT
+== TokenSheriff Advantages Beyond MP-JWT
 
 The following capabilities have no equivalent in MP-JWT 2.1:
 
@@ -171,19 +171,19 @@ The following capabilities have no equivalent in MP-JWT 2.1:
 
 [cols="2,2,1"]
 |===
-|MP-JWT Property |OAuthSheriff Equivalent |Notes
+|MP-JWT Property |TokenSheriff Equivalent |Notes
 
 |`mp.jwt.verify.issuer`
 |`sheriff.oauth.issuers.<name>.expected-issuer`
-|Per-issuer in OAuthSheriff
+|Per-issuer in TokenSheriff
 
 |`mp.jwt.verify.audiences`
 |`sheriff.oauth.issuers.<name>.expected-audience`
-|Per-issuer in OAuthSheriff
+|Per-issuer in TokenSheriff
 
 |`mp.jwt.verify.publickey.location`
 |`sheriff.oauth.issuers.<name>.jwks.http.well-known-url`
-|OAuthSheriff uses OIDC discovery or direct JWKS URL
+|TokenSheriff uses OIDC discovery or direct JWKS URL
 
 |`mp.jwt.verify.publickey.algorithm`
 |`sheriff.oauth.issuers.<name>.allowed-signature-algorithms`
@@ -191,11 +191,11 @@ The following capabilities have no equivalent in MP-JWT 2.1:
 
 |`mp.jwt.verify.clock.skew`
 |`sheriff.oauth.issuers.<name>.clock-skew-seconds`
-|Per-issuer in OAuthSheriff
+|Per-issuer in TokenSheriff
 
 |`mp.jwt.verify.token.age`
 |`sheriff.oauth.issuers.<name>.max-token-age-seconds`
-|Per-issuer in OAuthSheriff
+|Per-issuer in TokenSheriff
 
 |`mp.jwt.token.header`
 |`sheriff.oauth.token.header`
@@ -221,4 +221,4 @@ The following capabilities have no equivalent in MP-JWT 2.1:
 * https://datatracker.ietf.org/doc/html/rfc9068[RFC 9068 - JWT Profile for OAuth 2.0 Access Tokens]
 * https://datatracker.ietf.org/doc/html/rfc8725[RFC 8725 - JSON Web Token Best Current Practices]
 * https://datatracker.ietf.org/doc/html/rfc9449[RFC 9449 - OAuth 2.0 Demonstrating Proof of Possession (DPoP)]
-* xref:../architecture.adoc[OAuthSheriff Architecture Reference]
+* xref:../architecture.adoc[TokenSheriff Architecture Reference]

--- a/doc/specification/multi-idp-testing.adoc
+++ b/doc/specification/multi-idp-testing.adoc
@@ -7,7 +7,7 @@
 
 == Overview
 
-OAuthSheriff validates JWT tokens from any standards-compliant OIDC provider. To verify this claim beyond a single provider, multi-IDP integration testing exercises the validation pipeline against multiple identity providers running simultaneously.
+TokenSheriff validates JWT tokens from any standards-compliant OIDC provider. To verify this claim beyond a single provider, multi-IDP integration testing exercises the validation pipeline against multiple identity providers running simultaneously.
 
 This specification covers the architecture, provider selection, and usage of the multi-IDP testing infrastructure.
 
@@ -21,7 +21,7 @@ The multi-IDP testing approach extends the existing Docker Compose infrastructur
 │ Docker Compose Network: jwt-integration                               │
 │                                                                       │
 │  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────────────────┐  │
-│  │ Keycloak │  │   Dex    │  │ Zitadel  │  │ OAuthSheriff          │  │
+│  │ Keycloak │  │   Dex    │  │ Zitadel  │  │ TokenSheriff          │  │
 │  │ :8443    │  │  :5556   │  │  :8080   │  │ Integration Tests     │  │
 │  │ (always) │  │ (profile)│  │ (profile)│  │ :8443                 │  │
 │  └──────────┘  └──────────┘  └────┬─────┘  └──────────────────────┘  │
@@ -242,7 +242,7 @@ The `bearerAuthProviders()` method source requires `ROLES + GROUPS + CUSTOM_SCOP
 
 === Dex's value in the test suite
 
-Despite these limitations, Dex proves that OAuthSheriff correctly handles:
+Despite these limitations, Dex proves that TokenSheriff correctly handles:
 
 * A **different OIDC-certified issuer** with different token structure
 * **Missing optional claims** (no `scope` claim — RFC 9068 compliance)

--- a/doc/specification/token-decryption.adoc
+++ b/doc/specification/token-decryption.adoc
@@ -64,7 +64,7 @@ Key Material:
                            |
                            v
 
-RESOURCE SERVER (OAuthSheriff library)
+RESOURCE SERVER (TokenSheriff library)
 ======================================
 
 Key Material:

--- a/oauth-sheriff-core/README.adoc
+++ b/oauth-sheriff-core/README.adoc
@@ -1,4 +1,4 @@
-= OAuth Sheriff Core
+= Token-Sheriff Core
 :toc: left
 :toclevels: 2
 :source-highlighter: highlight.js

--- a/oauth-sheriff-core/doc/UnitTesting.adoc
+++ b/oauth-sheriff-core/doc/UnitTesting.adoc
@@ -1,4 +1,4 @@
-= OAuth Sheriff Core Test Utilities
+= Token-Sheriff Core Test Utilities
 :doctype: book
 :toc: left
 :toclevels: 3

--- a/oauth-sheriff-core/doc/api-reference.adoc
+++ b/oauth-sheriff-core/doc/api-reference.adoc
@@ -1,4 +1,4 @@
-= OAuth Sheriff Core API Reference
+= Token-Sheriff Core API Reference
 :toc: left
 :toclevels: 3
 :source-highlighter: highlight.js

--- a/oauth-sheriff-core/doc/usage-guide.adoc
+++ b/oauth-sheriff-core/doc/usage-guide.adoc
@@ -1,4 +1,4 @@
-= OAuth Sheriff Core Usage Guide
+= Token-Sheriff Core Usage Guide
 :toc: left
 :toclevels: 3
 :source-highlighter: highlight.js

--- a/oauth-sheriff-quarkus-parent/README.adoc
+++ b/oauth-sheriff-quarkus-parent/README.adoc
@@ -164,7 +164,7 @@ public class InstanceEndpoint {
     public Response getData(@BearerToken BearerTokenResult tokenResult) {
         AccessTokenContent token = tokenResult.getAccessTokenContent()
                 .orElseThrow(() -> new IllegalStateException("Token content missing after successful authorization"));
-        // TokenSheriff-specific API with richer types
+        // Token-Sheriff-specific API with richer types
         String userId = token.getSubject().orElse("unknown");
         OffsetDateTime expiry = token.getExpirationDateTime();
         List<String> scopes = token.getScopes();

--- a/oauth-sheriff-quarkus-parent/README.adoc
+++ b/oauth-sheriff-quarkus-parent/README.adoc
@@ -1,4 +1,4 @@
-= OAuth Sheriff Quarkus Integration
+= Token-Sheriff Quarkus Integration
 :toc: left
 :toclevels: 3
 :sectnumlevels: 1
@@ -7,7 +7,7 @@
 :sectnums:
 
 
-A Quarkus extension for the OAuth Sheriff validation library, consisting of:
+A Quarkus extension for the Token-Sheriff validation library, consisting of:
 
 * xref:oauth-sheriff-quarkus/README.adoc[oauth-sheriff-quarkus] - Runtime module with CDI producers and JWT validation
 * xref:oauth-sheriff-quarkus-deployment/README.adoc[oauth-sheriff-quarkus-deployment] - Build-time deployment processor
@@ -41,7 +41,7 @@ A Quarkus extension for the OAuth Sheriff validation library, consisting of:
 
 == Core Concepts
 
-This module provides integration of the OAuth Sheriff validation library into Quarkus applications. It includes:
+This module provides integration of the Token-Sheriff validation library into Quarkus applications. It includes:
 
 * Quarkus configuration support
 * CDI producers for JWT validation components
@@ -164,7 +164,7 @@ public class InstanceEndpoint {
     public Response getData(@BearerToken BearerTokenResult tokenResult) {
         AccessTokenContent token = tokenResult.getAccessTokenContent()
                 .orElseThrow(() -> new IllegalStateException("Token content missing after successful authorization"));
-        // OAuthSheriff-specific API with richer types
+        // TokenSheriff-specific API with richer types
         String userId = token.getSubject().orElse("unknown");
         OffsetDateTime expiry = token.getExpirationDateTime();
         List<String> scopes = token.getScopes();

--- a/oauth-sheriff-quarkus-parent/doc/README.adoc
+++ b/oauth-sheriff-quarkus-parent/doc/README.adoc
@@ -1,4 +1,4 @@
-= OAuth Sheriff Quarkus Extension Documentation
+= Token-Sheriff Quarkus Extension Documentation
 :toc: left
 :toclevels: 3
 :toc-title: Table of Contents
@@ -7,7 +7,7 @@
 
 == Overview
 
-Documentation for the OAuth Sheriff Quarkus extension -- a JWT validation library integrated with Quarkus. The extension provides automatic configuration, health checks, metrics integration, and development UI components.
+Documentation for the Token-Sheriff Quarkus extension -- a JWT validation library integrated with Quarkus. The extension provides automatic configuration, health checks, metrics integration, and development UI components.
 
 == Quick Links
 
@@ -16,7 +16,7 @@ Documentation for the OAuth Sheriff Quarkus extension -- a JWT validation librar
 
 == Architecture & Implementation
 
-The OAuth Sheriff Quarkus extension provides JWT validation through a modular architecture:
+The Token-Sheriff Quarkus extension provides JWT validation through a modular architecture:
 
 * **xref:integration/quarkus-integration.adoc[Quarkus Framework Integration]** - Core extension architecture
 * **xref:integration/health-checks.adoc[Health Checks]** - MicroProfile Health readiness and liveness probes

--- a/oauth-sheriff-quarkus-parent/doc/configuration/native-image-configuration.adoc
+++ b/oauth-sheriff-quarkus-parent/doc/configuration/native-image-configuration.adoc
@@ -7,7 +7,7 @@
 
 == Purpose
 
-Native image configuration for the OAuth Sheriff Quarkus extension, including reflection settings, resource inclusion, and build parameters for GraalVM compilation.
+Native image configuration for the Token-Sheriff Quarkus extension, including reflection settings, resource inclusion, and build parameters for GraalVM compilation.
 
 == Basic Native Image Configuration
 
@@ -23,7 +23,7 @@ quarkus.native.resources.includes=**/*.p12,**/*.crt,**/*.key,**/*.pem
 
 === Reflection Configuration
 
-The OAuth Sheriff Quarkus deployment automatically registers the following classes for reflection:
+The Token-Sheriff Quarkus deployment automatically registers the following classes for reflection:
 
 * **JWT Validation Pipeline**: `NonValidatingJwtParser`, `TokenSignatureValidator`, `TokenHeaderValidator`, `TokenClaimValidator`, `TokenBuilder`, `DecodedJwt`
 * **JWKS Loading**: `HttpJwksLoader`, `JWKSKeyLoader`, `KeyInfo`, `JwksParser`

--- a/oauth-sheriff-quarkus-parent/doc/configuration/testing-configuration.adoc
+++ b/oauth-sheriff-quarkus-parent/doc/configuration/testing-configuration.adoc
@@ -7,7 +7,7 @@
 
 == Purpose
 
-Testing configuration patterns and utilities for applications using the OAuth Sheriff Quarkus extension, covering test profiles, token generation, and validation testing.
+Testing configuration patterns and utilities for applications using the Token-Sheriff Quarkus extension, covering test profiles, token generation, and validation testing.
 
 == Test Profile Configuration
 

--- a/oauth-sheriff-quarkus-parent/doc/development/devui-implementation.adoc
+++ b/oauth-sheriff-quarkus-parent/doc/development/devui-implementation.adoc
@@ -1,4 +1,4 @@
-= OAuth Sheriff DevUI Implementation
+= Token-Sheriff DevUI Implementation
 :toc: left
 :toclevels: 3
 :source-highlighter: highlight.js
@@ -109,4 +109,4 @@ Sections: Status Overview (indicator dot, metrics grid), Issuers (per-issuer car
 
 . Start Quarkus in dev mode: `./mvnw quarkus:dev`
 . Open `http://localhost:8080/q/dev-ui/`
-. Locate the "OAuth Sheriff" extension card
+. Locate the "Token-Sheriff" extension card

--- a/oauth-sheriff-quarkus-parent/doc/development/devui-testing.adoc
+++ b/oauth-sheriff-quarkus-parent/doc/development/devui-testing.adoc
@@ -1,4 +1,4 @@
-= OAuth Sheriff DevUI Testing
+= Token-Sheriff DevUI Testing
 :toc: left
 :toclevels: 3
 :source-highlighter: highlight.js

--- a/oauth-sheriff-quarkus-parent/doc/development/quarkus-test-setup.adoc
+++ b/oauth-sheriff-quarkus-parent/doc/development/quarkus-test-setup.adoc
@@ -7,7 +7,7 @@
 
 == Overview
 
-Test framework configuration for the OAuth Sheriff Quarkus extension, covering dependencies, logging, and test execution setup.
+Test framework configuration for the Token-Sheriff Quarkus extension, covering dependencies, logging, and test execution setup.
 
 == Test Dependencies
 

--- a/oauth-sheriff-quarkus-parent/doc/performance/graalvm-enterprise-optimization-options.adoc
+++ b/oauth-sheriff-quarkus-parent/doc/performance/graalvm-enterprise-optimization-options.adoc
@@ -9,7 +9,7 @@
 
 GraalVM Enterprise Edition (Oracle GraalVM) specific optimization options. These features require Oracle GraalVM or commercial licensing.
 
-**Context**: OAuth Sheriff targets GraalVM Community Edition (Mandrel) as primary runtime +
+**Context**: Token-Sheriff targets GraalVM Community Edition (Mandrel) as primary runtime +
 **Current Performance**: Community Edition achieves 25,178 ops/s JWT validation (March 2026)
 
 == Enterprise Edition Features

--- a/oauth-sheriff-quarkus-parent/doc/performance/jwt-validation-performance.adoc
+++ b/oauth-sheriff-quarkus-parent/doc/performance/jwt-validation-performance.adoc
@@ -7,7 +7,7 @@
 
 == Purpose
 
-JWT validation performance characteristics, baselines, and analysis for the CUI OAuth Sheriff Quarkus integration.
+JWT validation performance characteristics, baselines, and analysis for the CUI Token-Sheriff Quarkus integration.
 
 == Performance Baselines (March 2026)
 

--- a/oauth-sheriff-quarkus-parent/doc/performance/native-optimization-guide.adoc
+++ b/oauth-sheriff-quarkus-parent/doc/performance/native-optimization-guide.adoc
@@ -34,7 +34,7 @@ quarkus.native.monitoring=jcmd,jfr,heapdump
 
 === Reflection Configuration
 
-The OAuth Sheriff Quarkus deployment automatically registers types for reflection across several build steps, covering JWT validation pipeline, JWKS loading, token content, claim mappers, and security/algorithm classes. The total number of registered types (including transitive Quarkus framework types) varies by build.
+The Token-Sheriff Quarkus deployment automatically registers types for reflection across several build steps, covering JWT validation pipeline, JWKS loading, token content, claim mappers, and security/algorithm classes. The total number of registered types (including transitive Quarkus framework types) varies by build.
 
 === Garbage Collection
 

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus-deployment/README.adoc
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus-deployment/README.adoc
@@ -1,4 +1,4 @@
-= OAuth Sheriff Quarkus Deployment
+= Token-Sheriff Quarkus Deployment
 :toc: left
 :toclevels: 3
 :sectnumlevels: 1
@@ -76,7 +76,7 @@ Access DevUI components during development:
 ----
 ./mvnw quarkus:dev
 # Navigate to http://localhost:8080/q/dev-ui/
-# Find "OAuth Sheriff" section for JWT validation tools
+# Find "Token-Sheriff" section for JWT validation tools
 ----
 
 == Configuration

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus-integration-tests/README.adoc
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus-integration-tests/README.adoc
@@ -1,4 +1,4 @@
-= OAuth Sheriff Quarkus Integration Tests
+= Token-Sheriff Quarkus Integration Tests
 :toc: left
 :toclevels: 3
 :sectnums:
@@ -8,7 +8,7 @@
 
 == Overview
 
-Integration tests for the OAuth Sheriff Quarkus extension with native container testing, HTTPS support, health checks, and metrics validation.
+Integration tests for the Token-Sheriff Quarkus extension with native container testing, HTTPS support, health checks, and metrics validation.
 
 == Port Configuration
 

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/README.adoc
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/README.adoc
@@ -1,4 +1,4 @@
-= OAuth Sheriff Quarkus Runtime
+= Token-Sheriff Quarkus Runtime
 :toc: left
 :toclevels: 3
 :sectnumlevels: 1

--- a/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/resources/META-INF/quarkus-config-doc.adoc
+++ b/oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus/src/main/resources/META-INF/quarkus-config-doc.adoc
@@ -1,4 +1,4 @@
-= OAuth Sheriff Quarkus Extension Configuration Reference
+= Token-Sheriff Quarkus Extension Configuration Reference
 :toc-title: Table of Contents
 :sectnums:
 :source-highlighter: highlight.js


### PR DESCRIPTION
## Context

Part of **Plan 01 — Restructure** (`doc/oidc/01-restructure`). Converts the display/brand product name to the canonical **Token-Sheriff** in documentation prose.

## Scope

- `.adoc` / `.md` files only — **34 docs**, 190 ↔ 190 lines (clean 1:1).
- Brand forms normalized: `OAuth-Sheriff`, `OAuth Sheriff`, standalone `OAuthSheriff` → `Token-Sheriff` / `TokenSheriff`.

## Deliberately preserved (later steps)

| Preserved | Why | Handled in |
|---|---|---|
| `github.com/cuioss/OAuthSheriff` repo URLs | would 404 before repo rename | Phase 3 |
| `cuioss.github.io/OAuth-Sheriff` Pages URLs | served at old path until reconfig | Phase 3 |
| `cuioss_OAuth-Sheriff` Sonar key | changing breaks CI Sonar analysis | Phase 3 |
| `OAuthSheriffProcessor` etc. (code identifiers) | move with `ChangeType` | mechanical rename PR |
| `de.cuioss.sheriff.oauth`, `oauth-sheriff-*` coords/paths | atomic with package/config flip | mechanical rename PR |

Implemented via a protect→replace→restore pass so those contexts are provably untouched (verified: protected counts unchanged, zero stray brand prose, no coordinate mutated).

## Verification

- **Docs-only** — no code/config/coordinate/URL changes; build impact none.
- Build/test gated by CI below.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated project and module documentation to use the new **Token-Sheriff** name throughout.
  * Refreshed titles, headings, and references across setup, architecture, FAQ, security, benchmarking, testing, performance, and API docs.
  * Aligned compatibility and usage guidance with the updated product branding and terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->