### PR TITLE
release: cut Token-Sheriff 0.9.0 (rebrand release)

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -2,7 +2,7 @@ name: token-sheriff
 description: A comprehensive framework for validating OAuth/JWT tokens in multi-issuer environments
 
 release:
-  current-version: 0.8.0
+  current-version: 0.9.0
   next-version: 1.0.0-SNAPSHOT
   create-github-release: true
 


### PR DESCRIPTION
## Context

Phase 2 of **Plan 01** — publish the first **Token-Sheriff** release. Per the project release flow, setting `release.current-version` and merging triggers the release build.

## What changes

- `.github/project.yml`: `release.current-version` `0.8.0 → 0.9.0`
- `next-version` stays `1.0.0-SNAPSHOT` — **1.0.0 is reserved** for when the OIDC client module is implemented + tested (per Plan 01).

## On merge (you merge to publish)

- Publishes `de.cuioss.sheriff.token:token-sheriff-{parent,bom,validation,validation-quarkus,validation-quarkus-deployment}:0.9.0` to Maven Central
- Deploys GitHub Pages at `cuioss.github.io/TokenSheriff` (`deploy-at-release: true`) → benchmark badges resolve
- Cuts the GitHub release

## Not included (separate decision)

Maven Central **relocation stubs** for the OLD `de.cuioss.sheriff.oauth:oauth-sheriff-*` coordinates (so existing consumers' builds auto-redirect). These are old-coordinate artifacts that don't fit the reactor release; see the PR discussion for the A/B decision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the project release version to **0.9.0**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->