### PR TITLE
ci: transient relocation-stubs dispatch workflow (one-shot, will be reverted)

### DIFF
--- a/.github/workflows/release-relocation-stubs.yml
+++ b/.github/workflows/release-relocation-stubs.yml
@@ -1,0 +1,41 @@
+name: Release Relocation Stubs
+
+# One-off, manually triggered deploy of the OAuth-Sheriff → Token-Sheriff Maven
+# Central relocation stubs. The stub project lives on the release/legacy branch
+# (deliberately NOT on main); this workflow checks that branch out explicitly, so
+# it can sit transiently on main only long enough to be dispatchable.
+# Run ONCE, AFTER the token-sheriff-* 0.9.0 release is live on Maven Central —
+# the stubs' <relocation> targets point at 0.9.0.
+#
+# Uses the same org secrets as the normal release; no local credentials needed.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-relocation-stubs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout release/legacy (where the stubs live)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: release/legacy
+
+      - name: Set up JDK, Maven Central server and GPG
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
+        with:
+          distribution: temurin
+          java-version: '21'
+          server-id: central
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+      - name: Deploy relocation stubs to Maven Central
+        run: ./mvnw -B --no-transfer-progress -f relocation-stubs/pom.xml -Prelease clean deploy
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSS_SONATYPE_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSS_SONATYPE_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}


### PR DESCRIPTION
## Purpose

Temporarily add the one-shot relocation-stubs deploy workflow to `main` **only so it can be dispatched** — GitHub requires a `workflow_dispatch` workflow to live on the default branch to be triggerable.

- Adds **only** `.github/workflows/release-relocation-stubs.yml` (one file). The stub project itself stays on `release/legacy`, **not** main.
- The workflow checks out `release/legacy` and deploys the relocation POMs to Maven Central using the org Sonatype + GPG secrets.

## Plan

1. Merge this PR.
2. I dispatch the workflow once → publishes the `oauth-sheriff-*:0.9.0` relocation stubs.
3. I verify the redirect resolves on Maven Central.
4. **Follow-up PR reverts this** — removing the workflow from `main` again.

So `main` only carries this workflow transiently; nothing relocation-related stays on it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manual release workflow to publish relocation stubs to Maven Central.
  * The release process now includes the required signing and repository credentials for a smoother deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->