### PR TITLE
build(relocation): Maven Central relocation stubs for old coordinates

### DIFF
--- a/relocation-stubs/README.adoc
+++ b/relocation-stubs/README.adoc
@@ -1,0 +1,60 @@
+= Maven Central relocation stubs (OAuth-Sheriff → Token-Sheriff)
+:toc: macro
+:sectnums:
+
+Standalone project (NOT part of the main reactor) that publishes a final
+release under each *old* `de.cuioss.sheriff.oauth` coordinate whose
+`distributionManagement/relocation` points at the renamed
+`de.cuioss.sheriff.token` artifact. Resolvers then auto-redirect old-coordinate
+builds to the new artifact and print a `has been relocated` warning.
+
+Relocation redirects *coordinates only* — Java packages
+(`de.cuioss.sheriff.oauth.* → de.cuioss.sheriff.token.*`) and config/metric keys
+(`sheriff.oauth.* → sheriff.token.*`) still require the source changes in
+xref:../doc/oidc/01-restructure/migration-nifi-extensions.adoc[the migration guide].
+
+toc::[]
+
+== Stubs published
+
+[cols="2,2"]
+|===
+| Old coordinate (published at 0.9.0) | Relocates to
+
+| `de.cuioss.sheriff.oauth:oauth-sheriff-parent`             | `de.cuioss.sheriff.token:token-sheriff-parent`
+| `de.cuioss.sheriff.oauth:oauth-sheriff-core`               | `de.cuioss.sheriff.token:token-sheriff-validation`
+| `de.cuioss.sheriff.oauth:oauth-sheriff-quarkus`            | `de.cuioss.sheriff.token:token-sheriff-validation-quarkus`
+| `de.cuioss.sheriff.oauth:oauth-sheriff-quarkus-deployment` | `de.cuioss.sheriff.token:token-sheriff-validation-quarkus-deployment`
+|===
+
+NOTE: `oauth-sheriff-bom` was never published to Maven Central (last release of the
+others was 0.8.0), so it gets no stub. `oauth-sheriff-quarkus-integration-tests` is a
+test module and was never published either.
+
+== When to deploy
+
+*After* the `0.9.0` release of the new `token-sheriff-*` artifacts is live on
+Maven Central (the relocation `<version>0.9.0</version>` targets must exist).
+
+== How to deploy
+
+From the repository root, using the same release profile / credentials as a
+normal release (Sonatype Central publishing + GPG signing are inherited from
+`cui-java-parent`):
+
+[source,bash]
+----
+./mvnw -f relocation-stubs/pom.xml -Prelease clean deploy
+----
+
+The aggregator (`oauth-sheriff-relocations`) sets `maven.deploy.skip=true`, so only
+the four relocation POMs are uploaded.
+
+== Verify
+
+[source,bash]
+----
+# an old-coordinate resolve should redirect + warn
+mvn dependency:get -Dartifact=de.cuioss.sheriff.oauth:oauth-sheriff-core:0.9.0
+# → "[WARNING] The artifact ... has been relocated to de.cuioss.sheriff.token:token-sheriff-validation:0.9.0"
+----

--- a/relocation-stubs/oauth-sheriff-core/pom.xml
+++ b/relocation-stubs/oauth-sheriff-core/pom.xml
@@ -37,7 +37,7 @@
             <version>0.9.0</version>
             <message>OAuth-Sheriff has been renamed to Token-Sheriff. Update coordinates to
                 de.cuioss.sheriff.token:token-sheriff-validation. Imports and config keys also change —
-                see https://github.com/cuioss/TokenSheriff/blob/main/doc/oidc/01-restructure/migration-nifi-extensions.adoc</message>
+                see https://github.com/cuioss/TokenSheriff/blob/0.9.0/doc/oidc/01-restructure/migration-nifi-extensions.adoc</message>
         </relocation>
     </distributionManagement>
 </project>

