### PR TITLE
fix(validation): repair issuer-config lifecycle (H-1, H-2, M-2)

### DIFF
--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/IssuerConfig.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/IssuerConfig.java
@@ -79,8 +79,10 @@ import java.util.*;
  *
  * @since 1.0
  */
-@EqualsAndHashCode
-@ToString
+// doNotUseGetters: getIssuerIdentifier() intentionally throws for disabled configs,
+// which must remain safe to log/compare (e.g. ISSUER_CONFIG_SKIPPED)
+@EqualsAndHashCode(doNotUseGetters = true)
+@ToString(doNotUseGetters = true)
 public class IssuerConfig implements LoadingStatusProvider {
 
     private static final CuiLogger LOGGER = new CuiLogger(IssuerConfig.class);

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/IssuerConfig.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/IssuerConfig.java
@@ -970,9 +970,9 @@ public class IssuerConfig implements LoadingStatusProvider {
             // the JWKS loading method. Validator maps and caches are keyed by this value
             // before any (async) JWKS loading has completed, so it cannot be supplied by
             // well-known discovery.
-            if (issuerIdentifier == null) {
+            if (issuerIdentifier == null || issuerIdentifier.isBlank()) {
                 throw new IllegalArgumentException("""
-                        issuerIdentifier is required for enabled issuer configurations. \
+                        issuerIdentifier is required (non-blank) for enabled issuer configurations. \
                         For well-known discovery, set it to the issuer URL of the discovery document.""");
             }
         }

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/IssuerConfig.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/IssuerConfig.java
@@ -53,6 +53,7 @@ import java.util.*;
  * <pre>
  * // Create an issuer configuration with HTTP-based JWKS loading (well-known discovery)
  * IssuerConfig issuerConfig = IssuerConfig.builder()
+ *     .issuerIdentifier("https://example.com")
  *     .expectedAudience("my-client")
  *     .httpJwksLoaderConfig(HttpJwksLoaderConfig.builder()
  *         .wellKnownUrl("https://example.com/.well-known/openid-configuration")
@@ -63,7 +64,6 @@ import java.util.*;
  * // Initialize the security event counter -> This is usually done by TokenValidator
  * issuerConfig.initJWKSLoader(new SecurityEventCounter());
  *
- * // Issuer identifier is dynamically obtained from well-known discovery
  * String issuer = issuerConfig.getIssuerIdentifier();
  * </pre>
  * <p>
@@ -103,22 +103,22 @@ public class IssuerConfig implements LoadingStatusProvider {
      * Default value is {@code true}.
      */
     @Getter
-    boolean enabled;
+    private final boolean enabled;
 
     /**
      * The issuer identifier for token validation.
      * <p>
-     * This field is required for all JWKS loading variants except well-known discovery.
-     * For well-known discovery, the issuer identifier is automatically extracted from
-     * the discovery document and this field is optional.
+     * This field is required for all enabled issuer configurations, regardless of the
+     * JWKS loading variant. For well-known discovery, the discovered issuer is compared
+     * against this value and a mismatch is logged as a security event, but this configured
+     * value is always authoritative.
      * </p>
      * <p>
      * This identifier must match the "iss" claim in validated tokens.
      * </p>
      */
-    @Getter
     @Nullable
-    String issuerIdentifier;
+    private final String issuerIdentifier;
 
     /**
      * Set of expected audience values.
@@ -129,7 +129,7 @@ public class IssuerConfig implements LoadingStatusProvider {
      * {@code true}. An empty audience set with validation enabled will fail at build time.
      */
     @Getter
-    Set<String> expectedAudience;
+    private final Set<String> expectedAudience;
 
     /**
      * Whether audience validation is explicitly disabled for this issuer.
@@ -140,7 +140,7 @@ public class IssuerConfig implements LoadingStatusProvider {
      * Default value is {@code false} (audience validation is required).
      */
     @Getter
-    boolean audienceValidationDisabled;
+    private final boolean audienceValidationDisabled;
 
     /**
      * Set of expected client ID values.
@@ -148,7 +148,7 @@ public class IssuerConfig implements LoadingStatusProvider {
      * If the token's client ID claim matches any of these values, it is considered valid.
      */
     @Getter
-    Set<String> expectedClientId;
+    private final Set<String> expectedClientId;
 
     /**
      * Whether the "sub" (subject) claim is optional for this issuer.
@@ -173,7 +173,7 @@ public class IssuerConfig implements LoadingStatusProvider {
      * @see <a href="https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.2">RFC 7519 - 4.1.2. "sub" (Subject) Claim</a>
      */
     @Getter
-    boolean claimSubOptional;
+    private final boolean claimSubOptional;
 
     /**
      * Whether the audience ("aud") claim is optional for access tokens from this issuer.
@@ -203,7 +203,7 @@ public class IssuerConfig implements LoadingStatusProvider {
      * @see <a href="https://datatracker.ietf.org/doc/html/rfc9068#section-4">RFC 9068 - 4. JWT Access Token Claims</a>
      */
     @Getter
-    boolean accessTokenAudienceOptional;
+    private final boolean accessTokenAudienceOptional;
 
     // Design Decision: expectedTokenType defaults to null (no token type validation).
     //
@@ -242,7 +242,7 @@ public class IssuerConfig implements LoadingStatusProvider {
      */
     @Getter
     @Nullable
-    String expectedTokenType;
+    private final String expectedTokenType;
 
     /**
      * Optional DPoP (Demonstrating Proof of Possession) configuration per RFC 9449.
@@ -260,7 +260,7 @@ public class IssuerConfig implements LoadingStatusProvider {
      */
     @Getter
     @Nullable
-    DpopConfig dpopConfig;
+    private final DpopConfig dpopConfig;
 
     /**
      * Clock skew tolerance in seconds for time-based claim validation (exp, nbf).
@@ -276,7 +276,7 @@ public class IssuerConfig implements LoadingStatusProvider {
      * @see <a href="https://download.eclipse.org/microprofile/microprofile-jwt-auth-2.1/microprofile-jwt-auth-spec-2.1.html">MP-JWT 2.1 - mp.jwt.verify.clock.skew</a>
      */
     @Getter
-    int clockSkewSeconds;
+    private final int clockSkewSeconds;
 
     /**
      * Maximum token age in seconds based on the {@code iat} claim, or {@code null} if disabled.
@@ -294,17 +294,17 @@ public class IssuerConfig implements LoadingStatusProvider {
      */
     @Getter
     @Nullable
-    Integer maxTokenAgeSeconds;
+    private final Integer maxTokenAgeSeconds;
 
     @Getter
-    SignatureAlgorithmPreferences algorithmPreferences;
+    private final SignatureAlgorithmPreferences algorithmPreferences;
 
     /**
      * Custom claim mappers that take precedence over the default ones.
      * The key is the claim name, and the value is the mapper to use for that claim.
      */
     @Getter
-    Map<String, ClaimMapper> claimMappers;
+    private final Map<String, ClaimMapper> claimMappers;
 
     /**
      * The JwksLoader instance used for loading JWKS keys.
@@ -313,41 +313,24 @@ public class IssuerConfig implements LoadingStatusProvider {
      */
     @Getter
     @Nullable
-    JwksLoader jwksLoader;
+    private final JwksLoader jwksLoader;
 
 
     /**
      * Gets the issuer identifier for token validation.
      * <p>
-     * This method provides the issuer identifier that should be used for token validation.
-     * The resolution logic prioritizes dynamic issuer identification (for well-known discovery)
-     * over static configuration:
-     * </p>
-     * <p>
-     * The resolution logic is:
-     * <ol>
-     *   <li>If the JwksLoader is initialized and healthy, delegate to its issuer identifier first</li>
-     *   <li>If the JwksLoader returns empty (for non-well-known cases), use the configured issuerIdentifier</li>
-     *   <li>Throws an exception if neither is available (validation ensures this never happens)</li>
-     * </ol>
+     * Returns the configured issuer identifier, which is required for all enabled
+     * configurations and validated during {@link IssuerConfigBuilder#build()}.
+     * For well-known discovery, the discovered issuer never overrides this value;
+     * a mismatch is surfaced as a {@code ISSUER_MISMATCH} security event by the loader.
      *
      * @return the issuer identifier, never null
+     * @throws IllegalStateException if called on a disabled configuration that was
+     *         built without an issuer identifier
      */
-   
     public String getIssuerIdentifier() {
-        // First try to get issuer identifier from JwksLoader (for well-known discovery)
-        if (jwksLoader != null && jwksLoader.isLoaderStatusOK()) {
-            Optional<String> jwksLoaderIssuer = jwksLoader.getIssuerIdentifier();
-            if (jwksLoaderIssuer.isPresent()) {
-                return jwksLoaderIssuer.get();
-            }
-        }
-
-        // Fall back to configured issuer identifier (for file-based, in-memory, etc.)
         Preconditions.checkState(issuerIdentifier != null,
-                """
-                        issuerIdentifier is null - this indicates a bug in validation logic. \
-                        Non-well-known JWKS loaders should have been validated to require issuerIdentifier during initialization.""");
+                "issuerIdentifier is null - it is only optional for disabled issuer configurations, which must not be used for validation");
         return issuerIdentifier;
     }
 
@@ -403,7 +386,7 @@ public class IssuerConfig implements LoadingStatusProvider {
      * The builder validates configuration consistency during the {@link #build()} method call, ensuring that:
      * <ul>
      *   <li>At least one JWKS loading method is configured for enabled issuers</li>
-     *   <li>Issuer identifier is provided when required (not needed for well-known discovery)</li>
+     *   <li>Issuer identifier is provided for enabled issuers</li>
      *   <li>Algorithm preferences and claim mappers are properly initialized</li>
      * </ul>
      */
@@ -450,9 +433,10 @@ public class IssuerConfig implements LoadingStatusProvider {
         /**
          * Sets the issuer identifier for token validation.
          * <p>
-         * This identifier must match the "iss" claim in validated tokens. It is required for all
-         * JWKS loading variants except well-known discovery, where the issuer identifier is
-         * automatically extracted from the discovery document.
+         * This identifier must match the "iss" claim in validated tokens. It is required for
+         * all enabled issuer configurations, regardless of the JWKS loading variant. For
+         * well-known discovery, set it to the issuer URL of the discovery document; a mismatch
+         * with the discovered issuer is reported as a security event.
          * </p>
          * <p>
          * Examples:
@@ -766,7 +750,7 @@ public class IssuerConfig implements LoadingStatusProvider {
          * <ul>
          *   <li>The loader implements proper error handling and retry logic</li>
          *   <li>The loader's {@link JwksLoader#getJwksType()} method returns an appropriate type</li>
-         *   <li>If the loader doesn't provide issuer identification, set {@link #issuerIdentifier(String)}</li>
+         *   <li>{@link #issuerIdentifier(String)} is set — it is required for all enabled configurations</li>
          * </ul>
          * <p>
          * Note: If a custom JwksLoader is provided, the other JWKS configuration methods
@@ -815,9 +799,10 @@ public class IssuerConfig implements LoadingStatusProvider {
          * builder.httpJwksLoaderConfig(directConfig);
          * </pre>
          * <p>
-         * <strong>Important:</strong> When using well-known discovery, the {@link #issuerIdentifier(String)}
-         * is optional as it will be automatically extracted from the discovery document. For direct JWKS URLs,
-         * the issuer identifier should typically be provided.
+         * <strong>Important:</strong> The {@link #issuerIdentifier(String)} is required for
+         * well-known discovery as well: set it to the issuer URL of the discovery document.
+         * The discovered issuer is compared against it and a mismatch is reported as a
+         * security event, but the configured value is authoritative.
          * </p>
          *
          * @param httpJwksLoaderConfig the HTTP JWKS loader configuration
@@ -926,7 +911,7 @@ public class IssuerConfig implements LoadingStatusProvider {
          * Validation includes:
          * <ul>
          *   <li><strong>JWKS Configuration:</strong> At least one JWKS loading method must be configured for enabled issuers</li>
-         *   <li><strong>Issuer Identifier:</strong> Required for file-based and in-memory JWKS loading (optional for well-known discovery)</li>
+         *   <li><strong>Issuer Identifier:</strong> Required for all enabled issuer configurations</li>
          *   <li><strong>Algorithm Preferences:</strong> Initialized with secure defaults if not explicitly set</li>
          *   <li><strong>Claim Mappers:</strong> Initialized as empty map if not explicitly set</li>
          * </ul>
@@ -981,18 +966,14 @@ public class IssuerConfig implements LoadingStatusProvider {
                         One of httpJwksLoaderConfig, jwksFilePath, jwksContent, or a custom jwksLoader must be provided.""");
             }
 
-            // Validate issuerIdentifier requirements based on JWKS loading method
-            if (jwksLoader != null) {
-                // For custom JwksLoaders, issuerIdentifier is required unless it's a well-known type
-                if (issuerIdentifier == null && !jwksLoader.getJwksType().providesIssuerIdentifier()) {
-                    throw new IllegalArgumentException("issuerIdentifier is required for custom JwksLoader unless it provides its own issuer identifier");
-                }
-            } else {
-                // For built-in JWKS loading methods, validate issuerIdentifier requirements
-                if ((jwksFilePath != null || jwksContent != null) && issuerIdentifier == null) {
-                    throw new IllegalArgumentException("issuerIdentifier is required for file-based and in-memory JWKS loading");
-                }
-                // For HTTP well-known discovery, issuerIdentifier is optional (will be extracted from discovery)
+            // issuerIdentifier is required for every enabled configuration, regardless of
+            // the JWKS loading method. Validator maps and caches are keyed by this value
+            // before any (async) JWKS loading has completed, so it cannot be supplied by
+            // well-known discovery.
+            if (issuerIdentifier == null) {
+                throw new IllegalArgumentException("""
+                        issuerIdentifier is required for enabled issuer configurations. \
+                        For well-known discovery, set it to the issuer URL of the discovery document.""");
             }
         }
 
@@ -1024,9 +1005,9 @@ public class IssuerConfig implements LoadingStatusProvider {
             Map<String, ClaimMapper> claimMappers, @Nullable JwksLoader jwksLoader) {
         this.enabled = enabled;
         this.issuerIdentifier = issuerIdentifier;
-        this.expectedAudience = Objects.requireNonNull(expectedAudience, "expectedAudience must not be null (use Set.of() for empty)");
+        this.expectedAudience = Set.copyOf(Objects.requireNonNull(expectedAudience, "expectedAudience must not be null (use Set.of() for empty)"));
         this.audienceValidationDisabled = audienceValidationDisabled;
-        this.expectedClientId = Objects.requireNonNull(expectedClientId, "expectedClientId must not be null (use Set.of() for empty)");
+        this.expectedClientId = Set.copyOf(Objects.requireNonNull(expectedClientId, "expectedClientId must not be null (use Set.of() for empty)"));
         this.claimSubOptional = claimSubOptional;
         this.accessTokenAudienceOptional = accessTokenAudienceOptional;
         this.expectedTokenType = expectedTokenType;
@@ -1034,7 +1015,7 @@ public class IssuerConfig implements LoadingStatusProvider {
         this.clockSkewSeconds = clockSkewSeconds;
         this.maxTokenAgeSeconds = maxTokenAgeSeconds;
         this.algorithmPreferences = Objects.requireNonNull(algorithmPreferences, "algorithmPreferences must not be null");
-        this.claimMappers = Objects.requireNonNull(claimMappers, "claimMappers must not be null (use Map.of() for empty)");
+        this.claimMappers = Map.copyOf(Objects.requireNonNull(claimMappers, "claimMappers must not be null (use Map.of() for empty)"));
         this.jwksLoader = jwksLoader;
     }
 

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/IssuerConfigCache.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/IssuerConfigCache.java
@@ -19,8 +19,6 @@ import de.cuioss.sheriff.token.validation.exception.TokenValidationException;
 import de.cuioss.sheriff.token.validation.security.SecurityEventCounter;
 import de.cuioss.sheriff.token.validation.util.LoaderStatus;
 import de.cuioss.tools.logging.CuiLogger;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Collection;
@@ -45,13 +43,21 @@ import static de.cuioss.sheriff.token.validation.JWTValidationLogMessages.WARN;
  *   <li>A ConcurrentHashMap for mutable cache during initialization</li>
  *   <li>An immutable Map for optimal lock-free reads after all configs are loaded</li>
  * </ul>
+ * <p>
+ * Issuers whose initial JWKS load fails are not lost: on every cache miss the resolver
+ * re-checks the loader status of the originally configured issuer, so an issuer that
+ * recovers via background refresh becomes resolvable again without a restart.
  * @since 1.0
  */
-@EqualsAndHashCode
-@ToString(of = {"mutableCache", "immutableCache", "loadingFutures"})
 public class IssuerConfigCache {
 
     private static final CuiLogger LOGGER = new CuiLogger(IssuerConfigCache.class);
+
+    /**
+     * Maximum time to wait for an in-flight initial JWKS load before treating the
+     * issuer as unavailable for the current validation attempt.
+     */
+    private static final long LOADING_WAIT_SECONDS = 5;
 
     /**
      * Mutable cache used during initialization phase.
@@ -72,6 +78,13 @@ public class IssuerConfigCache {
      */
     @SuppressWarnings("java:S3077") // Map.copyOf() creates truly immutable map, safe for concurrent reads after volatile publication
     private volatile @Nullable Map<String, IssuerConfig> immutableCache;
+
+    /**
+     * All enabled issuer configurations keyed by issuer identifier.
+     * Used as the recovery source when an issuer's initial load failed but its
+     * loader later became healthy through background refresh.
+     */
+    private final Map<String, IssuerConfig> enabledConfigsByIssuer;
 
     /**
      * Security event counter for tracking validation events.
@@ -95,12 +108,13 @@ public class IssuerConfigCache {
         this.loadingFutures = new ConcurrentHashMap<>();
         this.immutableCache = null; // Will be set after all loading completes
 
+        Map<String, IssuerConfig> enabledConfigs = new ConcurrentHashMap<>();
         // Trigger ALL async loading in constructor
-        int enabledCount = 0;
         int totalCount = issuerConfigs.size();
         for (IssuerConfig config : issuerConfigs) {
             if (config.isEnabled()) {
                 String issuer = config.getIssuerIdentifier();
+                enabledConfigs.put(issuer, config);
 
                 // Single initialization point: trigger async JWKS loading
                 CompletableFuture<LoaderStatus> future =
@@ -118,14 +132,14 @@ public class IssuerConfigCache {
                     }
                 });
 
-                enabledCount++;
                 LOGGER.debug("Triggered async loading for issuer: %s", issuer);
             } else {
                 LOGGER.info(INFO.ISSUER_CONFIG_SKIPPED, config);
             }
         }
+        this.enabledConfigsByIssuer = Map.copyOf(enabledConfigs);
 
-        LOGGER.debug("IssuerConfigCache initialized with %s enabled configurations (%s total)", enabledCount, totalCount);
+        LOGGER.debug("IssuerConfigCache initialized with %s enabled configurations (%s total)", enabledConfigsByIssuer.size(), totalCount);
 
         // After all futures are registered, create a combined future to optimize cache when all complete
         if (!loadingFutures.isEmpty()) {
@@ -140,10 +154,12 @@ public class IssuerConfigCache {
     /**
      * Resolves the issuer configuration for the given issuer identifier.
      * <p>
-     * This method implements a three-tier resolution strategy:
+     * This method implements a four-tier resolution strategy:
      * <ol>
      *   <li><strong>Fast path:</strong> Direct cache lookup (lock-free, constant time)</li>
      *   <li><strong>Loading wait:</strong> Wait for ongoing async loading if in progress</li>
+     *   <li><strong>Recovery:</strong> Re-check the configured issuer's loader status — an
+     *       issuer whose initial load failed may have recovered via background refresh</li>
      *   <li><strong>Failure:</strong> Throw exception if no healthy config is available</li>
      * </ol>
      * <p>
@@ -165,7 +181,7 @@ public class IssuerConfigCache {
         if (future != null) {
             try {
                 // Wait for loading to complete (with timeout)
-                LoaderStatus status = future.get(5, TimeUnit.SECONDS);
+                LoaderStatus status = future.get(LOADING_WAIT_SECONDS, TimeUnit.SECONDS);
                 if (status == LoaderStatus.OK) {
                     IssuerConfig loadedConfig = getCachedConfig(issuer);
                     if (loadedConfig != null) {
@@ -182,9 +198,19 @@ public class IssuerConfigCache {
             }
         }
 
+        // Recovery path: an issuer whose initial load failed is not in the caches, but its
+        // loader keeps retrying via background refresh. If it has become healthy since,
+        // re-admit it instead of failing until process restart.
+        IssuerConfig candidate = enabledConfigsByIssuer.get(issuer);
+        if (candidate != null && candidate.getJwksLoader() != null
+                && candidate.getJwksLoader().getLoaderStatus() == LoaderStatus.OK) {
+            mutableCache.put(issuer, candidate);
+            LOGGER.info(INFO.ISSUER_CONFIG_LOADED, issuer);
+            return candidate;
+        }
+
         // Not found or not healthy
-        handleIssuerNotFound(issuer);
-        throw new IllegalStateException("handleIssuerNotFound should have thrown an exception");
+        throw issuerNotFound(issuer);
     }
 
     /**
@@ -244,18 +270,16 @@ public class IssuerConfigCache {
     }
 
     /**
-     * Handles the case where no issuer configuration is found.
-     * <p>
-     * This method logs a warning, increments the security event counter,
-     * and throws a TokenValidationException with appropriate details.
+     * Creates the exception for the case where no issuer configuration is found,
+     * logging a warning and incrementing the security event counter.
      *
      * @param issuer the issuer identifier that wasn't found
-     * @throws TokenValidationException always thrown with NO_ISSUER_CONFIG event type
+     * @return the exception to throw, with NO_ISSUER_CONFIG event type
      */
-    private void handleIssuerNotFound(String issuer) {
+    private TokenValidationException issuerNotFound(String issuer) {
         LOGGER.warn(WARN.NO_ISSUER_CONFIG, issuer);
         securityEventCounter.increment(SecurityEventCounter.EventType.NO_ISSUER_CONFIG);
-        throw new TokenValidationException(
+        return new TokenValidationException(
                 SecurityEventCounter.EventType.NO_ISSUER_CONFIG,
                 "No healthy issuer configuration found for issuer: " + issuer
         );

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/TokenValidator.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/TokenValidator.java
@@ -201,6 +201,9 @@ public class TokenValidator implements Closeable {
         if (issuerConfigs.isEmpty()) {
             throw new IllegalArgumentException("At least one issuer configuration must be provided");
         }
+        if (issuerConfigs.contains(null)) {
+            throw new IllegalArgumentException("Issuer configurations must not contain null elements");
+        }
 
         // Disabled configs skip build-time validation and have no JwksLoader — they must not
         // participate in validator construction. IssuerConfigCache performs the same filtering

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/TokenValidator.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/TokenValidator.java
@@ -202,6 +202,16 @@ public class TokenValidator implements Closeable {
             throw new IllegalArgumentException("At least one issuer configuration must be provided");
         }
 
+        // Disabled configs skip build-time validation and have no JwksLoader — they must not
+        // participate in validator construction. IssuerConfigCache performs the same filtering
+        // (and logs the skipped configs).
+        List<IssuerConfig> enabledIssuerConfigs = issuerConfigs.stream()
+                .filter(IssuerConfig::isEnabled)
+                .toList();
+        if (enabledIssuerConfigs.isEmpty()) {
+            throw new IllegalArgumentException("At least one enabled issuer configuration must be provided");
+        }
+
         // Use default ParserConfig if not provided
         if (parserConfig == null) {
             parserConfig = ParserConfig.builder().build();
@@ -238,7 +248,7 @@ public class TokenValidator implements Closeable {
         Map<String, TokenClaimValidator> claimValidatorsMap = new HashMap<>();
         Map<String, TokenHeaderValidator> headerValidatorsMap = new HashMap<>();
 
-        for (IssuerConfig issuerConfig : issuerConfigs) {
+        for (IssuerConfig issuerConfig : enabledIssuerConfigs) {
             String issuerIdentifier = issuerConfig.getIssuerIdentifier();
 
             // Create one shared SignatureTemplateManager per issuer (reused by signature + DPoP validators)
@@ -281,7 +291,7 @@ public class TokenValidator implements Closeable {
         Map<String, DpopProofValidator> dpopValidatorsMap = new HashMap<>();
         long maxNonceCacheTtl = 0;
         int maxNonceCacheSize = 0;
-        for (IssuerConfig issuerConfig : issuerConfigs) {
+        for (IssuerConfig issuerConfig : enabledIssuerConfigs) {
             if (issuerConfig.getDpopConfig() != null) {
                 maxNonceCacheTtl = Math.max(maxNonceCacheTtl, issuerConfig.getDpopConfig().getNonceCacheTtlSeconds());
                 maxNonceCacheSize = Math.max(maxNonceCacheSize, issuerConfig.getDpopConfig().getNonceCacheSize());
@@ -290,7 +300,7 @@ public class TokenValidator implements Closeable {
         this.dpopReplayProtection = maxNonceCacheSize > 0
                 ? new DpopReplayProtection(maxNonceCacheTtl, maxNonceCacheSize)
                 : null;
-        for (IssuerConfig issuerConfig : issuerConfigs) {
+        for (IssuerConfig issuerConfig : enabledIssuerConfigs) {
             if (issuerConfig.getDpopConfig() != null) {
                 DpopProofValidator dpopValidator = new DpopProofValidator(
                         issuerConfig, this.securityEventCounter, this.dpopReplayProtection,
@@ -332,7 +342,7 @@ public class TokenValidator implements Closeable {
         // Compute maximum clock skew across all issuers for cache expiration tolerance.
         // The cache is shared across issuers, so we use the most lenient skew to avoid
         // evicting tokens that would still be valid for their respective issuer.
-        int maxClockSkew = issuerConfigs.stream()
+        int maxClockSkew = enabledIssuerConfigs.stream()
                 .mapToInt(IssuerConfig::getClockSkewSeconds)
                 .max()
                 .orElse(0);
@@ -355,7 +365,9 @@ public class TokenValidator implements Closeable {
         LOGGER.debug("AccessTokenValidationPipeline initialized with cache maxSize=%s, evictionInterval=%ss",
                 cacheConfig.getMaxSize(), cacheConfig.getEvictionIntervalSeconds());
 
-        LOGGER.info(JWTValidationLogMessages.INFO.TOKEN_FACTORY_INITIALIZED, issuerConfigCache.toString());
+        LOGGER.info(JWTValidationLogMessages.INFO.TOKEN_FACTORY_INITIALIZED,
+                "%s enabled issuer(s): %s".formatted(enabledIssuerConfigs.size(),
+                        enabledIssuerConfigs.stream().map(IssuerConfig::getIssuerIdentifier).toList()));
 
         if (jweDecryptionConfig != null) {
             LOGGER.info(JWTValidationLogMessages.INFO.JWE_DECRYPTION_ENABLED, jweDecryptionConfig.getKeyCount());

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/jwks/JwksType.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/jwks/JwksType.java
@@ -21,30 +21,18 @@ package de.cuioss.sheriff.token.validation.jwks;
  */
 public enum JwksType {
     /** HTTP JWKS endpoint */
-    HTTP("http", false),
+    HTTP("http"),
     /** Well-known discovery JWKS endpoint */
-    WELL_KNOWN("well-known", true),
+    WELL_KNOWN("well-known"),
     /** File-based JWKS */
-    FILE("file", false),
+    FILE("file"),
     /** In-memory JWKS */
-    MEMORY("memory", false);
+    MEMORY("memory");
 
     private final String value;
-    private final boolean providesIssuerIdentifier;
 
-    JwksType(String value, boolean providesIssuerIdentifier) {
+    JwksType(String value) {
         this.value = value;
-        this.providesIssuerIdentifier = providesIssuerIdentifier;
-    }
-
-    /**
-     * Returns true if this JWKS type provides its own issuer identifier.
-     * Currently only true for well-known discovery endpoints.
-     *
-     * @return true if this type provides issuer identifier, false otherwise
-     */
-    public boolean providesIssuerIdentifier() {
-        return providesIssuerIdentifier;
     }
 
     @Override

--- a/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/IssuerConfigCacheRecoveryTest.java
+++ b/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/IssuerConfigCacheRecoveryTest.java
@@ -29,7 +29,8 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Verifies that an issuer whose initial JWKS load fails becomes resolvable again

--- a/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/IssuerConfigCacheRecoveryTest.java
+++ b/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/IssuerConfigCacheRecoveryTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.token.validation;
+
+import de.cuioss.sheriff.token.validation.exception.TokenValidationException;
+import de.cuioss.sheriff.token.validation.jwks.JwksLoader;
+import de.cuioss.sheriff.token.validation.jwks.JwksType;
+import de.cuioss.sheriff.token.validation.jwks.key.KeyInfo;
+import de.cuioss.sheriff.token.validation.security.SecurityEventCounter;
+import de.cuioss.sheriff.token.validation.util.LoaderStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies that an issuer whose initial JWKS load fails becomes resolvable again
+ * once its loader recovers (e.g. through background refresh), instead of being
+ * permanently unavailable until process restart.
+ */
+class IssuerConfigCacheRecoveryTest {
+
+    private static final String ISSUER = "https://recovering-issuer.example.com";
+
+    /**
+     * Minimal JwksLoader stub whose status can be flipped externally, simulating
+     * a loader that fails its initial load but recovers via background refresh.
+     */
+    private static final class StatusControlledLoader implements JwksLoader {
+
+        private final AtomicReference<LoaderStatus> status = new AtomicReference<>(LoaderStatus.UNDEFINED);
+
+        void setStatus(LoaderStatus newStatus) {
+            status.set(newStatus);
+        }
+
+        @Override
+        public LoaderStatus getLoaderStatus() {
+            return status.get();
+        }
+
+        @Override
+        public Optional<KeyInfo> getKeyInfo(String kid) {
+            return Optional.empty();
+        }
+
+        @Override
+        public JwksType getJwksType() {
+            return JwksType.HTTP;
+        }
+
+        @Override
+        public Optional<String> getIssuerIdentifier() {
+            return Optional.of(ISSUER);
+        }
+
+        @Override
+        public CompletableFuture<LoaderStatus> initJWKSLoader(SecurityEventCounter securityEventCounter) {
+            // Simulates a failed initial load: status stays non-OK, background refresh may recover later
+            return CompletableFuture.completedFuture(status.get());
+        }
+    }
+
+    @Test
+    @DisplayName("Issuer with failed initial load is resolvable after loader recovers")
+    void recoversIssuerAfterLoaderBecomesHealthy() {
+        StatusControlledLoader loader = new StatusControlledLoader();
+        IssuerConfig config = IssuerConfig.builder()
+                .issuerIdentifier(ISSUER)
+                .expectedAudience("test-audience")
+                .jwksLoader(loader)
+                .build();
+
+        IssuerConfigCache cache = new IssuerConfigCache(List.of(config), new SecurityEventCounter());
+
+        // Initial load failed: resolution must fail closed
+        assertThrows(TokenValidationException.class, () -> cache.resolveConfig(ISSUER));
+
+        // Background refresh succeeds: the issuer must become resolvable without restart
+        loader.setStatus(LoaderStatus.OK);
+        IssuerConfig resolved = cache.resolveConfig(ISSUER);
+        assertSame(config, resolved);
+
+        // And it stays resolvable through the regular cache path
+        assertSame(config, cache.resolveConfig(ISSUER));
+    }
+
+    @Test
+    @DisplayName("Unknown issuer still fails after recovery path")
+    void unknownIssuerStillFails() {
+        StatusControlledLoader loader = new StatusControlledLoader();
+        loader.setStatus(LoaderStatus.OK);
+        IssuerConfig config = IssuerConfig.builder()
+                .issuerIdentifier(ISSUER)
+                .expectedAudience("test-audience")
+                .jwksLoader(loader)
+                .build();
+
+        IssuerConfigCache cache = new IssuerConfigCache(List.of(config), new SecurityEventCounter());
+
+        assertThrows(TokenValidationException.class, () -> cache.resolveConfig("https://unknown.example.com"));
+    }
+}

--- a/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/IssuerConfigTest.java
+++ b/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/IssuerConfigTest.java
@@ -253,6 +253,10 @@ class IssuerConfigTest implements ShouldImplementToString<IssuerConfig>, ShouldI
 
             assertFalse(config.isEnabled());
             assertThrows(IllegalStateException.class, config::getIssuerIdentifier);
+            // Disabled configs are logged (ISSUER_CONFIG_SKIPPED) and compared —
+            // Lombok-generated methods must not trip over the guarded getter
+            assertDoesNotThrow(config::toString);
+            assertDoesNotThrow(config::hashCode);
         }
     }
 

--- a/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/IssuerConfigTest.java
+++ b/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/IssuerConfigTest.java
@@ -96,6 +96,7 @@ class IssuerConfigTest implements ShouldImplementToString<IssuerConfig>, ShouldI
                     .build();
 
             var config = IssuerConfig.builder()
+                    .issuerIdentifier("test-issuer")
                     .expectedAudience(audience)
                     .expectedClientId(clientId)
                     .algorithmPreferences(algorithmPreferences)
@@ -181,6 +182,7 @@ class IssuerConfigTest implements ShouldImplementToString<IssuerConfig>, ShouldI
         @DisplayName("Should initialize with HTTP JwksLoader")
         void shouldInitializeWithHttpJwksLoader() {
             var config = IssuerConfig.builder()
+                    .issuerIdentifier("test-issuer")
                     .httpJwksLoaderConfig(HttpJwksLoaderConfig.builder()
                             .jwksUrl(TEST_JWKS_URL)
                             .issuerIdentifier("test-issuer")
@@ -279,6 +281,7 @@ class IssuerConfigTest implements ShouldImplementToString<IssuerConfig>, ShouldI
                     .build();
             assertDoesNotThrow(() -> {
                 IssuerConfig.builder()
+                        .issuerIdentifier("test-issuer")
                         .httpJwksLoaderConfig(httpConfig)
                         .audienceValidationDisabled(true)
                         .build();

--- a/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/IssuerConfigTest.java
+++ b/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/IssuerConfigTest.java
@@ -228,6 +228,30 @@ class IssuerConfigTest implements ShouldImplementToString<IssuerConfig>, ShouldI
 
             assertTrue(exception.getMessage().contains("No JwksLoader configuration is present"));
         }
+
+        @Test
+        @DisplayName("Should throw exception during build when well-known discovery is configured without issuerIdentifier")
+        void shouldRequireIssuerIdentifierForWellKnownDiscovery() {
+            var builder = IssuerConfig.builder()
+                    .expectedAudience("test-audience")
+                    .httpJwksLoaderConfig(de.cuioss.sheriff.token.validation.jwks.http.HttpJwksLoaderConfig.builder()
+                            .wellKnownUrl("https://example.com/.well-known/openid-configuration")
+                            .build());
+            var exception = assertThrows(IllegalArgumentException.class, builder::build);
+
+            assertTrue(exception.getMessage().contains("issuerIdentifier is required"));
+        }
+
+        @Test
+        @DisplayName("Should build disabled configuration without issuerIdentifier")
+        void shouldBuildDisabledConfigurationWithoutIssuerIdentifier() {
+            var config = IssuerConfig.builder()
+                    .enabled(false)
+                    .build();
+
+            assertFalse(config.isEnabled());
+            assertThrows(IllegalStateException.class, config::getIssuerIdentifier);
+        }
     }
 
     @Nested

--- a/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/IssuerConfigTest.java
+++ b/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/IssuerConfigTest.java
@@ -236,7 +236,7 @@ class IssuerConfigTest implements ShouldImplementToString<IssuerConfig>, ShouldI
         void shouldRequireIssuerIdentifierForWellKnownDiscovery() {
             var builder = IssuerConfig.builder()
                     .expectedAudience("test-audience")
-                    .httpJwksLoaderConfig(de.cuioss.sheriff.token.validation.jwks.http.HttpJwksLoaderConfig.builder()
+                    .httpJwksLoaderConfig(HttpJwksLoaderConfig.builder()
                             .wellKnownUrl("https://example.com/.well-known/openid-configuration")
                             .build());
             var exception = assertThrows(IllegalArgumentException.class, builder::build);

--- a/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/TokenValidatorTest.java
+++ b/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/TokenValidatorTest.java
@@ -91,6 +91,31 @@ class TokenValidatorTest {
                 JWTValidationLogMessages.INFO.TOKEN_FACTORY_INITIALIZED.resolveIdentifierString());
     }
 
+    @Test
+    @DisplayName("Should ignore disabled issuer configurations during construction")
+    void shouldIgnoreDisabledIssuerConfigs() {
+        // Disabled configs skip build-time validation and have no JwksLoader —
+        // their presence must not break validator construction
+        IssuerConfig disabled = IssuerConfig.builder().enabled(false).build();
+
+        TokenValidator validator = TokenValidator.builder()
+                .issuerConfig(issuerConfig)
+                .issuerConfig(disabled)
+                .build();
+
+        assertNotNull(validator);
+    }
+
+    @Test
+    @DisplayName("Should reject construction when all issuer configurations are disabled")
+    void shouldRejectAllDisabledIssuerConfigs() {
+        IssuerConfig disabled = IssuerConfig.builder().enabled(false).build();
+        var builder = TokenValidator.builder().issuerConfig(disabled);
+
+        var exception = assertThrows(IllegalArgumentException.class, builder::build);
+        assertTrue(exception.getMessage().contains("enabled issuer configuration"));
+    }
+
     @Nested
     class TokenCreationTests {
 

--- a/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/jwks/JwksLoaderFactoryTest.java
+++ b/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/jwks/JwksLoaderFactoryTest.java
@@ -157,19 +157,4 @@ class JwksLoaderFactoryTest {
                 "Should count JWKS_JSON_PARSE_FAILED event");
     }
 
-    @Test
-    @DisplayName("Should return correct providesIssuerIdentifier for all JwksType values")
-    void shouldReturnCorrectProvidesIssuerIdentifierForAllJwksTypes() {
-        // Only WELL_KNOWN should provide issuer identifier
-        assertTrue(JwksType.WELL_KNOWN.providesIssuerIdentifier(),
-                "WELL_KNOWN should provide issuer identifier");
-
-        // All other types should not provide issuer identifier
-        assertFalse(JwksType.HTTP.providesIssuerIdentifier(),
-                "HTTP should not provide issuer identifier");
-        assertFalse(JwksType.FILE.providesIssuerIdentifier(),
-                "FILE should not provide issuer identifier");
-        assertFalse(JwksType.MEMORY.providesIssuerIdentifier(),
-                "MEMORY should not provide issuer identifier");
-    }
 }


### PR DESCRIPTION
## Summary

Fixes the issuer-config lifecycle findings from the semantic code analysis (`doc/code-findings.adoc`, PR #526):

- **H-1** — The documented "well-known discovery without issuerIdentifier" feature never worked: caches and validator maps are keyed by `getIssuerIdentifier()` *before* async JWKS loading completes, so a well-known-only config deterministically threw `IllegalStateException`. `issuerIdentifier` is now required for **all** enabled issuer configurations (matching what the Quarkus resolver already enforced), `getIssuerIdentifier()` no longer depends on loader state, and the discovered issuer remains a cross-check only (`ISSUER_MISMATCH` security event).
- **H-2** — An issuer whose initial JWKS load failed was permanently unresolvable even after its loader recovered via background refresh. `IssuerConfigCache.resolveConfig()` now re-checks the configured issuer's loader status on cache miss and re-admits recovered issuers.
- **M-2** — `TokenValidator` built validators for disabled issuer configs and crashed on `getIssuerIdentifier()` for them; it now filters to enabled configs and fails fast when none are enabled.
- **L-8** — `IssuerConfigCache`: removed meaningless map-based `equals`/`toString` (the raw map internals were also what `TOKEN_FACTORY_INITIALIZED` logged — it now logs the enabled issuer identifiers), named the 5s loading-wait constant, `issuerNotFound()` returns the exception instead of hiding the throw.
- **L-13** — `IssuerConfig`: all fields `final`, builder-provided collections defensively copied (`Set.copyOf`/`Map.copyOf`).
- Removed now-unused `JwksType.providesIssuerIdentifier()`.

## Breaking change (pre-1.0)

Enabled `IssuerConfig`s must set `issuerIdentifier`. Previously the builder accepted well-known-only configs — which then failed at runtime. Quarkus users are unaffected (the resolver already required `issuer-identifier`).

## Tests

- New `IssuerConfigCacheRecoveryTest` covering failed-load → background-recovery → resolvable (H-2)
- New build-validation tests: well-known without identifier fails fast; disabled configs build without identifier (H-1)
- New `TokenValidator` tests: disabled configs are ignored; all-disabled rejected (M-2)
- `./mvnw -Ppre-commit clean verify -pl token-sheriff-validation` green (1515+ tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012RwRgQHDskAEsKYkgKanH3

---
_Generated by [Claude Code](https://claude.ai/code/session_012RwRgQHDskAEsKYkgKanH3)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved issuer configuration recovery after an initial JWKS load failure.
  * Stricter validation ensures required issuer identifiers are present for enabled configurations.
  * Token validation now ignores disabled issuers and rejects invalid inputs (including null entries) rather than proceeding.

* **New Features**
  * Added more robust background refresh handling so issuer resolution can recover once JWKS loading becomes healthy.

* **Tests**
  * Added/updated unit tests for issuer cache recovery, disabled configuration behavior, and strengthened validation failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->