### PR TITLE
chore: configure plan-marshall via marshall-steward wizard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,14 +22,15 @@ __pycache__/
 .claude/settings.local.json
 
 # Planning system (managed by /plan-marshall)
+# Planning system (managed by /marshall-steward)
+# Runtime state (plans, run-configuration, lessons-learned, memory, logs — managed by plan-marshall)
 .plan/*
 !.plan/marshal.json
+!.plan/project-architecture/
+!.plan/plugin-doctor.yml
+.plan/local/worktrees/
 
-# Planning system (managed by /marshall-steward)
 !.plan/project-structure.toon
 
-# Planning system (managed by /marshall-steward)
 !.plan/project-structure.json
 
-# Planning system (managed by /marshall-steward)
-!.plan/project-architecture/

--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -1,0 +1,226 @@
+{
+  "plan": {
+    "effort": "level-3",
+    "open_in_ide": true,
+    "coverage": {
+      "thoroughness": "inherit",
+      "scope": "inherit"
+    },
+    "phase-1-init": {
+      "branch_strategy": "feature",
+      "use_worktree": true,
+      "effort": "level-3",
+      "init_without_asking": true,
+      "deep_lane": "auto",
+      "escalation": "auto",
+      "auto_route_recipe": true,
+      "auto_route_recipe_threshold": 0.6
+    },
+    "phase-2-refine": {
+      "confidence_threshold": 95,
+      "compatibility": "breaking",
+      "simplicity": "lean",
+      "effort": "level-3",
+      "revalidation": "auto"
+    },
+    "phase-3-outline": {
+      "plan_without_asking": false,
+      "qgate": "auto",
+      "effort": "level-4"
+    },
+    "phase-4-plan": {
+      "execute_without_asking": true,
+      "effort": "level-3"
+    },
+    "phase-5-execute": {
+      "commit_and_push": true,
+      "max_iterations": 5,
+      "per_deliverable_build": [
+        "default:verify:compile",
+        "default:verify:module-tests"
+      ],
+      "cost_size_token_table": {
+        "S": "25K",
+        "M": "60K",
+        "L": "130K",
+        "XL": "260K"
+      },
+      "per_envelope_budget_tokens": "400K",
+      "verification_steps": {
+        "default:verify:quality-gate": {},
+        "default:verify:module-tests": {}
+      },
+      "effort": {
+        "default": "level-4",
+        "verification-feedback": "level-3"
+      }
+    },
+    "phase-6-finalize": {
+      "max_iterations": 3,
+      "finalize_without_asking": true,
+      "loop_back_without_asking": true,
+      "qgate": "auto",
+      "checks_wait_timeout_seconds": 600,
+      "steps": {
+        "default:finalize-step-sync-baseline": {
+          "auto_rebase_threshold": "no_overlap_only"
+        },
+        "default:pre-push-quality-gate": {},
+        "default:finalize-step-simplify": {
+          "simplify": "auto"
+        },
+        "default:push": {},
+        "default:create-pr": {},
+        "default:ci-verify": {},
+        "default:automated-review": {
+          "review_bot_buffer_seconds": 180,
+          "re_review_on_loopback": false,
+          "re_review_on_branch_cleanup": true,
+          "re_review_await_timeout_seconds": 600,
+          "re_review_on_timeout": "ask"
+        },
+        "default:sonar-roundtrip": {
+          "touched_file_cleanup": "new_code_only",
+          "do_transition": false,
+          "ce_wait_timeout_seconds": 600
+        },
+        "default:lessons-capture": {},
+        "default:branch-cleanup": {
+          "pr_merge_strategy": "squash",
+          "final_merge_without_asking": false,
+          "auto_rebase_threshold": "no_overlap_only",
+          "merge_queue_wait_budget_seconds": 1800,
+          "admin_merge_on_stuck_state": false
+        },
+        "default:record-metrics": {},
+        "default:archive-plan": {}
+      },
+      "effort": {
+        "default": "level-3",
+        "verification-feedback": "level-3",
+        "post-run-review": "level-4"
+      }
+    }
+  },
+  "build": {
+    "queue": {
+      "max_slots": 5,
+      "max_retries": 10,
+      "upper_limit_seconds": 600
+    },
+    "map": {
+      "java": [
+        {
+          "glob": "*/src/main/*.java",
+          "role": "production",
+          "build_class": "compile"
+        },
+        {
+          "glob": "*/src/test/*.java",
+          "role": "test",
+          "build_class": "module-tests"
+        },
+        {
+          "glob": "pom.xml",
+          "role": "config",
+          "build_class": "verify"
+        }
+      ],
+      "javascript": [
+        {
+          "glob": "*.js",
+          "role": "production",
+          "build_class": "compile"
+        },
+        {
+          "glob": "*.spec.js",
+          "role": "test",
+          "build_class": "module-tests"
+        },
+        {
+          "glob": "*.test.js",
+          "role": "test",
+          "build_class": "module-tests"
+        },
+        {
+          "glob": "package.json",
+          "role": "config",
+          "build_class": "verify"
+        }
+      ]
+    }
+  },
+  "project": {
+    "default_base_branch": "main",
+    "working_prefixes": [
+      "feature/",
+      "fix/",
+      "chore/"
+    ]
+  },
+  "providers": [
+    {
+      "skill_name": "plan-marshall:workflow-integration-sonar",
+      "category": "other",
+      "description": "SonarCloud/SonarQube code analysis platform",
+      "url": "https://sonarcloud.io"
+    },
+    {
+      "skill_name": "plan-marshall:workflow-integration-github",
+      "category": "ci",
+      "verify_command": "gh auth status",
+      "description": "GitHub CI provider via gh CLI — PRs, issues, CI status, reviews",
+      "url": "https://api.github.com"
+    },
+    {
+      "skill_name": "plan-marshall:workflow-integration-git",
+      "category": "version-control",
+      "verify_command": "git config user.name",
+      "description": "Git version control via git CLI — commit, push, branch operations",
+      "url": "https://github.com/cuioss/TokenSheriff.git"
+    }
+  ],
+  "skill_domains": {
+    "system": {
+      "defaults": [],
+      "optionals": []
+    },
+    "java": {
+      "bundle": "pm-dev-java",
+      "workflow_skill_extensions": {
+        "triage": "pm-dev-java:ext-triage-java"
+      }
+    },
+    "java-cui": {
+      "bundle": "pm-dev-java-cui"
+    },
+    "javascript": {
+      "bundle": "pm-dev-frontend",
+      "workflow_skill_extensions": {
+        "triage": "pm-dev-frontend:ext-triage-js"
+      }
+    },
+    "documentation": {
+      "bundle": "pm-documents",
+      "workflow_skill_extensions": {
+        "triage": "pm-documents:ext-triage-docs"
+      }
+    },
+    "general-dev": {
+      "bundle": "plan-marshall"
+    },
+    "active_profiles": [
+      "implementation",
+      "module_testing",
+      "quality"
+    ]
+  },
+  "system": {
+    "retention": {
+      "logs_days": 1,
+      "archived_plans_days": 5,
+      "lessons_superseded_days": 0,
+      "temp_on_maintenance": true
+    }
+  }
+}

--- a/.plan/project-architecture/_project.json
+++ b/.plan/project-architecture/_project.json
@@ -1,0 +1,26 @@
+{
+  "description": "Token-Sheriff is a security-focused Java/Quarkus framework for validating OAuth2/OIDC JWT tokens in multi-issuer environments. It provides a standalone core validation library (parsing, JWKS key loading, claim mapping, JWE decryption, DPoP), a Quarkus extension (runtime + build-time deployment) with Dev-UI tooling, plus benchmarking and end-to-end test harnesses.",
+  "description_reasoning": "source: README.md introduction and parent pom description; corroborated by module descriptions",
+  "extensions_used": [
+    "plan-marshall",
+    "pm-documents"
+  ],
+  "modules": {
+    "benchmark-core": {},
+    "benchmark-integration-wrk": {},
+    "benchmarking": {},
+    "benchmarking-common": {},
+    "documentation": {},
+    "e-2-e-playwright-maven": {},
+    "e-2-e-playwright-npm": {},
+    "token-sheriff-bom": {},
+    "token-sheriff-parent": {},
+    "token-sheriff-quarkus-integration-tests": {},
+    "token-sheriff-quarkus-parent": {},
+    "token-sheriff-validation": {},
+    "token-sheriff-validation-quarkus": {},
+    "token-sheriff-validation-quarkus-deployment-maven": {},
+    "token-sheriff-validation-quarkus-deployment-npm": {}
+  },
+  "name": "TokenSheriff"
+}

--- a/.plan/project-architecture/benchmark-core/enriched.json
+++ b/.plan/project-architecture/benchmark-core/enriched.json
@@ -1,0 +1,92 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [
+    "token-sheriff-validation",
+    "benchmarking-common"
+  ],
+  "key_dependencies": [],
+  "key_dependencies_reasoning": "Benchmarks the core library using shared benchmarking-common infrastructure",
+  "key_packages": {
+    "de.cuioss.sheriff.token.validation.benchmark": {
+      "description": "Benchmark runners and the mock token repository driving JMH/JFR/concurrency-sweep runs."
+    },
+    "de.cuioss.sheriff.token.validation.benchmark.jfr.benchmarks": {
+      "description": "JFR-instrumented benchmark variants for profiling validation under different loads."
+    },
+    "de.cuioss.sheriff.token.validation.benchmark.standard": {
+      "description": "Standard JMH benchmarks for core validation and error-load throughput."
+    }
+  },
+  "purpose": "benchmark",
+  "purpose_reasoning": "JMH benchmark classes (jar) targeting the core library",
+  "responsibility": "JMH micro-benchmarks measuring the core token-validation library in isolation. Defines benchmark runners (standard, concurrency-sweep, JFR-profiled), delegates for core/error/mixed validation loads, and a mock token repository to exercise TokenValidator without network.",
+  "responsibility_reasoning": "source: pom description 'Benchmarking module for OAuth/JWT token validation', packages benchmark/standard/jfr/delegates and runners; benchmark profiles",
+  "skills_by_profile": {
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "module_testing": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
+          "skill": "plan-marshall:persona-module-tester"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
+          "skill": "pm-dev-java:junit-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "quality": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JavaDoc documentation standards including class, method, and code example patterns",
+          "skill": "pm-dev-java:javadoc"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "",
+  "tips": []
+}

--- a/.plan/project-architecture/benchmark-integration-wrk/enriched.json
+++ b/.plan/project-architecture/benchmark-integration-wrk/enriched.json
@@ -1,0 +1,85 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [
+    "benchmarking-common"
+  ],
+  "key_dependencies": [],
+  "key_dependencies_reasoning": "Reuses benchmarking-common converters/reporting for wrk result processing",
+  "key_packages": {
+    "de.cuioss.sheriff.token.wrk.benchmark": {
+      "description": "WrkResultPostProcessor converting raw wrk output into the shared benchmark data/report model."
+    }
+  },
+  "purpose": "benchmark",
+  "purpose_reasoning": "HTTP load benchmarks (jar) using external wrk against running endpoints",
+  "responsibility": "WRK-based HTTP integration benchmarks driving the deployed Quarkus validation endpoints. Bundles wrk Lua/shell scripts (ablation, JFR, concurrency, health) plus a WrkResultPostProcessor that parses raw wrk output into the common benchmark report model.",
+  "responsibility_reasoning": "source: pom description 'WRK-based HTTP benchmarks for OAuth/JWT validation endpoints', WrkResultPostProcessor + wrk-scripts resources",
+  "skills_by_profile": {
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "module_testing": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
+          "skill": "plan-marshall:persona-module-tester"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
+          "skill": "pm-dev-java:junit-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "quality": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JavaDoc documentation standards including class, method, and code example patterns",
+          "skill": "pm-dev-java:javadoc"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "",
+  "tips": []
+}

--- a/.plan/project-architecture/benchmarking-common/enriched.json
+++ b/.plan/project-architecture/benchmarking-common/enriched.json
@@ -1,0 +1,92 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [],
+  "key_dependencies": [],
+  "key_dependencies_reasoning": "",
+  "key_packages": {
+    "de.cuioss.benchmarking.common.converter": {
+      "description": "Converters normalizing JMH and WRK raw output into the common BenchmarkData model."
+    },
+    "de.cuioss.benchmarking.common.metrics": {
+      "description": "Metrics collection/transformation pipeline incl. Prometheus client and JSON exporters."
+    },
+    "de.cuioss.benchmarking.common.report": {
+      "description": "Report, badge and GitHub-Pages generation from benchmark results with historical trend data."
+    },
+    "de.cuioss.benchmarking.common.repository": {
+      "description": "Keycloak-backed token repositories/providers supplying real tokens for benchmark load."
+    }
+  },
+  "purpose": "library",
+  "purpose_reasoning": "packaging=jar of reusable benchmark infrastructure consumed by benchmark-core and benchmark-integration-wrk",
+  "responsibility": "Shared benchmarking infrastructure used by all benchmark modules. Provides JMH/WRK result converters, a metrics pipeline (Prometheus client, transformers, JFR instrumentation), Keycloak token repositories/providers for load generation, and HTML/badge report + GitHub-Pages generation.",
+  "responsibility_reasoning": "source: pom description 'Common benchmarking infrastructure with JMH integration', packages config/converter/metrics/jfr/report/repository",
+  "skills_by_profile": {
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "module_testing": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
+          "skill": "plan-marshall:persona-module-tester"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
+          "skill": "pm-dev-java:junit-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "quality": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JavaDoc documentation standards including class, method, and code example patterns",
+          "skill": "pm-dev-java:javadoc"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "",
+  "tips": []
+}

--- a/.plan/project-architecture/benchmarking/enriched.json
+++ b/.plan/project-architecture/benchmarking/enriched.json
@@ -1,0 +1,79 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [],
+  "key_dependencies": [],
+  "key_dependencies_reasoning": "",
+  "key_packages": {},
+  "purpose": "parent",
+  "purpose_reasoning": "packaging=pom aggregating benchmark sub-modules",
+  "responsibility": "Parent POM aggregating all benchmarking sub-modules (common infrastructure, JMH micro-benchmarks, WRK integration benchmarks). Coordinates the benchmark build profile and groups performance-measurement tooling.",
+  "responsibility_reasoning": "source: benchmarking/pom.xml packaging=pom, description 'Parent module for all benchmarking related modules'",
+  "skills_by_profile": {
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "module_testing": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
+          "skill": "plan-marshall:persona-module-tester"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
+          "skill": "pm-dev-java:junit-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "quality": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JavaDoc documentation standards including class, method, and code example patterns",
+          "skill": "pm-dev-java:javadoc"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "",
+  "tips": []
+}

--- a/.plan/project-architecture/documentation/enriched.json
+++ b/.plan/project-architecture/documentation/enriched.json
@@ -1,0 +1,15 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [],
+  "key_dependencies": [],
+  "key_dependencies_reasoning": "",
+  "key_packages": {},
+  "purpose": "documentation",
+  "purpose_reasoning": "documentation build system, only .adoc docs and diagram scripts",
+  "responsibility": "AsciiDoc project documentation tree under doc/, including the OIDC client specification/planning series and PlantUML diagram sources. Holds narrative architecture, specification and migration documents rather than build artifacts.",
+  "responsibility_reasoning": "source: doc/ build_system=documentation, contains README.adoc plus oidc/01-06 spec series and plantuml scripts",
+  "skills_by_profile": {},
+  "skills_by_profile_reasoning": "",
+  "tips": []
+}

--- a/.plan/project-architecture/e-2-e-playwright-maven/enriched.json
+++ b/.plan/project-architecture/e-2-e-playwright-maven/enriched.json
@@ -1,0 +1,81 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [
+    "e-2-e-playwright-npm"
+  ],
+  "key_dependencies": [],
+  "key_dependencies_reasoning": "Maven facet delegates to the npm Playwright test sibling",
+  "key_packages": {},
+  "purpose": "integration-tests",
+  "purpose_reasoning": "Maven wrapper (pom) driving the Playwright E2E npm tests",
+  "responsibility": "Maven build facet (virtual) that hooks the Playwright end-to-end Dev-UI tests into the Maven lifecycle via the e2e-tests profile, orchestrating the npm test run against a started dev environment.",
+  "responsibility_reasoning": "source: pom packaging=pom, description 'End-to-End Playwright tests for Token-Sheriff Dev-UI components', e2e-tests profile, paired npm sibling",
+  "skills_by_profile": {
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "module_testing": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
+          "skill": "plan-marshall:persona-module-tester"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
+          "skill": "pm-dev-java:junit-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "quality": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JavaDoc documentation standards including class, method, and code example patterns",
+          "skill": "pm-dev-java:javadoc"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "",
+  "tips": []
+}

--- a/.plan/project-architecture/e-2-e-playwright-npm/enriched.json
+++ b/.plan/project-architecture/e-2-e-playwright-npm/enriched.json
@@ -1,0 +1,68 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [],
+  "key_dependencies": [],
+  "key_dependencies_reasoning": "",
+  "key_packages": {},
+  "purpose": "integration-tests",
+  "purpose_reasoning": "npm Playwright browser E2E test project, no shipped artifact",
+  "responsibility": "The Playwright end-to-end test suite (virtual npm sibling) validating the Quarkus Dev-UI in a real browser. Provides functional and accessibility (axe-core) tests, Keycloak token fixtures, and a precheck-gated runner against a live dev environment.",
+  "responsibility_reasoning": "source: package.json 'End-to-End Playwright tests for Token-Sheriff Dev-UI', @playwright/test + @axe-core deps, test:functional/test:a11y scripts, fixtures/utils",
+  "skills_by_profile": {
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core JavaScript development standards covering ES modules, modern patterns, web component patterns, DOM trust boundaries / XSS prevention, and code quality",
+          "skill": "pm-dev-frontend:javascript"
+        }
+      ]
+    },
+    "module_testing": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
+          "skill": "plan-marshall:persona-module-tester"
+        },
+        {
+          "description": "Core JavaScript development standards covering ES modules, modern patterns, web component patterns, DOM trust boundaries / XSS prevention, and code quality",
+          "skill": "pm-dev-frontend:javascript"
+        },
+        {
+          "description": "JavaScript unit testing with Jest, DOM testing, mocking, async patterns",
+          "skill": "pm-dev-frontend:jest-testing"
+        }
+      ]
+    },
+    "quality": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        }
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "",
+  "tips": []
+}

--- a/.plan/project-architecture/token-sheriff-bom/enriched.json
+++ b/.plan/project-architecture/token-sheriff-bom/enriched.json
@@ -1,0 +1,79 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [],
+  "key_dependencies": [],
+  "key_dependencies_reasoning": "",
+  "key_packages": {},
+  "purpose": "bom",
+  "purpose_reasoning": "Bill of Materials POM under bom/",
+  "responsibility": "Bill of Materials (BOM) POM that publishes a curated, version-aligned set of Token-Sheriff artifact coordinates so downstream consumers can import consistent module versions via dependencyManagement.",
+  "responsibility_reasoning": "source: bom/pom.xml description 'Bill of Materials (BOM) for Token-Sheriff modules', packaging=pom",
+  "skills_by_profile": {
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "module_testing": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
+          "skill": "plan-marshall:persona-module-tester"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
+          "skill": "pm-dev-java:junit-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "quality": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JavaDoc documentation standards including class, method, and code example patterns",
+          "skill": "pm-dev-java:javadoc"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "",
+  "tips": []
+}

--- a/.plan/project-architecture/token-sheriff-parent/enriched.json
+++ b/.plan/project-architecture/token-sheriff-parent/enriched.json
@@ -1,0 +1,79 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [],
+  "key_dependencies": [],
+  "key_dependencies_reasoning": "",
+  "key_packages": {},
+  "purpose": "parent",
+  "purpose_reasoning": "packaging=pom at root with module aggregation",
+  "responsibility": "Root aggregator/parent POM for the entire Token-Sheriff build. Declares shared build configuration, plugin management, dependency versions and the cuioss parent inheritance, and aggregates all sub-modules (validation core, Quarkus integration, BOM, benchmarking, documentation).",
+  "responsibility_reasoning": "source: pom.xml packaging=pom at repo root, parent de.cuioss:cui-java-parent, aggregates 14 build files",
+  "skills_by_profile": {
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "module_testing": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
+          "skill": "plan-marshall:persona-module-tester"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
+          "skill": "pm-dev-java:junit-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "quality": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JavaDoc documentation standards including class, method, and code example patterns",
+          "skill": "pm-dev-java:javadoc"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "",
+  "tips": []
+}

--- a/.plan/project-architecture/token-sheriff-quarkus-integration-tests/enriched.json
+++ b/.plan/project-architecture/token-sheriff-quarkus-integration-tests/enriched.json
@@ -1,0 +1,85 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [
+    "token-sheriff-validation-quarkus"
+  ],
+  "key_dependencies": [],
+  "key_dependencies_reasoning": "Integration-tests the Quarkus runtime extension end-to-end",
+  "key_packages": {
+    "de.cuioss.sheriff.token.integration.endpoint": {
+      "description": "Test JAX-RS endpoints (real + mock) used as the system-under-test for validation IT suites."
+    }
+  },
+  "purpose": "integration-tests",
+  "purpose_reasoning": "jar of Failsafe *IT tests + container infrastructure, no published API",
+  "responsibility": "End-to-end integration tests for the Quarkus extension. Ships a TestApplication with JWT/mock validation endpoints and *IT suites exercising bearer auth, DPoP, JWE, and health against real Keycloak/Zitadel IdPs in Docker, including native-image and HTTPS scenarios.",
+  "responsibility_reasoning": "source: pom description 'Integration tests for the Token-Sheriff Quarkus extension including native container testing with HTTPS', *SpecIT/*IT classes, docker keycloak/zitadel scripts",
+  "skills_by_profile": {
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "module_testing": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
+          "skill": "plan-marshall:persona-module-tester"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
+          "skill": "pm-dev-java:junit-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "quality": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JavaDoc documentation standards including class, method, and code example patterns",
+          "skill": "pm-dev-java:javadoc"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "",
+  "tips": []
+}

--- a/.plan/project-architecture/token-sheriff-quarkus-parent/enriched.json
+++ b/.plan/project-architecture/token-sheriff-quarkus-parent/enriched.json
@@ -1,0 +1,79 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [],
+  "key_dependencies": [],
+  "key_dependencies_reasoning": "",
+  "key_packages": {},
+  "purpose": "parent",
+  "purpose_reasoning": "packaging=pom aggregating Quarkus runtime/deployment/IT modules",
+  "responsibility": "Parent POM for the Quarkus integration sub-tree. Aggregates the runtime extension, build-time deployment module, integration-tests and Playwright E2E modules, and centralizes Quarkus-specific build configuration and the coverage profile.",
+  "responsibility_reasoning": "source: token-sheriff-quarkus-parent/pom.xml packaging=pom, description references Quarkus integration parent, aggregates 7 build files",
+  "skills_by_profile": {
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "module_testing": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
+          "skill": "plan-marshall:persona-module-tester"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
+          "skill": "pm-dev-java:junit-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "quality": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JavaDoc documentation standards including class, method, and code example patterns",
+          "skill": "pm-dev-java:javadoc"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "",
+  "tips": []
+}

--- a/.plan/project-architecture/token-sheriff-validation-quarkus-deployment-maven/enriched.json
+++ b/.plan/project-architecture/token-sheriff-validation-quarkus-deployment-maven/enriched.json
@@ -1,0 +1,87 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [
+    "token-sheriff-validation-quarkus"
+  ],
+  "key_dependencies": [
+    "io.quarkus:quarkus-core-deployment"
+  ],
+  "key_dependencies_reasoning": "Deployment module augments the runtime extension at build time via Quarkus deployment API",
+  "key_packages": {
+    "de.cuioss.sheriff.token.quarkus.deployment": {
+      "description": "TokenSheriffProcessor build steps registering beans, native/reflection config and Dev-UI integration."
+    }
+  },
+  "purpose": "deployment",
+  "purpose_reasoning": "Quarkus build-time deployment processor (jar) paired with the runtime extension",
+  "responsibility": "The Quarkus build-time deployment companion to the runtime extension. Its TokenSheriffProcessor defines the @BuildStep wiring (bean registration, reflection/native config, Dev-UI card and JWT debugger/status pages) that Quarkus executes during augmentation.",
+  "responsibility_reasoning": "source: pom description 'Deployment module for Quarkus integration', TokenSheriffProcessor + dev-ui qwc-* resources",
+  "skills_by_profile": {
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "module_testing": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
+          "skill": "plan-marshall:persona-module-tester"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
+          "skill": "pm-dev-java:junit-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "quality": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JavaDoc documentation standards including class, method, and code example patterns",
+          "skill": "pm-dev-java:javadoc"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "",
+  "tips": []
+}

--- a/.plan/project-architecture/token-sheriff-validation-quarkus-deployment-npm/enriched.json
+++ b/.plan/project-architecture/token-sheriff-validation-quarkus-deployment-npm/enriched.json
@@ -1,0 +1,72 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [],
+  "key_dependencies": [],
+  "key_dependencies_reasoning": "",
+  "key_packages": {
+    "de.cuioss.sheriff.token.quarkus.deployment": {
+      "description": "Dev-UI JavaScript components (qwc-jwt-debugger, qwc-jwt-status-config) and their build/test tooling."
+    }
+  },
+  "purpose": "extension",
+  "purpose_reasoning": "npm virtual module providing the Dev-UI JS components for the Quarkus deployment extension",
+  "responsibility": "The JavaScript/Dev-UI build facet of the deployment module (virtual npm sibling). Owns the Lit-based Dev-UI web components (JWT debugger, status/config cards) under src/main/resources/dev-ui with their npm lint/test/format/coverage tooling.",
+  "responsibility_reasoning": "source: package.json 'DevUI components for Token-Sheriff Quarkus extension', 26 npm scripts (test/lint/css), qwc-jwt-*.js dev-ui sources",
+  "skills_by_profile": {
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core JavaScript development standards covering ES modules, modern patterns, web component patterns, DOM trust boundaries / XSS prevention, and code quality",
+          "skill": "pm-dev-frontend:javascript"
+        }
+      ]
+    },
+    "module_testing": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
+          "skill": "plan-marshall:persona-module-tester"
+        },
+        {
+          "description": "Core JavaScript development standards covering ES modules, modern patterns, web component patterns, DOM trust boundaries / XSS prevention, and code quality",
+          "skill": "pm-dev-frontend:javascript"
+        },
+        {
+          "description": "JavaScript unit testing with Jest, DOM testing, mocking, async patterns",
+          "skill": "pm-dev-frontend:jest-testing"
+        }
+      ]
+    },
+    "quality": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        }
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "",
+  "tips": []
+}

--- a/.plan/project-architecture/token-sheriff-validation-quarkus/enriched.json
+++ b/.plan/project-architecture/token-sheriff-validation-quarkus/enriched.json
@@ -1,0 +1,97 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [
+    "token-sheriff-validation"
+  ],
+  "key_dependencies": [
+    "io.quarkus:quarkus-arc",
+    "io.quarkus:quarkus-rest"
+  ],
+  "key_dependencies_reasoning": "Wraps the core token-sheriff-validation library; built on Quarkus ARC (CDI) and REST",
+  "key_packages": {
+    "de.cuioss.sheriff.token.quarkus.annotation": {
+      "description": "Injection annotations (@BearerToken, @BearerAuth) and the servlet objects resolver for the CDI security integration."
+    },
+    "de.cuioss.sheriff.token.quarkus.config": {
+      "description": "MicroProfile-Config-driven resolvers mapping application properties into core IssuerConfig/ParserConfig/cache/JWE configuration."
+    },
+    "de.cuioss.sheriff.token.quarkus.health": {
+      "description": "SmallRye health checks for the token validator and configured JWKS endpoints."
+    },
+    "de.cuioss.sheriff.token.quarkus.producer": {
+      "description": "CDI producers turning validated bearer tokens into injectable results (TokenValidatorProducer, BearerTokenProducer)."
+    }
+  },
+  "purpose": "extension",
+  "purpose_reasoning": "Quarkus runtime extension (jar) with CDI producers, config resolvers and Dev-UI runtime service; paired with deployment module",
+  "responsibility": "The Quarkus runtime extension that wires the core validation library into Quarkus/CDI. Provides CDI producers for TokenValidator and bearer-token injection (@BearerToken/@BearerAuth), MicroProfile-Config-driven issuer/parser/cache/JWE resolvers, health checks, Micrometer metrics, access logging, and Keycloak claim-mapper beans.",
+  "responsibility_reasoning": "source: pom description 'Runtime module for Quarkus integration...providing configuration, producers, and integration from SecurityEvents to Micrometer', packages quarkus.producer/config/health/metrics/annotation",
+  "skills_by_profile": {
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "module_testing": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
+          "skill": "plan-marshall:persona-module-tester"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
+          "skill": "pm-dev-java:junit-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "quality": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JavaDoc documentation standards including class, method, and code example patterns",
+          "skill": "pm-dev-java:javadoc"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "",
+  "tips": []
+}

--- a/.plan/project-architecture/token-sheriff-validation/enriched.json
+++ b/.plan/project-architecture/token-sheriff-validation/enriched.json
@@ -1,0 +1,95 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [],
+  "key_dependencies": [
+    "de.cuioss:cui-http",
+    "de.cuioss:cui-java-tools"
+  ],
+  "key_dependencies_reasoning": "cui-http provides the resilient HTTP/ETag client used by HttpJwksLoader; cui-java-tools provides core utilities and logging",
+  "key_packages": {
+    "de.cuioss.sheriff.token.validation": {
+      "description": "Public API surface: TokenValidator entry point, IssuerConfig, ParserConfig, TokenType and issuer-config caching."
+    },
+    "de.cuioss.sheriff.token.validation.domain.claim.mapper": {
+      "description": "Claim value mappers, including Keycloak-specific roles/groups and scope/collection mappers."
+    },
+    "de.cuioss.sheriff.token.validation.jwks": {
+      "description": "JWKS key loading (HTTP/file/in-memory), parsing and key resolution for signature verification."
+    },
+    "de.cuioss.sheriff.token.validation.pipeline": {
+      "description": "The staged token-validation pipeline orchestrating signature, claim and expiration checks."
+    }
+  },
+  "purpose": "library",
+  "purpose_reasoning": "packaging=jar, framework-agnostic core, depended on by Quarkus and benchmark modules",
+  "responsibility": "The standalone core JWT validation library. Provides the TokenValidator entry point and a full validation pipeline: multi-issuer configuration, JWKS key loading/caching, signature verification, claim extraction and mapping (incl. Keycloak mappers), JWE decryption, DPoP proof validation, and OIDC well-known discovery \u2014 all with no runtime framework dependency.",
+  "responsibility_reasoning": "source: README.adoc 'Comprehensive JWT token validation library', pom description 'Core library for OAuth/JWT token validation in multi-issuer environments', package layout (pipeline, jwks, jwe, dpop, domain.claim.mapper)",
+  "skills_by_profile": {
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "module_testing": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
+          "skill": "plan-marshall:persona-module-tester"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
+          "skill": "pm-dev-java:junit-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "quality": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JavaDoc documentation standards including class, method, and code example patterns",
+          "skill": "pm-dev-java:javadoc"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "",
+  "tips": []
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,5 +200,5 @@ Execute comprehensive quality verification and commit workflow for a specific mo
 
 ## Tool Usage
 
-- Use proper tools (Edit, Read, Write) instead of shell commands (echo, cat)
-- Never use Bash for file operations (find, grep, cat, ls) — use Glob, Read, Grep tools instead
+- For ad-hoc file reading, searching, and editing, prefer the dedicated tools (Edit, Read, Write, Glob, Grep) over their shell equivalents (echo, cat, ls, find, grep).
+- This is a default for exploratory work only — it does **not** override the prescribed `grep`/`find`-based steps in the custom commands above (fixOpenRewriteMarkers, verifyCuiLoggingGuidelines, verifyAndCommit) or any other documented verification/cleanup workflow. Run those commands exactly as written.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,3 +197,8 @@ Execute comprehensive quality verification and commit workflow for a specific mo
 - **NEVER commit with source artifacts** - Source directories must be clean of .class files
 - **ALWAYS fix issues systematically** - Address root causes, not symptoms
 
+
+## Tool Usage
+
+- Use proper tools (Edit, Read, Write) instead of shell commands (echo, cat)
+- Never use Bash for file operations (find, grep, cat, ls) — use Glob, Read, Grep tools instead


### PR DESCRIPTION
Initializes the plan-marshall planning system for TokenSheriff (output of the `/marshall-steward` first-run wizard).

## Changes
- **`.plan/marshal.json`** — skill domains (java, java-cui, javascript, documentation, general-dev), GitHub CI + SonarCloud providers, `full` finalize preset, review gates (pause only at outline→plan), build map (java + javascript). The `build` block carries only `queue` + `map` — the `require_wrapper` knobs were removed (wrapper use is auto-detected from the filesystem at execution time, so the knob was inert; tracked as a plan-marshall lesson for upstream removal).
- **`.plan/project-architecture/`** — discovered + LLM-enriched descriptors for all 15 modules (responsibilities, purpose classification, key packages).
- **`.gitignore`** — consolidated the plan-marshall managed block (track `marshal.json` + `project-architecture/`; ignore runtime/local state).
- **`CLAUDE.md`** — appended the plan-marshall tool-usage note.

No production code or build changes; configuration only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on using the project’s dedicated Edit/Read/Write/Glob/Grep tools (instead of shell commands) for exploratory work.
* **Chores**
  * Refined ignore rules for planning/runtime `.plan/` artifacts to better manage generated and local plan files.
  * Added/updated planning and architecture metadata (including benchmark and end-to-end test descriptors) to make workflows more consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->