--- a/relocation-stubs/oauth-sheriff-core/pom.xml
+++ b/relocation-stubs/oauth-sheriff-core/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>de.cuioss</groupId>
+        <artifactId>cui-java-parent</artifactId>
+        <version>1.4.5</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>de.cuioss.sheriff.oauth</groupId>
+    <artifactId>oauth-sheriff-core</artifactId>
+    <version>0.9.0</version>
+    <packaging>pom</packaging>
+
+    <name>OAuth-Sheriff Core (relocated to Token-Sheriff)</name>
+    <description>Renamed to de.cuioss.sheriff.token:token-sheriff-validation. This is a relocation
+        stub; resolvers redirect automatically and print a relocation warning. Note: Java packages
+        (de.cuioss.sheriff.oauth.core → de.cuioss.sheriff.token.validation) and config keys
+        (sheriff.oauth → sheriff.token) still require the source changes in the migration guide.</description>
+    <url>https://github.com/cuioss/TokenSheriff/</url>
+
+    <scm>
+        <connection>scm:git:https://github.com/cuioss/TokenSheriff.git</connection>
+        <developerConnection>scm:git:https://github.com/cuioss/TokenSheriff.git</developerConnection>
+        <url>https://github.com/cuioss/TokenSheriff/</url>
+        <tag>HEAD</tag>
+    </scm>
+
+    <distributionManagement>
+        <relocation>
+            <groupId>de.cuioss.sheriff.token</groupId>
+            <artifactId>token-sheriff-validation</artifactId>
+            <version>0.9.0</version>
+            <message>OAuth-Sheriff has been renamed to Token-Sheriff. Update coordinates to
+                de.cuioss.sheriff.token:token-sheriff-validation. Imports and config keys also change —
+                see https://github.com/cuioss/TokenSheriff/blob/main/doc/oidc/01-restructure/migration-nifi-extensions.adoc</message>
+        </relocation>
+    </distributionManagement>
+</project>

--- a/relocation-stubs/oauth-sheriff-parent/pom.xml
+++ b/relocation-stubs/oauth-sheriff-parent/pom.xml
@@ -35,7 +35,7 @@
             <version>0.9.0</version>
             <message>OAuth-Sheriff has been renamed to Token-Sheriff. Update coordinates to
                 de.cuioss.sheriff.token:token-sheriff-parent. See
-                https://github.com/cuioss/TokenSheriff/blob/main/doc/oidc/01-restructure/migration-nifi-extensions.adoc</message>
+                https://github.com/cuioss/TokenSheriff/blob/0.9.0/doc/oidc/01-restructure/migration-nifi-extensions.adoc</message>
         </relocation>
     </distributionManagement>
 </project>

--- a/relocation-stubs/oauth-sheriff-parent/pom.xml
+++ b/relocation-stubs/oauth-sheriff-parent/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>de.cuioss</groupId>
+        <artifactId>cui-java-parent</artifactId>
+        <version>1.4.5</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>de.cuioss.sheriff.oauth</groupId>
+    <artifactId>oauth-sheriff-parent</artifactId>
+    <version>0.9.0</version>
+    <packaging>pom</packaging>
+
+    <name>OAuth-Sheriff Parent (relocated to Token-Sheriff)</name>
+    <description>Renamed to de.cuioss.sheriff.token:token-sheriff-parent. This is a relocation
+        stub; resolvers redirect automatically and print a relocation warning.</description>
+    <url>https://github.com/cuioss/TokenSheriff/</url>
+
+    <scm>
+        <connection>scm:git:https://github.com/cuioss/TokenSheriff.git</connection>
+        <developerConnection>scm:git:https://github.com/cuioss/TokenSheriff.git</developerConnection>
+        <url>https://github.com/cuioss/TokenSheriff/</url>
+        <tag>HEAD</tag>
+    </scm>
+
+    <distributionManagement>
+        <relocation>
+            <groupId>de.cuioss.sheriff.token</groupId>
+            <artifactId>token-sheriff-parent</artifactId>
+            <version>0.9.0</version>
+            <message>OAuth-Sheriff has been renamed to Token-Sheriff. Update coordinates to
+                de.cuioss.sheriff.token:token-sheriff-parent. See
+                https://github.com/cuioss/TokenSheriff/blob/main/doc/oidc/01-restructure/migration-nifi-extensions.adoc</message>
+        </relocation>
+    </distributionManagement>
+</project>

--- a/relocation-stubs/oauth-sheriff-quarkus-deployment/pom.xml
+++ b/relocation-stubs/oauth-sheriff-quarkus-deployment/pom.xml
@@ -35,7 +35,7 @@
             <version>0.9.0</version>
             <message>OAuth-Sheriff has been renamed to Token-Sheriff. Update coordinates to
                 de.cuioss.sheriff.token:token-sheriff-validation-quarkus-deployment. See
-                https://github.com/cuioss/TokenSheriff/blob/main/doc/oidc/01-restructure/migration-nifi-extensions.adoc</message>
+                https://github.com/cuioss/TokenSheriff/blob/0.9.0/doc/oidc/01-restructure/migration-nifi-extensions.adoc</message>
         </relocation>
     </distributionManagement>
 </project>

--- a/relocation-stubs/oauth-sheriff-quarkus-deployment/pom.xml
+++ b/relocation-stubs/oauth-sheriff-quarkus-deployment/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>de.cuioss</groupId>
+        <artifactId>cui-java-parent</artifactId>
+        <version>1.4.5</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>de.cuioss.sheriff.oauth</groupId>
+    <artifactId>oauth-sheriff-quarkus-deployment</artifactId>
+    <version>0.9.0</version>
+    <packaging>pom</packaging>
+
+    <name>OAuth-Sheriff Quarkus Deployment (relocated to Token-Sheriff)</name>
+    <description>Renamed to de.cuioss.sheriff.token:token-sheriff-validation-quarkus-deployment.
+        This is a relocation stub; resolvers redirect automatically and print a relocation warning.</description>
+    <url>https://github.com/cuioss/TokenSheriff/</url>
+
+    <scm>
+        <connection>scm:git:https://github.com/cuioss/TokenSheriff.git</connection>
+        <developerConnection>scm:git:https://github.com/cuioss/TokenSheriff.git</developerConnection>
+        <url>https://github.com/cuioss/TokenSheriff/</url>
+        <tag>HEAD</tag>
+    </scm>
+
+    <distributionManagement>
+        <relocation>
+            <groupId>de.cuioss.sheriff.token</groupId>
+            <artifactId>token-sheriff-validation-quarkus-deployment</artifactId>
+            <version>0.9.0</version>
+            <message>OAuth-Sheriff has been renamed to Token-Sheriff. Update coordinates to
+                de.cuioss.sheriff.token:token-sheriff-validation-quarkus-deployment. See
+                https://github.com/cuioss/TokenSheriff/blob/main/doc/oidc/01-restructure/migration-nifi-extensions.adoc</message>
+        </relocation>
+    </distributionManagement>
+</project>

--- a/relocation-stubs/oauth-sheriff-quarkus/pom.xml
+++ b/relocation-stubs/oauth-sheriff-quarkus/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>de.cuioss</groupId>
+        <artifactId>cui-java-parent</artifactId>
+        <version>1.4.5</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>de.cuioss.sheriff.oauth</groupId>
+    <artifactId>oauth-sheriff-quarkus</artifactId>
+    <version>0.9.0</version>
+    <packaging>pom</packaging>
+
+    <name>OAuth-Sheriff Quarkus (relocated to Token-Sheriff)</name>
+    <description>Renamed to de.cuioss.sheriff.token:token-sheriff-validation-quarkus. This is a
+        relocation stub; resolvers redirect automatically and print a relocation warning.</description>
+    <url>https://github.com/cuioss/TokenSheriff/</url>
+
+    <scm>
+        <connection>scm:git:https://github.com/cuioss/TokenSheriff.git</connection>
+        <developerConnection>scm:git:https://github.com/cuioss/TokenSheriff.git</developerConnection>
+        <url>https://github.com/cuioss/TokenSheriff/</url>
+        <tag>HEAD</tag>
+    </scm>
+
+    <distributionManagement>
+        <relocation>
+            <groupId>de.cuioss.sheriff.token</groupId>
+            <artifactId>token-sheriff-validation-quarkus</artifactId>
+            <version>0.9.0</version>
+            <message>OAuth-Sheriff has been renamed to Token-Sheriff. Update coordinates to
+                de.cuioss.sheriff.token:token-sheriff-validation-quarkus. See
+                https://github.com/cuioss/TokenSheriff/blob/main/doc/oidc/01-restructure/migration-nifi-extensions.adoc</message>
+        </relocation>
+    </distributionManagement>
+</project>

--- a/relocation-stubs/oauth-sheriff-quarkus/pom.xml
+++ b/relocation-stubs/oauth-sheriff-quarkus/pom.xml
@@ -35,7 +35,7 @@
             <version>0.9.0</version>
             <message>OAuth-Sheriff has been renamed to Token-Sheriff. Update coordinates to
                 de.cuioss.sheriff.token:token-sheriff-validation-quarkus. See
-                https://github.com/cuioss/TokenSheriff/blob/main/doc/oidc/01-restructure/migration-nifi-extensions.adoc</message>
+                https://github.com/cuioss/TokenSheriff/blob/0.9.0/doc/oidc/01-restructure/migration-nifi-extensions.adoc</message>
         </relocation>
     </distributionManagement>
 </project>

--- a/relocation-stubs/pom.xml
+++ b/relocation-stubs/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>de.cuioss</groupId>
+        <artifactId>cui-java-parent</artifactId>
+        <version>1.4.5</version>
+        <relativePath/>
+    </parent>
+
+    <!-- Build/deploy aggregator for the OAuth-Sheriff → Token-Sheriff Maven Central
+         relocation stubs. NOT part of the main reactor and NOT itself published. -->
+    <groupId>de.cuioss.sheriff.oauth</groupId>
+    <artifactId>oauth-sheriff-relocations</artifactId>
+    <version>0.9.0</version>
+    <packaging>pom</packaging>
+
+    <name>OAuth-Sheriff → Token-Sheriff relocation stubs (aggregator)</name>
+    <description>Aggregator that builds and deploys the relocation POMs published under the
+        old de.cuioss.sheriff.oauth coordinates so existing consumer builds auto-redirect to the
+        renamed de.cuioss.sheriff.token artifacts. This aggregator is itself not published.</description>
+    <url>https://github.com/cuioss/TokenSheriff/</url>
+
+    <properties>
+        <!-- the aggregator carries no artifact of its own -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
+    <modules>
+        <module>oauth-sheriff-parent</module>
+        <module>oauth-sheriff-core</module>
+        <module>oauth-sheriff-quarkus</module>
+        <module>oauth-sheriff-quarkus-deployment</module>
+    </modules>
+</project>


### PR DESCRIPTION
## Context

Phase 2 of **Plan 01** (companion to the #513 0.9.0 release). Adds a standalone `relocation-stubs/` project — **not part of the main reactor** — that publishes a final release under each OLD `de.cuioss.sheriff.oauth` coordinate with a `distributionManagement/relocation` redirect to the renamed `de.cuioss.sheriff.token` artifact. Old-coordinate consumer builds then auto-redirect and print a `has been relocated` warning.

## Stubs (version 0.9.0)

| Old coordinate | Relocates to |
|---|---|
| `oauth-sheriff-parent` | `token-sheriff-parent` |
| `oauth-sheriff-core` | `token-sheriff-validation` |
| `oauth-sheriff-quarkus` | `token-sheriff-validation-quarkus` |
| `oauth-sheriff-quarkus-deployment` | `token-sheriff-validation-quarkus-deployment` |

`oauth-sheriff-bom` was never published (404 on Central), so no stub.

## Deploy (deliberate one-off, by maintainer, AFTER 0.9.0 is live)

```bash
./mvnw -f relocation-stubs/pom.xml -Prelease clean deploy
```
Aggregator is `deploy-skip`; signing + Sonatype Central publishing inherited from `cui-java-parent`. Full notes in `relocation-stubs/README.adoc`.

Relocation redirects coordinates only — Java packages and config keys still need the migration-guide source changes. Verified `validate` builds green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Maven Central “relocation stubs” for legacy OAuth-Sheriff artifacts to automatically redirect requests to the corresponding Token-Sheriff coordinates (with relocation warnings).
* **Documentation**
  * Added a standalone guide describing which coordinates are redirected and when/how to deploy and verify the behavior.
* **Bug Fixes**
  * Reduces dependency resolution confusion by ensuring consumers targeting older coordinates are transparently redirected to the new artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->