### PR TITLE
fix(benchmarking): make published results trustworthy (H-4..H-7, M-21..M-23, M-29, M-32)

### DIFF
--- a/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/token/validation/benchmark/ConcurrencySweepRunner.java
+++ b/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/token/validation/benchmark/ConcurrencySweepRunner.java
@@ -15,6 +15,7 @@
  */
 package de.cuioss.sheriff.token.validation.benchmark;
 
+import de.cuioss.benchmarking.common.config.BenchmarkConfiguration;
 import de.cuioss.sheriff.token.validation.benchmark.standard.SimpleCoreValidationBenchmark;
 import de.cuioss.tools.logging.CuiLogger;
 import org.openjdk.jmh.results.RunResult;
@@ -33,6 +34,8 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+
+import static de.cuioss.benchmarking.common.constants.BenchmarkConstants.Integration.Jmh;
 
 /**
  * Runs the core validation benchmark at multiple thread counts (1, 10, 50, 100)
@@ -60,6 +63,15 @@ public class ConcurrencySweepRunner {
         Path outputPath = Path.of(OUTPUT_DIR);
         Files.createDirectories(outputPath);
 
+        // Honor the same jmh.* system properties as the other runners (see BenchmarkConfiguration),
+        // falling back to the sweep's previous hardcoded values when a property is not set.
+        // Thread counts are the sweep dimension and are therefore not configurable here.
+        int forks = Integer.getInteger(Jmh.FORKS, 1);
+        int warmupIterations = Integer.getInteger(Jmh.WARMUP_ITERATIONS, 3);
+        int measurementIterations = Integer.getInteger(Jmh.MEASUREMENT_ITERATIONS, 5);
+        TimeValue measurementTime = BenchmarkConfiguration.parseTimeValue(System.getProperty(Jmh.MEASUREMENT_TIME, "4s"));
+        TimeValue warmupTime = BenchmarkConfiguration.parseTimeValue(System.getProperty(Jmh.WARMUP_TIME, "1s"));
+
         List<RunResult> allResults = new ArrayList<>();
 
         for (int threads : THREAD_COUNTS) {
@@ -67,11 +79,11 @@ public class ConcurrencySweepRunner {
 
             Options options = new OptionsBuilder()
                     .include(SimpleCoreValidationBenchmark.class.getSimpleName() + "\\.measureAverageTime")
-                    .forks(1)
-                    .warmupIterations(3)
-                    .measurementIterations(5)
-                    .measurementTime(TimeValue.seconds(4))
-                    .warmupTime(TimeValue.seconds(1))
+                    .forks(forks)
+                    .warmupIterations(warmupIterations)
+                    .measurementIterations(measurementIterations)
+                    .measurementTime(measurementTime)
+                    .warmupTime(warmupTime)
                     .threads(threads)
                     .jvmArgsPrepend(
                             "-Djava.util.logging.manager=java.util.logging.LogManager",

--- a/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/token/validation/benchmark/delegates/ErrorLoadDelegate.java
+++ b/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/token/validation/benchmark/delegates/ErrorLoadDelegate.java
@@ -19,6 +19,7 @@ import de.cuioss.sheriff.token.validation.TokenValidator;
 import de.cuioss.sheriff.token.validation.benchmark.MockTokenRepository;
 import de.cuioss.sheriff.token.validation.domain.token.AccessTokenContent;
 import de.cuioss.sheriff.token.validation.exception.TokenValidationException;
+import de.cuioss.sheriff.token.validation.test.InMemoryKeyMaterialHandler;
 import io.jsonwebtoken.Jwts;
 import org.openjdk.jmh.infra.Blackhole;
 
@@ -36,6 +37,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class ErrorLoadDelegate extends BenchmarkDelegate {
 
     private final String expiredToken;
+    private final String expiredTokenIssuer;
     private final String malformedToken;
     private final String invalidSignatureToken;
     private final int errorPercentage;
@@ -46,20 +48,43 @@ public class ErrorLoadDelegate extends BenchmarkDelegate {
         this.errorPercentage = errorPercentage;
 
         // Initialize error tokens
-        this.expiredToken = createExpiredToken();
+        InMemoryKeyMaterialHandler.IssuerKeyMaterial expiredIssuer = tokenRepository.getIssuers()[0];
+        this.expiredTokenIssuer = expiredIssuer.getIssuerIdentifier();
+        this.expiredToken = createExpiredToken(expiredIssuer);
         this.malformedToken = "not.a.valid.jwt.token";
         this.invalidSignatureToken = createInvalidSignatureToken();
+    }
+
+    /**
+     * Returns the next token from the valid-token rotation pool.
+     * Use this to obtain the token that will be validated by {@link #validateValid(String)},
+     * so metadata (issuer, size) can be derived from the same token that is actually validated.
+     *
+     * @return the next valid token from the pool
+     */
+    public String nextValidToken() {
+        return tokenRepository.getToken(tokenIndex.getAndIncrement());
     }
 
     /**
      * Validates a valid token using full spectrum rotation.
      *
      * @return the validated access token content
-     * @throws RuntimeException if validation fails unexpectedly
+     * @throws IllegalStateException if validation fails unexpectedly
      */
     public AccessTokenContent validateValid() {
+        return validateValid(nextValidToken());
+    }
+
+    /**
+     * Validates the given valid token.
+     *
+     * @param token the token to validate
+     * @return the validated access token content
+     * @throws IllegalStateException if validation fails unexpectedly
+     */
+    public AccessTokenContent validateValid(String token) {
         try {
-            String token = tokenRepository.getToken(tokenIndex.getAndIncrement());
             return validateToken(token);
         } catch (TokenValidationException e) {
             throw new IllegalStateException("Unexpected validation failure for valid token", e);
@@ -69,11 +94,14 @@ public class ErrorLoadDelegate extends BenchmarkDelegate {
     /**
      * Validates an expired token.
      *
-     * @return the exception or null if validation unexpectedly succeeds
+     * @return the expected validation exception
+     * @throws IllegalStateException if validation unexpectedly succeeds
      */
     public Object validateExpired() {
         try {
-            return validateToken(expiredToken);
+            AccessTokenContent content = validateToken(expiredToken);
+            throw new IllegalStateException(
+                    "Validation of known-expired token unexpectedly succeeded: " + content);
         } catch (TokenValidationException e) {
             return e; // Expected
         }
@@ -82,11 +110,14 @@ public class ErrorLoadDelegate extends BenchmarkDelegate {
     /**
      * Validates a malformed token.
      *
-     * @return the exception or null if validation unexpectedly succeeds
+     * @return the expected validation exception
+     * @throws IllegalStateException if validation unexpectedly succeeds
      */
     public Object validateMalformed() {
         try {
-            return validateToken(malformedToken);
+            AccessTokenContent content = validateToken(malformedToken);
+            throw new IllegalStateException(
+                    "Validation of known-malformed token unexpectedly succeeded: " + content);
         } catch (TokenValidationException | IllegalArgumentException e) {
             return e; // Expected - malformed tokens can throw various validation exceptions
         }
@@ -95,11 +126,14 @@ public class ErrorLoadDelegate extends BenchmarkDelegate {
     /**
      * Validates a token with invalid signature.
      *
-     * @return the exception or null if validation unexpectedly succeeds
+     * @return the expected validation exception
+     * @throws IllegalStateException if validation unexpectedly succeeds
      */
     public Object validateInvalidSignature() {
         try {
-            return validateToken(invalidSignatureToken);
+            AccessTokenContent content = validateToken(invalidSignatureToken);
+            throw new IllegalStateException(
+                    "Validation of token with known-invalid signature unexpectedly succeeded: " + content);
         } catch (TokenValidationException e) {
             return e; // Expected
         }
@@ -107,12 +141,24 @@ public class ErrorLoadDelegate extends BenchmarkDelegate {
 
     /**
      * Validates mixed tokens based on error percentage.
+     * Selects a token internally; use {@link #validateMixed(String, Blackhole)} when the
+     * caller needs to know which token is validated (e.g. for JFR metadata).
      *
      * @param blackhole JMH blackhole to consume results
      * @return the validation result (token content or exception)
      */
     public Object validateMixed(Blackhole blackhole) {
-        String token = selectToken();
+        return validateMixed(selectToken(), blackhole);
+    }
+
+    /**
+     * Validates the given token, tolerating validation failures (mixed valid/error load).
+     *
+     * @param token the token to validate
+     * @param blackhole JMH blackhole to consume results
+     * @return the validation result (token content or exception)
+     */
+    public Object validateMixed(String token, Blackhole blackhole) {
         try {
             AccessTokenContent result = validateToken(token);
             if (blackhole != null) {
@@ -169,20 +215,49 @@ public class ErrorLoadDelegate extends BenchmarkDelegate {
         return "valid";
     }
 
-    private String createExpiredToken() {
+    /**
+     * Gets the issuer identifier used for the expired token.
+     * This is a real configured issuer, so the expired-token benchmark measures the
+     * expiry path (not unknown-issuer rejection).
+     *
+     * @return the issuer identifier of the expired token
+     */
+    public String getExpiredTokenIssuer() {
+        return expiredTokenIssuer;
+    }
+
+    /**
+     * Gets the expired token used by {@link #validateExpired()}.
+     *
+     * @return the expired token
+     */
+    public String getExpiredToken() {
+        return expiredToken;
+    }
+
+    /**
+     * Creates a token that is signed by a real configured issuer's key but is already expired.
+     * Signing with a configured issuer ensures the validator reaches the expiry check instead
+     * of rejecting the token earlier for an unknown issuer.
+     */
+    private String createExpiredToken(InMemoryKeyMaterialHandler.IssuerKeyMaterial issuer) {
+        String audience = tokenRepository.getConfig().getExpectedAudience();
         Instant past = Instant.now().minusSeconds(3600);
 
         return Jwts.builder()
-                .issuer("benchmark-issuer")
+                .header()
+                .keyId(issuer.getKeyId())
+                .and()
+                .issuer(issuer.getIssuerIdentifier())
                 .subject("benchmark-user")
-                .audience().add("benchmark-client").and()
+                .audience().add(audience).and()
                 .expiration(Date.from(past)) // Already expired
                 .notBefore(Date.from(past.minusSeconds(60)))
                 .issuedAt(Date.from(past.minusSeconds(120)))
                 .id(UUID.randomUUID().toString())
                 .claim("typ", "Bearer")
-                .claim("azp", "benchmark-client")
-                .signWith(Jwts.SIG.HS256.key().build())
+                .claim("azp", audience)
+                .signWith(issuer.getPrivateKey())
                 .compact();
     }
 

--- a/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/token/validation/benchmark/delegates/ErrorLoadDelegate.java
+++ b/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/token/validation/benchmark/delegates/ErrorLoadDelegate.java
@@ -48,7 +48,11 @@ public class ErrorLoadDelegate extends BenchmarkDelegate {
         this.errorPercentage = errorPercentage;
 
         // Initialize error tokens
-        InMemoryKeyMaterialHandler.IssuerKeyMaterial expiredIssuer = tokenRepository.getIssuers()[0];
+        InMemoryKeyMaterialHandler.IssuerKeyMaterial[] issuers = tokenRepository.getIssuers();
+        if (issuers == null || issuers.length == 0) {
+            throw new IllegalStateException("No issuers configured in token repository");
+        }
+        InMemoryKeyMaterialHandler.IssuerKeyMaterial expiredIssuer = issuers[0];
         this.expiredTokenIssuer = expiredIssuer.getIssuerIdentifier();
         this.expiredToken = createExpiredToken(expiredIssuer);
         this.malformedToken = "not.a.valid.jwt.token";

--- a/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/token/validation/benchmark/jfr/benchmarks/ErrorJfrBenchmark.java
+++ b/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/token/validation/benchmark/jfr/benchmarks/ErrorJfrBenchmark.java
@@ -61,12 +61,13 @@ public class ErrorJfrBenchmark extends AbstractJfrBenchmark {
     @BenchmarkMode(Mode.AverageTime)
     @OutputTimeUnit(TimeUnit.MICROSECONDS)
     public AccessTokenContent validateValidTokenWithJfr() {
+        // Select the token once so JFR metadata describes the token that is actually validated
+        String token = errorLoadDelegate.nextValidToken();
         try (var recorder = jfrInstrumentation.recordOperation("validateValidTokenWithJfr", "validation")) {
-            String token = tokenRepository.getPrimaryToken();
             recorder.withPayloadSize(token.length())
                     .withMetadata(ISSUER, tokenRepository.getTokenIssuer(token).orElse(null));
 
-            AccessTokenContent result = errorLoadDelegate.validateValid();
+            AccessTokenContent result = errorLoadDelegate.validateValid(token);
             recorder.withSuccess(true);
             return result;
         }
@@ -80,8 +81,8 @@ public class ErrorJfrBenchmark extends AbstractJfrBenchmark {
     @OutputTimeUnit(TimeUnit.MICROSECONDS)
     public Object validateExpiredTokenWithJfr() {
         try (var recorder = jfrInstrumentation.recordOperation("validateExpiredTokenWithJfr", ERROR_VALIDATION_OPERATION)) {
-            recorder.withPayloadSize(200) // Approximate size
-                    .withMetadata(ISSUER, "benchmark-issuer")
+            recorder.withPayloadSize(errorLoadDelegate.getExpiredToken().length())
+                    .withMetadata(ISSUER, errorLoadDelegate.getExpiredTokenIssuer())
                     .withError("expired");
 
             Object result = errorLoadDelegate.validateExpired();

--- a/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/token/validation/benchmark/jfr/benchmarks/MixedJfrBenchmark.java
+++ b/benchmarking/benchmark-core/src/main/java/de/cuioss/sheriff/token/validation/benchmark/jfr/benchmarks/MixedJfrBenchmark.java
@@ -74,7 +74,7 @@ public class MixedJfrBenchmark extends AbstractJfrBenchmark {
                 recorder.withError(errorType);
             }
 
-            Object result = errorLoadDelegate0.validateMixed(blackhole);
+            Object result = errorLoadDelegate0.validateMixed(token, blackhole);
             recorder.withSuccess(isValid);
             return result;
         }
@@ -99,7 +99,7 @@ public class MixedJfrBenchmark extends AbstractJfrBenchmark {
                 recorder.withError(errorType);
             }
 
-            Object result = errorLoadDelegate50.validateMixed(blackhole);
+            Object result = errorLoadDelegate50.validateMixed(token, blackhole);
             recorder.withSuccess(isValid);
             return result;
         }

--- a/benchmarking/benchmark-integration-wrk/src/main/java/de/cuioss/sheriff/token/wrk/benchmark/WrkResultPostProcessor.java
+++ b/benchmarking/benchmark-integration-wrk/src/main/java/de/cuioss/sheriff/token/wrk/benchmark/WrkResultPostProcessor.java
@@ -76,6 +76,9 @@ public class WrkResultPostProcessor {
      * Main entry point for processing WRK benchmark results.
      * Usage:
      *   - args[0]=inputDir, args[1]=outputDir (optional)
+     * <p>
+     * Exits with a non-zero code when processing fails, including when the input
+     * directory is missing or no benchmark yields parseable metrics.
      *
      * @param args Command line arguments
      */
@@ -98,7 +101,7 @@ public class WrkResultPostProcessor {
 
             LOGGER.info(INFO.RESULTS_AVAILABLE, outputDir);
 
-        } catch (IOException e) {
+        } catch (IOException | IllegalStateException | IllegalArgumentException e) {
             LOGGER.error(e, ERROR.WRK_PROCESSOR_FAILED);
             System.exit(1);
         }
@@ -110,14 +113,13 @@ public class WrkResultPostProcessor {
      * @param inputDir Directory containing WRK output files
      * @param outputDir Directory to write reports to
      * @throws IOException if processing fails
+     * @throws IllegalArgumentException if the input directory is missing or not a directory
+     * @throws IllegalStateException if no benchmark yields parseable metrics
      */
     public void process(Path inputDir, Path outputDir) throws IOException {
         LOGGER.info(INFO.WRK_PROCESSING_START);
 
-        // Parse all WRK result files to extract metadata
-        parseBenchmarkMetadata(inputDir);
-
-        // Validate input directory
+        // Validate input directory BEFORE any parsing
         if (!Files.exists(inputDir)) {
             throw new IllegalArgumentException("Input directory does not exist: " + inputDir);
         }
@@ -126,47 +128,23 @@ public class WrkResultPostProcessor {
             throw new IllegalArgumentException("Input path is not a directory: " + inputDir);
         }
 
-        // Check for WRK output files in wrk subdirectory
-        Path wrkDir = inputDir.resolve("wrk");
-        boolean hasWrkFiles = false;
-        if (Files.exists(wrkDir)) {
-            try (Stream<Path> files = Files.list(wrkDir)) {
-                hasWrkFiles = files.anyMatch(p -> p.getFileName().toString().endsWith(".txt"));
-            }
-        }
-
-        if (!hasWrkFiles) {
-            LOGGER.error(ERROR.NO_WRK_FILES, wrkDir);
-        }
+        // Parse all WRK result files to extract metadata (fails if no result files exist)
+        parseBenchmarkMetadata(inputDir);
 
         // Convert WRK output to BenchmarkData from wrk subdirectory
-        BenchmarkData benchmarkData;
+        Path wrkDir = inputDir.resolve("wrk");
         if (!Files.exists(wrkDir)) {
             LOGGER.error(ERROR.WRK_DIR_NOT_EXIST, wrkDir);
-            benchmarkData = BenchmarkData.builder()
-                    .metadata(BenchmarkData.Metadata.builder()
-                            .reportVersion("2.0")
-                            .timestamp(Instant.now().toString())
-                            .displayTimestamp(Instant.now().toString())
-                            .benchmarkType("Integration Performance")
-                            .build())
-                    .overview(BenchmarkData.Overview.builder()
-                            .throughput("0 ops/s")
-                            .latency("0ms")
-                            .throughputBenchmarkName("N/A")
-                            .latencyBenchmarkName("N/A")
-                            .performanceScore(0)
-                            .performanceGrade("F")
-                            .performanceGradeClass("grade-f")
-                            .build())
-                    .benchmarks(List.of())
-                    .build();
-        } else {
-            benchmarkData = converter.convert(wrkDir);
+            throw new IllegalStateException("WRK output directory does not exist: " + wrkDir);
         }
 
+        BenchmarkData benchmarkData = converter.convert(wrkDir);
+
+        // Fail loudly instead of publishing a report with fabricated zero-metrics
         if (benchmarkData.getBenchmarks() == null || benchmarkData.getBenchmarks().isEmpty()) {
             LOGGER.error(ERROR.NO_BENCHMARK_DATA);
+            throw new IllegalStateException(
+                    "No benchmark yielded parseable metrics from WRK output in: " + wrkDir);
         }
 
         // Generate reports using new OutputDirectoryStructure (no duplication)

--- a/benchmarking/benchmark-integration-wrk/src/test/java/de/cuioss/sheriff/token/wrk/benchmark/WrkResultPostProcessorTest.java
+++ b/benchmarking/benchmark-integration-wrk/src/test/java/de/cuioss/sheriff/token/wrk/benchmark/WrkResultPostProcessorTest.java
@@ -271,6 +271,40 @@ class WrkResultPostProcessorTest {
     }
 
     @Test
+    void missingInputDirectoryFailsBeforeAnyParsing() {
+        Path missingInput = tempDir.resolve("does-not-exist");
+        Path outputDir = tempDir.resolve("output");
+
+        assertThrows(IllegalArgumentException.class, () -> processor.process(missingInput, outputDir),
+                "Missing input directory must fail instead of producing an empty report");
+        assertFalse(Files.exists(outputDir.resolve("gh-pages-ready/data/benchmark-data.json")),
+                "No report may be generated for a missing input directory");
+    }
+
+    @Test
+    void unparseableWrkOutputFailsInsteadOfPublishingZeros() throws Exception {
+        // A result file with valid metadata but no parseable WRK metrics (no Requests/sec line)
+        String unparseable = """
+                === BENCHMARK METADATA ===
+                benchmark_name: jwtValidation
+                start_time: 1700000000
+                === WRK OUTPUT ===
+                wrk crashed before producing any output
+                === BENCHMARK COMPLETE ===
+                end_time: 1700000010
+                """;
+        Path wrkDir = tempDir.resolve("wrk");
+        Files.createDirectories(wrkDir);
+        Files.writeString(wrkDir.resolve(WRK_JWT_OUTPUT_FILE), unparseable);
+
+        Path outputDir = tempDir.resolve("output");
+        assertThrows(IllegalStateException.class, () -> processor.process(tempDir, outputDir),
+                "Runs where no benchmark yields parseable metrics must fail loudly");
+        assertFalse(Files.exists(outputDir.resolve("gh-pages-ready/data/benchmark-data.json")),
+                "No zero-metrics report may be published for unparseable WRK output");
+    }
+
+    @Test
     void parseRealWrkFormatVariations() throws Exception {
         // Test with actual WRK output showing various time units
         String wrkOutput = """

--- a/benchmarking/benchmarking-common/doc/LogMessages.adoc
+++ b/benchmarking/benchmarking-common/doc/LogMessages.adoc
@@ -130,6 +130,7 @@ All messages follow the format: `Benchmarking-[identifier]: [message]`
 | 123 | UNKNOWN_TIME_UNIT | Unknown time unit '%s' in '%s', defaulting to seconds
 | 124 | TOKEN_POOL_EMPTY | Token pool is empty, fetching single token
 | 125 | ISSUE_PARSING_HISTORY_FILE | Issue during parsing history file: %s
+| 126 | SECRET_PROPERTY_ON_FORK_COMMAND_LINE | Secret system property '%s' is forwarded on the forked JVM command line and may be visible in process listings
 |===
 
 == ERROR Level Messages (200-299)

--- a/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/config/BenchmarkConfiguration.java
+++ b/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/config/BenchmarkConfiguration.java
@@ -147,7 +147,13 @@ IntegrationConfiguration integrationConfig
     }
 
 
-    private static TimeValue parseTimeValue(String timeStr) {
+    /**
+     * Parses a time value string like {@code "4"} (seconds), {@code "4s"}, {@code "2m"} or {@code "1h"}.
+     *
+     * @param timeStr the time string to parse
+     * @return the parsed time value, defaulting to 1 second for null/empty input
+     */
+    public static TimeValue parseTimeValue(String timeStr) {
         if (timeStr == null || timeStr.isEmpty()) {
             return TimeValue.seconds(1);
         }

--- a/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/constants/BenchmarkConstants.java
+++ b/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/constants/BenchmarkConstants.java
@@ -347,8 +347,8 @@ public final class BenchmarkConstants {
             public static final String NO_RESULTS_PROVIDED = "No benchmark results provided";
             public static final String THROUGHPUT_NOT_FOUND_FORMAT = "Required throughput benchmark '%s' not found in results";
             public static final String LATENCY_NOT_FOUND_FORMAT = "Required latency benchmark '%s' not found in results";
-            public static final String THROUGHPUT_POSITIVE = "Throughput must be positive, got: ";
-            public static final String LATENCY_POSITIVE = "Latency must be positive, got: ";
+            public static final String THROUGHPUT_NON_NEGATIVE = "Throughput must not be negative, got: ";
+            public static final String LATENCY_NON_NEGATIVE = "Latency must not be negative, got: ";
             public static final String SCORE_NON_NEGATIVE = "Performance score must be non-negative, got: ";
         }
 

--- a/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/converter/JmhBenchmarkConverter.java
+++ b/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/converter/JmhBenchmarkConverter.java
@@ -22,6 +22,7 @@ import com.google.gson.JsonObject;
 import de.cuioss.benchmarking.common.config.BenchmarkType;
 import de.cuioss.benchmarking.common.model.BenchmarkData;
 import de.cuioss.benchmarking.common.report.MetricConversionUtil;
+import de.cuioss.benchmarking.common.report.MetricsComputer;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -184,8 +185,9 @@ public class JmhBenchmarkConverter implements BenchmarkConverter {
             };
         }).orElse(0.0);
 
-        int score = calculatePerformanceScore(throughput, latency);
-        String grade = calculatePerformanceGrade(score);
+        // Delegate to MetricsComputer - the single home for score/grade computation
+        int score = (int) Math.round(MetricsComputer.calculatePerformanceScore(throughput, latency));
+        String grade = MetricsComputer.getPerformanceGrade(score);
 
         return BenchmarkData.Overview.builder()
                 .throughput(bestThroughput.map(BenchmarkData.Benchmark::getScore).orElse("N/A"))
@@ -223,25 +225,4 @@ public class JmhBenchmarkConverter implements BenchmarkConverter {
         return String.format(Locale.US, "%.1f %s", score, unit);
     }
 
-    private int calculatePerformanceScore(double throughput, double latency) {
-        // Performance scoring per benchmarking/doc/performance-scoring.adoc
-        // Performance Score = (Throughput_Score × 0.5) + (Latency_Score × 0.5)
-        // Where:
-        // - Throughput_Score = Throughput ÷ 100
-        // - Latency_Score = 100 ÷ Latency_ms
-        // Scores are NOT capped - exceptional performance can exceed 100
-        double throughputScore = throughput / 100.0;
-        double latencyScore = latency > 0 ? 100.0 / latency : 0.0;
-        double rawScore = (throughputScore * 0.5) + (latencyScore * 0.5);
-        return (int) Math.round(rawScore);
-    }
-
-    private String calculatePerformanceGrade(int score) {
-        if (score >= 95) return "A+";
-        if (score >= 90) return "A";
-        if (score >= 75) return "B";
-        if (score >= 60) return "C";
-        if (score >= 40) return "D";
-        return "F";
-    }
 }

--- a/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/converter/WrkBenchmarkConverter.java
+++ b/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/converter/WrkBenchmarkConverter.java
@@ -17,6 +17,7 @@ package de.cuioss.benchmarking.common.converter;
 
 import de.cuioss.benchmarking.common.config.BenchmarkType;
 import de.cuioss.benchmarking.common.model.BenchmarkData;
+import de.cuioss.benchmarking.common.report.MetricsComputer;
 import de.cuioss.tools.logging.CuiLogger;
 
 import java.io.IOException;
@@ -38,6 +39,9 @@ import static de.cuioss.benchmarking.common.util.BenchmarkingLogMessages.ERROR.F
 public class WrkBenchmarkConverter implements BenchmarkConverter {
 
     private static final CuiLogger LOGGER = new CuiLogger(WrkBenchmarkConverter.class);
+
+    /** Key for the wrk-reported average latency (ms) in {@link BenchmarkData.Benchmark#getAdditionalData()}. */
+    static final String LATENCY_AVG_MS = "latencyAvgMs";
 
     // Regex patterns for parsing WRK output
     private static final Pattern REQUESTS_PER_SEC = Pattern.compile("Requests/sec:\\s+([\\d.]+)");
@@ -104,16 +108,25 @@ public class WrkBenchmarkConverter implements BenchmarkConverter {
                 .build();
     }
 
+    /**
+     * Parses a single WRK output file into a benchmark.
+     *
+     * @param file the WRK output file
+     * @return the parsed benchmark, or {@code null} if the file contains no parseable
+     *         {@code Requests/sec} line (the caller must skip such files)
+     * @throws IOException if reading the file fails
+     */
     private BenchmarkData.Benchmark parseWrkFile(Path file) throws IOException {
         String content = Files.readString(file);
         String name = extractBenchmarkName(file);
 
-        // Parse requests per second (throughput)
-        double requestsPerSec = 0;
+        // Parse requests per second (throughput) - without it the file yields no usable metrics
         Matcher m = REQUESTS_PER_SEC.matcher(content);
-        if (m.find()) {
-            requestsPerSec = Double.parseDouble(m.group(1));
+        if (!m.find()) {
+            LOGGER.error(FAILED_PARSE_WRK_FILE, file);
+            return null;
         }
+        double requestsPerSec = Double.parseDouble(m.group(1));
 
         // Parse latency statistics
         double latencyAvg = 0;
@@ -124,7 +137,8 @@ public class WrkBenchmarkConverter implements BenchmarkConverter {
             latencyStdev = convertToMs(Double.parseDouble(m.group(3)), m.group(4));
         }
 
-        // Parse percentiles
+        // Parse percentiles - only measured values are reported, missing percentiles
+        // are NOT estimated/fabricated. Downstream consumers tolerate missing keys.
         Map<String, Double> percentiles = new LinkedHashMap<>();
         m = LATENCY_PERCENTILE.matcher(content);
         while (m.find()) {
@@ -132,9 +146,6 @@ public class WrkBenchmarkConverter implements BenchmarkConverter {
             double value = convertToMs(Double.parseDouble(m.group(2)), m.group(3));
             percentiles.put(String.valueOf(percentile), value);
         }
-
-        // Ensure standard percentiles exist
-        ensureStandardPercentiles(percentiles, latencyAvg, latencyStdev);
 
         return BenchmarkData.Benchmark.builder()
                 .name(name)
@@ -150,6 +161,7 @@ public class WrkBenchmarkConverter implements BenchmarkConverter {
                 .confidenceLow(Math.max(0, latencyAvg - latencyStdev))
                 .confidenceHigh(latencyAvg + latencyStdev)
                 .percentiles(percentiles)
+                .additionalData(Map.of(LATENCY_AVG_MS, latencyAvg))
                 .build();
     }
 
@@ -192,28 +204,6 @@ public class WrkBenchmarkConverter implements BenchmarkConverter {
         };
     }
 
-    private void ensureStandardPercentiles(Map<String, Double> percentiles, double avg, double stdev) {
-        String[] standard = {"0.0", "50.0", "90.0", "95.0", "99.0", "99.9", "99.99", "100.0"};
-
-        for (String p : standard) {
-            if (percentiles.containsKey(p)) {
-                continue;
-            }
-            double percentileValue = Double.parseDouble(p);
-            // Simple estimation based on normal distribution
-            double estimated = estimatePercentile(percentileValue, avg, stdev);
-            percentiles.put(p, estimated);
-        }
-    }
-
-    private double estimatePercentile(double percentile, double avg, double stdev) {
-        if (percentile <= 50) {
-            return Math.max(0, avg - stdev * (50 - percentile) / 50);
-        } else {
-            return avg + stdev * (percentile - 50) / 50 * 2;
-        }
-    }
-
     private BenchmarkData.Metadata createMetadata() {
         Instant now = Instant.now();
         return BenchmarkData.Metadata.builder()
@@ -246,9 +236,10 @@ public class WrkBenchmarkConverter implements BenchmarkConverter {
         }
 
         double throughput = primary.getRawScore();
-        double latencyMs = primary.getPercentiles().getOrDefault("50.0", 100.0);
-        int score = calculatePerformanceScore(throughput, latencyMs);
-        String grade = calculatePerformanceGrade(score);
+        double latencyMs = resolveLatencyMs(primary);
+        // Delegate to MetricsComputer - the single home for score/grade computation
+        int score = MetricsComputer.computeIntegrationScore(throughput, latencyMs);
+        String grade = MetricsComputer.gradeIntegration(score);
 
         return BenchmarkData.Overview.builder()
                 .throughput(primary.getThroughput())
@@ -277,18 +268,21 @@ public class WrkBenchmarkConverter implements BenchmarkConverter {
         return String.format(Locale.US, "%.1fms", ms);
     }
 
-    private int calculatePerformanceScore(double throughput, double latencyMs) {
-        // Score based on throughput (0-50 points) and latency (0-50 points)
-        int throughputScore = (int) Math.min(50, throughput / 200);
-        int latencyScore = (int) Math.max(0, 50 - latencyMs / 2);
-        return throughputScore + latencyScore;
-    }
-
-    private String calculatePerformanceGrade(int score) {
-        if (score >= 90) return "A";
-        if (score >= 80) return "B";
-        if (score >= 70) return "C";
-        if (score >= 60) return "D";
-        return "F";
+    /**
+     * Resolves the latency (in milliseconds) for the overview from measured data only:
+     * the measured P50 percentile if present, otherwise the wrk-reported average latency.
+     *
+     * @param benchmark the primary benchmark
+     * @return the measured latency in milliseconds, or 0 if neither value was reported
+     */
+    private double resolveLatencyMs(BenchmarkData.Benchmark benchmark) {
+        if (benchmark.getPercentiles() != null && benchmark.getPercentiles().containsKey("50.0")) {
+            return benchmark.getPercentiles().get("50.0");
+        }
+        if (benchmark.getAdditionalData() != null
+                && benchmark.getAdditionalData().get(LATENCY_AVG_MS) instanceof Double avg) {
+            return avg;
+        }
+        return 0;
     }
 }

--- a/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/metrics/BenchmarkMetricsTransformer.java
+++ b/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/metrics/BenchmarkMetricsTransformer.java
@@ -22,6 +22,10 @@ import java.util.*;
 /**
  * Transforms Prometheus time-series data into the benchmark server metrics format
  * as defined in benchmark-metrics.adoc.
+ * <p>
+ * Each metric may be backed by multiple series (e.g. {@code jvm_memory_used_bytes}
+ * with different {@code area} labels); the transformer selects or aggregates the
+ * relevant series per metric.
  *
  */
 public class BenchmarkMetricsTransformer {
@@ -35,14 +39,14 @@ public class BenchmarkMetricsTransformer {
      * @param benchmarkName Name of the benchmark
      * @param startTime Start time of the benchmark
      * @param endTime End time of the benchmark
-     * @param timeSeriesData Raw time-series data from Prometheus
+     * @param timeSeriesData Raw time-series data from Prometheus (all series per metric)
      * @return Structured benchmark metrics as defined in requirements
      */
     public Map<String, Object> transformToServerMetrics(
             String benchmarkName,
             Instant startTime,
             Instant endTime,
-            Map<String, PrometheusClient.TimeSeries> timeSeriesData) {
+            Map<String, List<PrometheusClient.TimeSeries>> timeSeriesData) {
 
         Map<String, Object> result = new LinkedHashMap<>();
         Duration duration = Duration.between(startTime, endTime);
@@ -65,16 +69,16 @@ public class BenchmarkMetricsTransformer {
     }
 
 
-    private Map<String, Object> createResourceMetrics(Map<String, PrometheusClient.TimeSeries> data) {
+    private Map<String, Object> createResourceMetrics(Map<String, List<PrometheusClient.TimeSeries>> data) {
         Map<String, Object> resources = new LinkedHashMap<>();
 
         // CPU metrics
         Map<String, Object> cpu = new LinkedHashMap<>();
-        cpu.put("process", createCpuMetrics(data.get(METRIC_PROCESS_CPU_USAGE), "Process"));
-        cpu.put("system", createCpuMetrics(data.get("system_cpu_usage"), "System"));
+        cpu.put("process", createCpuMetrics(firstSeries(data, METRIC_PROCESS_CPU_USAGE), "Process"));
+        cpu.put("system", createCpuMetrics(firstSeries(data, "system_cpu_usage"), "System"));
 
         // Get CPU cores
-        PrometheusClient.TimeSeries cpuCount = data.get("system_cpu_count");
+        PrometheusClient.TimeSeries cpuCount = firstSeries(data, "system_cpu_count");
         if (cpuCount != null && !cpuCount.values().isEmpty()) {
             cpu.put("cores_available", (int) cpuCount.values().getFirst().value());
         } else {
@@ -123,10 +127,10 @@ public class BenchmarkMetricsTransformer {
         return cpuMetrics;
     }
 
-    private Map<String, Object> createMemoryMetrics(Map<String, PrometheusClient.TimeSeries> data) {
+    private Map<String, Object> createMemoryMetrics(Map<String, List<PrometheusClient.TimeSeries>> data) {
         Map<String, Object> memory = new LinkedHashMap<>();
 
-        // Heap memory
+        // Heap memory - select the series labeled area="heap" from all memory series
         Map<String, Object> heap = new LinkedHashMap<>();
         PrometheusClient.TimeSeries heapUsed = findHeapMemory(data.get(METRIC_JVM_MEMORY_USED_BYTES));
         if (heapUsed != null && !heapUsed.values().isEmpty()) {
@@ -147,7 +151,7 @@ public class BenchmarkMetricsTransformer {
 
         // GC metrics
         Map<String, Object> gc = new LinkedHashMap<>();
-        PrometheusClient.TimeSeries gcOverhead = data.get("jvm_gc_overhead");
+        PrometheusClient.TimeSeries gcOverhead = firstSeries(data, "jvm_gc_overhead");
         if (gcOverhead != null && !gcOverhead.values().isEmpty()) {
             double avgOverhead = gcOverhead.values().stream()
                     .mapToDouble(PrometheusClient.DataPoint::value)
@@ -161,10 +165,10 @@ public class BenchmarkMetricsTransformer {
         return memory;
     }
 
-    private Map<String, Object> createThreadMetrics(Map<String, PrometheusClient.TimeSeries> data) {
+    private Map<String, Object> createThreadMetrics(Map<String, List<PrometheusClient.TimeSeries>> data) {
         Map<String, Object> threads = new LinkedHashMap<>();
 
-        PrometheusClient.TimeSeries liveThreads = data.get("jvm_threads_live_threads");
+        PrometheusClient.TimeSeries liveThreads = firstSeries(data, "jvm_threads_live_threads");
         if (liveThreads != null && !liveThreads.values().isEmpty()) {
             Statistics stats = calculateStatistics(
                     liveThreads.values().stream()
@@ -180,7 +184,7 @@ public class BenchmarkMetricsTransformer {
             threads.put("final", 0);
         }
 
-        PrometheusClient.TimeSeries daemonThreads = data.get("jvm_threads_daemon_threads");
+        PrometheusClient.TimeSeries daemonThreads = firstSeries(data, "jvm_threads_daemon_threads");
         if (daemonThreads != null && !daemonThreads.values().isEmpty()) {
             threads.put("daemon", (int) daemonThreads.values().getFirst().value());
         } else {
@@ -191,27 +195,29 @@ public class BenchmarkMetricsTransformer {
     }
 
 
-    private Map<String, Object> createApplicationMetrics(Map<String, PrometheusClient.TimeSeries> data) {
+    private Map<String, Object> createApplicationMetrics(Map<String, List<PrometheusClient.TimeSeries>> data) {
         Map<String, Object> application = new LinkedHashMap<>();
 
         Map<String, Object> jwtValidations = new LinkedHashMap<>();
 
-        // JWT validation metrics
-        PrometheusClient.TimeSeries jwtSuccess = data.get("sheriff_token_validation_success_operations_total");
+        // JWT validation metrics - aggregate across ALL series (e.g. per event_type label)
         double totalSuccess = 0;
         double cacheHits = 0;
 
-        if (jwtSuccess != null && !jwtSuccess.values().isEmpty()) {
-            totalSuccess = getDeltaValue(jwtSuccess);
+        for (PrometheusClient.TimeSeries series : allSeries(data, "sheriff_token_validation_success_operations_total")) {
+            double delta = getDeltaValue(series);
+            totalSuccess += delta;
             // Check if it's a cache hit based on metric labels
-            if (jwtSuccess.labels().containsKey("event_type") &&
-                    jwtSuccess.labels().get("event_type").contains("CACHE_HIT")) {
-                cacheHits = totalSuccess;
+            if (series.labels().containsKey("event_type") &&
+                    series.labels().get("event_type").contains("CACHE_HIT")) {
+                cacheHits += delta;
             }
         }
 
-        PrometheusClient.TimeSeries jwtErrors = data.get("sheriff_token_validation_errors_total");
-        double totalErrors = jwtErrors != null ? getDeltaValue(jwtErrors) : 0;
+        double totalErrors = 0;
+        for (PrometheusClient.TimeSeries series : allSeries(data, "sheriff_token_validation_errors_total")) {
+            totalErrors += getDeltaValue(series);
+        }
 
         double total = totalSuccess + totalErrors;
         jwtValidations.put("total", (int) total);
@@ -220,15 +226,17 @@ public class BenchmarkMetricsTransformer {
         jwtValidations.put("cache_hits", (int) cacheHits);
         jwtValidations.put("cache_hit_rate_percent", total > 0 ? round(cacheHits / total * 100, 1) : 0.0);
 
-        // JWT validation timing
-        PrometheusClient.TimeSeries jwtDurationSum = data.get("sheriff_token_bearer_token_validation_seconds_sum");
-        PrometheusClient.TimeSeries jwtDurationCount = data.get("sheriff_token_bearer_token_validation_seconds_count");
-        if (jwtDurationSum != null && jwtDurationCount != null) {
-            double sum = getDeltaValue(jwtDurationSum);
-            double count = getDeltaValue(jwtDurationCount);
-            if (count > 0) {
-                jwtValidations.put("average_validation_time_ms", round(sum / count * 1000, 2));
-            }
+        // JWT validation timing - aggregate sums/counts across all series
+        double sum = 0;
+        double count = 0;
+        for (PrometheusClient.TimeSeries series : allSeries(data, "sheriff_token_bearer_token_validation_seconds_sum")) {
+            sum += getDeltaValue(series);
+        }
+        for (PrometheusClient.TimeSeries series : allSeries(data, "sheriff_token_bearer_token_validation_seconds_count")) {
+            count += getDeltaValue(series);
+        }
+        if (count > 0) {
+            jwtValidations.put("average_validation_time_ms", round(sum / count * 1000, 2));
         }
 
         application.put("jwt_validations", jwtValidations);
@@ -236,16 +244,37 @@ public class BenchmarkMetricsTransformer {
         return application;
     }
 
-    private PrometheusClient.TimeSeries findHeapMemory(PrometheusClient.TimeSeries memorySeries) {
+    /**
+     * Returns the first series of a metric, or {@code null} if the metric has no series.
+     * Use for metrics that are expected to have exactly one series.
+     */
+    private PrometheusClient.TimeSeries firstSeries(Map<String, List<PrometheusClient.TimeSeries>> data, String metricName) {
+        List<PrometheusClient.TimeSeries> series = data.get(metricName);
+        return series == null || series.isEmpty() ? null : series.getFirst();
+    }
+
+    /**
+     * Returns all series of a metric, or an empty list if the metric has no series.
+     */
+    private List<PrometheusClient.TimeSeries> allSeries(Map<String, List<PrometheusClient.TimeSeries>> data, String metricName) {
+        List<PrometheusClient.TimeSeries> series = data.get(metricName);
+        return series == null ? List.of() : series;
+    }
+
+    /**
+     * Selects the heap memory series (label {@code area="heap"}) from all memory series.
+     *
+     * @param memorySeries all series of the memory metric, may be {@code null}
+     * @return the heap series, or {@code null} if none is labeled as heap
+     */
+    private PrometheusClient.TimeSeries findHeapMemory(List<PrometheusClient.TimeSeries> memorySeries) {
         if (memorySeries == null) {
             return null;
         }
-        // Check if this is heap memory based on labels
-        if (memorySeries.labels().containsKey("area") &&
-                "heap".equals(memorySeries.labels().get("area"))) {
-            return memorySeries;
-        }
-        return null;
+        return memorySeries.stream()
+                .filter(series -> "heap".equals(series.labels().get("area")))
+                .findFirst()
+                .orElse(null);
     }
 
     private double getDeltaValue(PrometheusClient.TimeSeries series) {

--- a/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/metrics/MetricsOrchestrator.java
+++ b/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/metrics/MetricsOrchestrator.java
@@ -96,7 +96,7 @@ public class MetricsOrchestrator {
         try {
             // Query Prometheus for metrics within the benchmark time window
             Duration step = Duration.ofSeconds(2); // 2-second resolution matching scrape interval
-            Map<String, PrometheusClient.TimeSeries> timeSeriesData =
+            Map<String, List<PrometheusClient.TimeSeries>> timeSeriesData =
                     prometheusClient.queryRange(metricNames, startTime, endTime, step);
 
             // Transform time-series data using the new BenchmarkMetricsTransformer

--- a/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/metrics/PrometheusClient.java
+++ b/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/metrics/PrometheusClient.java
@@ -78,20 +78,24 @@ public class PrometheusClient {
 
     /**
      * Query Prometheus for time-series data in a specific time range.
+     * <p>
+     * A single metric name can match multiple series (e.g. {@code jvm_memory_used_bytes}
+     * with different {@code area}/{@code id} labels). ALL matching series are returned,
+     * each with its own label set and data points.
      *
      * @param metricNames List of metric names to query
      * @param startTime   Start of time range (inclusive)
      * @param endTime     End of time range (inclusive)
      * @param step        Step size between data points
-     * @return Map of metric name to time series data
+     * @return Map of metric name to all matching time series (empty list if the metric is not exported)
      * @throws PrometheusException if query fails or Prometheus unavailable
      */
-    public Map<String, TimeSeries> queryRange(List<String> metricNames, Instant startTime, Instant endTime, Duration step) throws PrometheusException {
-        Map<String, TimeSeries> results = new HashMap<>();
+    public Map<String, List<TimeSeries>> queryRange(List<String> metricNames, Instant startTime, Instant endTime, Duration step) throws PrometheusException {
+        Map<String, List<TimeSeries>> results = new HashMap<>();
 
         for (String metricName : metricNames) {
             try {
-                TimeSeries timeSeries = queryRangeForMetric(metricName, startTime, endTime, step);
+                List<TimeSeries> timeSeries = queryRangeForMetric(metricName, startTime, endTime, step);
                 results.put(metricName, timeSeries);
             } catch (PrometheusException e) {
                 LOGGER.warn(FAILED_QUERY_METRIC, metricName, e.getMessage());
@@ -102,7 +106,7 @@ public class PrometheusClient {
         return results;
     }
 
-    private TimeSeries queryRangeForMetric(String metricName, Instant startTime, Instant endTime, Duration step) throws PrometheusException {
+    private List<TimeSeries> queryRangeForMetric(String metricName, Instant startTime, Instant endTime, Duration step) throws PrometheusException {
         String stepSeconds = step.getSeconds() + "s";
         String startEpoch = String.valueOf(startTime.getEpochSecond());
         String endEpoch = String.valueOf(endTime.getEpochSecond());
@@ -140,7 +144,7 @@ public class PrometheusClient {
         }
     }
 
-    private TimeSeries parsePrometheusResponse(String metricName, String responseBody) throws PrometheusException {
+    private List<TimeSeries> parsePrometheusResponse(String metricName, String responseBody) throws PrometheusException {
         try {
             JsonObject root = GSON.fromJson(responseBody, JsonObject.class);
             validateStatus(root);
@@ -149,15 +153,18 @@ public class PrometheusClient {
             JsonArray resultArray = data.getAsJsonArray("result");
 
             if (resultArray == null || resultArray.isEmpty()) {
-                // Metric may not be exported by the application - return empty series silently
-                return new TimeSeries(metricName, Map.of(), List.of());
+                // Metric may not be exported by the application - return no series silently
+                return List.of();
             }
 
-            JsonObject firstResult = resultArray.get(0).getAsJsonObject();
-            Map<String, String> labels = extractLabels(firstResult.getAsJsonObject("metric"));
-            List<DataPoint> dataPoints = extractDataPoints(firstResult.getAsJsonArray("values"));
-
-            return new TimeSeries(metricName, labels, dataPoints);
+            List<TimeSeries> allSeries = new ArrayList<>();
+            for (JsonElement resultElement : resultArray) {
+                JsonObject result = resultElement.getAsJsonObject();
+                Map<String, String> labels = extractLabels(result.getAsJsonObject("metric"));
+                List<DataPoint> dataPoints = extractDataPoints(result.getAsJsonArray("values"));
+                allSeries.add(new TimeSeries(metricName, labels, dataPoints));
+            }
+            return List.copyOf(allSeries);
 
         } catch (JsonParseException | IllegalStateException | NullPointerException e) {
             // JsonParseException: malformed JSON

--- a/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/report/BenchmarkMetrics.java
+++ b/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/report/BenchmarkMetrics.java
@@ -20,6 +20,10 @@ import static de.cuioss.benchmarking.common.constants.BenchmarkConstants.Report.
 /**
  * Immutable record containing all computed benchmark metrics.
  * This is the central data structure shared across all report generators.
+ * <p>
+ * Throughput and latency may be zero: failed or empty benchmark runs are reported
+ * as degraded (F-grade) results instead of crashing report generation.
+ * Negative values are always rejected.
  */
 public record BenchmarkMetrics(
 String throughputBenchmarkName,
@@ -36,11 +40,11 @@ String performanceGrade
         if (latencyBenchmarkName == null || latencyBenchmarkName.isBlank()) {
             throw new IllegalArgumentException(LATENCY_NAME_REQUIRED);
         }
-        if (throughput <= 0) {
-            throw new IllegalArgumentException(THROUGHPUT_POSITIVE + throughput);
+        if (throughput < 0) {
+            throw new IllegalArgumentException(THROUGHPUT_NON_NEGATIVE + throughput);
         }
-        if (latency <= 0) {
-            throw new IllegalArgumentException(LATENCY_POSITIVE + latency);
+        if (latency < 0) {
+            throw new IllegalArgumentException(LATENCY_NON_NEGATIVE + latency);
         }
         if (performanceScore < 0) {
             throw new IllegalArgumentException(SCORE_NON_NEGATIVE + performanceScore);

--- a/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/report/MetricConversionUtil.java
+++ b/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/report/MetricConversionUtil.java
@@ -19,7 +19,6 @@ import java.util.Locale;
 
 import static de.cuioss.benchmarking.common.constants.BenchmarkConstants.Metrics.Conversions;
 import static de.cuioss.benchmarking.common.constants.BenchmarkConstants.Metrics.Units;
-import static de.cuioss.benchmarking.common.constants.BenchmarkConstants.Report.Grades;
 
 /**
  * Central utility for converting benchmark metrics between different units.
@@ -93,22 +92,6 @@ public final class MetricConversionUtil {
         }
         // Unknown unit, return 0 to filter out in calculations
         return 0;
-    }
-
-    /**
-     * Calculates a performance grade based on throughput.
-     * 
-     * @param throughput operations per second
-     * @return performance grade string
-     */
-    public static String calculatePerformanceGrade(double throughput) {
-        return switch ((int) Math.log10(Math.max(1, throughput))) {
-            case 6, 7, 8, 9 -> Grades.A_PLUS;
-            case 5 -> Grades.A;
-            case 4 -> Grades.B;
-            case 3 -> Grades.C;
-            default -> Grades.D;
-        };
     }
 
     /**

--- a/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/report/MetricsComputer.java
+++ b/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/report/MetricsComputer.java
@@ -125,18 +125,69 @@ public class MetricsComputer {
                 LATENCY_NOT_FOUND_FORMAT.formatted(latencyBenchmarkName));
     }
 
-    private double calculatePerformanceScore(double throughput, double latency) {
+    /**
+     * Calculates the composite performance score for micro (JMH) benchmarks.
+     * <p>
+     * Performance scoring per benchmarking/doc/performance-scoring.adoc:
+     * {@code Performance Score = (Throughput / 100 x 0.5) + (100 / Latency_ms x 0.5)}.
+     * Scores are NOT capped - exceptional performance can exceed 100.
+     * <p>
+     * This is the single home for this formula - all callers must delegate here.
+     *
+     * @param throughput throughput in operations per second
+     * @param latency latency in milliseconds per operation
+     * @return the raw (unrounded) performance score
+     */
+    public static double calculatePerformanceScore(double throughput, double latency) {
         double throughputScore = (throughput / 100.0) * 0.5;
-        double latencyScore = (100.0 / latency) * 0.5;
+        double latencyScore = latency > 0 ? (100.0 / latency) * 0.5 : 0.0;
         return throughputScore + latencyScore;
     }
 
-    private String getPerformanceGrade(double score) {
+    /**
+     * Maps a micro (JMH) benchmark performance score to a letter grade.
+     *
+     * @param score the performance score
+     * @return the letter grade (A+, A, B, C, D or F)
+     */
+    public static String getPerformanceGrade(double score) {
         if (score >= 95) return A_PLUS;
         if (score >= 90) return A;
         if (score >= 75) return B;
         if (score >= 60) return C;
         if (score >= 40) return D;
+        return F;
+    }
+
+    /**
+     * Calculates the composite performance score for integration (WRK) benchmarks.
+     * <p>
+     * Uses a different formula and scale than {@link #calculatePerformanceScore(double, double)}:
+     * throughput contributes 0-50 points (capped at 50, 1 point per 200 ops/s) and latency
+     * contributes 0-50 points (50 minus half the latency in milliseconds, floored at 0).
+     *
+     * @param throughput throughput in requests per second
+     * @param latencyMs latency in milliseconds
+     * @return the integration performance score (0-100)
+     */
+    public static int computeIntegrationScore(double throughput, double latencyMs) {
+        int throughputScore = (int) Math.min(50, throughput / 200);
+        int latencyScore = (int) Math.max(0, 50 - latencyMs / 2);
+        return throughputScore + latencyScore;
+    }
+
+    /**
+     * Maps an integration (WRK) benchmark performance score to a letter grade.
+     * Note: uses different thresholds than {@link #getPerformanceGrade(double)} and has no A+.
+     *
+     * @param score the integration performance score
+     * @return the letter grade (A, B, C, D or F)
+     */
+    public static String gradeIntegration(int score) {
+        if (score >= 90) return A;
+        if (score >= 80) return B;
+        if (score >= 70) return C;
+        if (score >= 60) return D;
         return F;
     }
 

--- a/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/report/MetricsComputer.java
+++ b/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/report/MetricsComputer.java
@@ -171,7 +171,7 @@ public class MetricsComputer {
      * @return the integration performance score (0-100)
      */
     public static int computeIntegrationScore(double throughput, double latencyMs) {
-        int throughputScore = (int) Math.min(50, throughput / 200);
+        int throughputScore = (int) Math.max(0, Math.min(50, throughput / 200));
         int latencyScore = (int) Math.max(0, 50 - latencyMs / 2);
         return throughputScore + latencyScore;
     }

--- a/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/runner/AbstractBenchmarkRunner.java
+++ b/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/runner/AbstractBenchmarkRunner.java
@@ -33,6 +33,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static de.cuioss.benchmarking.common.util.BenchmarkingLogMessages.INFO.*;
@@ -66,6 +67,20 @@ public abstract class AbstractBenchmarkRunner {
 
     private static final CuiLogger LOGGER =
             new CuiLogger(AbstractBenchmarkRunner.class);
+
+    /**
+     * Prefixes of system properties that are forwarded to forked benchmark JVMs.
+     */
+    private static final List<String> FORWARDED_PROPERTY_PREFIXES = List.of(
+            "jmh.", "benchmark.", "token.", "integration.", "quarkus.", "javax.net.ssl.");
+
+    /**
+     * Known secret-bearing property keys. They are required by the forked JVM
+     * (read via System.getProperty in TokenRepositoryConfig), so they are forwarded when set,
+     * but a warning is emitted because they appear on the fork command line.
+     */
+    private static final Set<String> SECRET_PROPERTY_KEYS = Set.of(
+            "token.keycloak.password", "token.keycloak.clientSecret");
 
     private final PrometheusMetricsManager prometheusMetricsManager;
     private Instant benchmarkStartTime;
@@ -318,15 +333,27 @@ public abstract class AbstractBenchmarkRunner {
                 .warmupTime(config.warmupTime())
                 .threads(config.threads());
 
-        // Pass all system properties from parent JVM to forked JVMs
-        // This ensures all Maven-provided properties are available in benchmark processes
+        // Forward only an explicit allowlist of benchmark-related system properties to forked
+        // JVMs. Forwarding EVERY parent property would leak arbitrary values (including
+        // credentials) onto the fork command line, visible in process listings and CI logs.
         var systemProperties = System.getProperties().entrySet().stream()
+                .filter(e -> isForwardedProperty(String.valueOf(e.getKey())))
                 .map(e -> "-D" + e.getKey() + "=" + e.getValue())
                 .toArray(String[]::new);
 
         builder.jvmArgsPrepend(systemProperties);
 
         return builder;
+    }
+
+    private static boolean isForwardedProperty(String key) {
+        if (FORWARDED_PROPERTY_PREFIXES.stream().noneMatch(key::startsWith)) {
+            return false;
+        }
+        if (SECRET_PROPERTY_KEYS.contains(key)) {
+            LOGGER.warn(SECRET_PROPERTY_ON_FORK_COMMAND_LINE, key);
+        }
+        return true;
     }
 
     /**

--- a/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/runner/AbstractBenchmarkRunner.java
+++ b/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/runner/AbstractBenchmarkRunner.java
@@ -31,6 +31,7 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -350,7 +351,12 @@ public abstract class AbstractBenchmarkRunner {
         if (FORWARDED_PROPERTY_PREFIXES.stream().noneMatch(key::startsWith)) {
             return false;
         }
-        if (SECRET_PROPERTY_KEYS.contains(key)) {
+        String lowerKey = key.toLowerCase(Locale.ROOT);
+        if (SECRET_PROPERTY_KEYS.contains(key)
+                || lowerKey.contains("password")
+                || lowerKey.contains("secret")
+                || lowerKey.contains("credential")
+                || lowerKey.contains("private")) {
             LOGGER.warn(SECRET_PROPERTY_ON_FORK_COMMAND_LINE, key);
         }
         return true;

--- a/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/util/BenchmarkingLogMessages.java
+++ b/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/util/BenchmarkingLogMessages.java
@@ -754,6 +754,13 @@ public final class BenchmarkingLogMessages {
                 .identifier(125)
                 .template("Issue during parsing history file: %s")
                 .build();
+
+        /** Warning when a secret-bearing system property is forwarded to a forked JVM command line. */
+        public static final LogRecord SECRET_PROPERTY_ON_FORK_COMMAND_LINE = LogRecordModel.builder()
+                .prefix(PREFIX)
+                .identifier(126)
+                .template("Secret system property '%s' is forwarded on the forked JVM command line and may be visible in process listings")
+                .build();
     }
 
     /**

--- a/benchmarking/benchmarking-common/src/test/java/de/cuioss/benchmarking/common/converter/WrkBenchmarkConverterTest.java
+++ b/benchmarking/benchmarking-common/src/test/java/de/cuioss/benchmarking/common/converter/WrkBenchmarkConverterTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.benchmarking.common.converter;
+
+import de.cuioss.benchmarking.common.model.BenchmarkData;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link WrkBenchmarkConverter}, focusing on honest reporting:
+ * no fabricated percentiles and no silent zero-metrics for unparseable files.
+ */
+class WrkBenchmarkConverterTest {
+
+    private static final String WRK_OUTPUT = """
+            === BENCHMARK METADATA ===
+            benchmark_name: jwtValidation
+            start_time: 1700000000
+            === WRK OUTPUT ===
+
+            Running 10s test @ https://localhost:10443/jwt/validate
+              4 threads and 20 connections
+              Thread Stats   Avg      Stdev     Max   +/- Stdev
+                Latency     2.00ms    1.00ms   20.00ms   90.00%
+                Req/Sec     5.00k   1.00k    10.00k    75.00%
+              Latency Distribution
+                 50%    1.50ms
+                 75%    2.50ms
+                 90%    4.00ms
+                 99%    9.00ms
+              100000 requests in 10.00s, 50.00MB read
+            Requests/sec:  10000.00
+            Transfer/sec:      5.00MB
+            """;
+
+    private final WrkBenchmarkConverter converter = new WrkBenchmarkConverter();
+
+    @Test
+    void shouldOnlyReportMeasuredPercentiles(@TempDir Path tempDir) throws Exception {
+        Path file = tempDir.resolve("wrk-jwt-results.txt");
+        Files.writeString(file, WRK_OUTPUT);
+
+        BenchmarkData data = converter.convert(file);
+
+        assertEquals(1, data.getBenchmarks().size());
+        Map<String, Double> percentiles = data.getBenchmarks().getFirst().getPercentiles();
+
+        // Only the percentiles actually measured by wrk are reported
+        assertEquals(Set.of("50.0", "75.0", "90.0", "99.0"), percentiles.keySet(),
+                "No fabricated percentiles: only measured keys may be present");
+        assertEquals(1.5, percentiles.get("50.0"));
+        assertEquals(9.0, percentiles.get("99.0"));
+    }
+
+    @Test
+    void shouldUseMeasuredP50ForOverviewLatency(@TempDir Path tempDir) throws Exception {
+        Path file = tempDir.resolve("wrk-jwt-results.txt");
+        Files.writeString(file, WRK_OUTPUT);
+
+        BenchmarkData data = converter.convert(file);
+
+        assertEquals(1.5, data.getOverview().getLatencyMs(),
+                "Overview latency must use the measured P50");
+    }
+
+    @Test
+    void shouldFallBackToAverageLatencyWhenP50Missing(@TempDir Path tempDir) throws Exception {
+        // wrk output without a latency distribution section (e.g. --latency flag missing)
+        String withoutDistribution = """
+                === WRK OUTPUT ===
+                Running 10s test @ https://localhost:10443/jwt/validate
+                  4 threads and 20 connections
+                  Thread Stats   Avg      Stdev     Max   +/- Stdev
+                    Latency     2.00ms    1.00ms   20.00ms   90.00%
+                Requests/sec:  10000.00
+                """;
+        Path file = tempDir.resolve("wrk-jwt-results.txt");
+        Files.writeString(file, withoutDistribution);
+
+        BenchmarkData data = converter.convert(file);
+
+        assertEquals(1, data.getBenchmarks().size());
+        assertTrue(data.getBenchmarks().getFirst().getPercentiles().isEmpty(),
+                "No percentiles may be fabricated");
+        assertEquals(2.0, data.getOverview().getLatencyMs(),
+                "Overview latency must fall back to the wrk-reported average latency");
+    }
+
+    @Test
+    void shouldSkipFilesWithoutParseableThroughput(@TempDir Path tempDir) throws Exception {
+        Path wrkDir = tempDir.resolve("wrk");
+        Files.createDirectories(wrkDir);
+        Files.writeString(wrkDir.resolve("wrk-jwt-results.txt"),
+                "=== WRK OUTPUT ===\ncompletely unparseable garbage\n");
+
+        BenchmarkData data = converter.convert(wrkDir);
+
+        assertTrue(data.getBenchmarks().isEmpty(),
+                "Files without a Requests/sec line must be skipped, not reported as zero");
+        assertEquals("F", data.getOverview().getPerformanceGrade());
+    }
+
+    @Test
+    void shouldSkipUnparseableSingleFile(@TempDir Path tempDir) throws Exception {
+        Path file = tempDir.resolve("wrk-jwt-results.txt");
+        Files.writeString(file, "no wrk content at all");
+
+        BenchmarkData data = converter.convert(file);
+
+        assertTrue(data.getBenchmarks().isEmpty(),
+                "Unparseable file must yield no benchmark instead of zero-metrics");
+    }
+}

--- a/benchmarking/benchmarking-common/src/test/java/de/cuioss/benchmarking/common/metrics/BenchmarkMetricsTransformerTest.java
+++ b/benchmarking/benchmarking-common/src/test/java/de/cuioss/benchmarking/common/metrics/BenchmarkMetricsTransformerTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.benchmarking.common.metrics;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Tests for {@link BenchmarkMetricsTransformer}, focusing on correct handling of
+ * metrics backed by multiple series (multi-label metrics).
+ */
+class BenchmarkMetricsTransformerTest {
+
+    private static final Instant START = Instant.ofEpochSecond(1758792520);
+    private static final Instant END = Instant.ofEpochSecond(1758792760);
+
+    private final BenchmarkMetricsTransformer transformer = new BenchmarkMetricsTransformer();
+
+    private static PrometheusClient.TimeSeries series(String metric, Map<String, String> labels, double... values) {
+        List<PrometheusClient.DataPoint> points = new ArrayList<>();
+        long ts = START.getEpochSecond();
+        for (double value : values) {
+            points.add(new PrometheusClient.DataPoint(Instant.ofEpochSecond(ts), value));
+            ts += 2;
+        }
+        return new PrometheusClient.TimeSeries(metric, labels, points);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldSelectHeapSeriesFromMultiSeriesMemoryMetric() {
+        // Given - nonheap series FIRST, heap series second: the transformer must select
+        // by the area label, not simply take the first series
+        double heapBytes = 512.0 * 1024 * 1024;
+        Map<String, List<PrometheusClient.TimeSeries>> data = Map.of(
+                "jvm_memory_used_bytes", List.of(
+                        series("jvm_memory_used_bytes", Map.of("area", "nonheap", "id", "code cache"),
+                                42.0 * 1024 * 1024, 42.0 * 1024 * 1024),
+                        series("jvm_memory_used_bytes", Map.of("area", "heap", "id", "eden space"),
+                                heapBytes, heapBytes)));
+
+        // When
+        Map<String, Object> result = transformer.transformToServerMetrics("test", START, END, data);
+
+        // Then
+        Map<String, Object> resources = (Map<String, Object>) result.get("resources");
+        Map<String, Object> memory = (Map<String, Object>) resources.get("memory");
+        Map<String, Object> heap = (Map<String, Object>) memory.get("heap");
+
+        assertEquals(512.0, heap.get("average_mb"), "Heap metrics must come from the area=heap series");
+        assertEquals(512.0, heap.get("peak_mb"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldAggregateJwtValidationsAcrossAllSeries() {
+        // Given - success counter split across two series with different event_type labels
+        Map<String, List<PrometheusClient.TimeSeries>> data = Map.of(
+                "sheriff_token_validation_success_operations_total", List.of(
+                        series("sheriff_token_validation_success_operations_total",
+                                Map.of("event_type", "ACCESS_TOKEN_CREATED"), 100.0, 300.0),
+                        series("sheriff_token_validation_success_operations_total",
+                                Map.of("event_type", "ACCESS_TOKEN_CACHE_HIT"), 50.0, 150.0)));
+
+        // When
+        Map<String, Object> result = transformer.transformToServerMetrics("test", START, END, data);
+
+        // Then - deltas of ALL series are summed: (300-100) + (150-50) = 300
+        Map<String, Object> application = (Map<String, Object>) result.get("application");
+        Map<String, Object> jwtValidations = (Map<String, Object>) application.get("jwt_validations");
+
+        assertEquals(300, jwtValidations.get("success"));
+        assertEquals(100, jwtValidations.get("cache_hits"), "Cache hits come from the CACHE_HIT series only");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldHandleMissingMetricsGracefully() {
+        Map<String, Object> result = transformer.transformToServerMetrics("test", START, END, Map.of());
+
+        Map<String, Object> resources = (Map<String, Object>) result.get("resources");
+        Map<String, Object> memory = (Map<String, Object>) resources.get("memory");
+        Map<String, Object> heap = (Map<String, Object>) memory.get("heap");
+
+        assertEquals(0.0, heap.get("average_mb"));
+        assertNotNull(result.get("application"));
+    }
+}

--- a/benchmarking/benchmarking-common/src/test/java/de/cuioss/benchmarking/common/metrics/PrometheusClientTest.java
+++ b/benchmarking/benchmarking-common/src/test/java/de/cuioss/benchmarking/common/metrics/PrometheusClientTest.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
@@ -60,14 +62,15 @@ class PrometheusClientTest {
         List<String> metricNames = List.of("process_cpu_usage");
 
         // When
-        Map<String, PrometheusClient.TimeSeries> result = prometheusClient.queryRange(
+        Map<String, List<PrometheusClient.TimeSeries>> result = prometheusClient.queryRange(
                 metricNames, START_TIME, END_TIME, STEP);
 
         // Then
         assertEquals(1, result.size());
         assertTrue(result.containsKey("process_cpu_usage"));
 
-        PrometheusClient.TimeSeries timeSeries = result.get("process_cpu_usage");
+        assertEquals(1, result.get("process_cpu_usage").size());
+        PrometheusClient.TimeSeries timeSeries = result.get("process_cpu_usage").getFirst();
         assertEquals("process_cpu_usage", timeSeries.metricName());
 
         // Verify labels
@@ -93,7 +96,7 @@ class PrometheusClientTest {
         List<String> metricNames = List.of("process_cpu_usage", "system_cpu_usage", "jvm_memory_used_bytes");
 
         // When
-        Map<String, PrometheusClient.TimeSeries> result = prometheusClient.queryRange(
+        Map<String, List<PrometheusClient.TimeSeries>> result = prometheusClient.queryRange(
                 metricNames, START_TIME, END_TIME, STEP);
 
         // Then
@@ -103,10 +106,13 @@ class PrometheusClientTest {
         assertTrue(result.containsKey("jvm_memory_used_bytes"));
 
         // Verify each metric has expected structure
-        result.forEach((metricName, timeSeries) -> {
-            assertEquals(metricName, timeSeries.metricName());
-            assertFalse(timeSeries.labels().isEmpty());
-            assertFalse(timeSeries.values().isEmpty());
+        result.forEach((metricName, seriesList) -> {
+            assertFalse(seriesList.isEmpty());
+            for (PrometheusClient.TimeSeries timeSeries : seriesList) {
+                assertEquals(metricName, timeSeries.metricName());
+                assertFalse(timeSeries.labels().isEmpty());
+                assertFalse(timeSeries.values().isEmpty());
+            }
         });
 
         assertEquals(3, moduleDispatcher.getCallCounter());
@@ -119,15 +125,13 @@ class PrometheusClientTest {
         List<String> metricNames = List.of("non_existent_metric");
 
         // When
-        Map<String, PrometheusClient.TimeSeries> result = prometheusClient.queryRange(
+        Map<String, List<PrometheusClient.TimeSeries>> result = prometheusClient.queryRange(
                 metricNames, START_TIME, END_TIME, STEP);
 
         // Then
         assertEquals(1, result.size());
-        PrometheusClient.TimeSeries timeSeries = result.get("non_existent_metric");
-        assertEquals("non_existent_metric", timeSeries.metricName());
-        assertTrue(timeSeries.labels().isEmpty());
-        assertTrue(timeSeries.values().isEmpty());
+        assertTrue(result.get("non_existent_metric").isEmpty(),
+                "Metric without data should yield an empty series list");
 
         assertEquals(1, moduleDispatcher.getCallCounter());
     }
@@ -287,11 +291,11 @@ class PrometheusClientTest {
         List<String> metricNames = List.of("sheriff_token_validation_success_operations_total");
 
         // When
-        Map<String, PrometheusClient.TimeSeries> result = prometheusClient.queryRange(
+        Map<String, List<PrometheusClient.TimeSeries>> result = prometheusClient.queryRange(
                 metricNames, START_TIME, END_TIME, STEP);
 
         // Then
-        PrometheusClient.TimeSeries timeSeries = result.get("sheriff_token_validation_success_operations_total");
+        PrometheusClient.TimeSeries timeSeries = result.get("sheriff_token_validation_success_operations_total").getFirst();
         Map<String, String> labels = timeSeries.labels();
 
         assertEquals("ACCESS_TOKEN_CREATED", labels.get("event_type"));
@@ -303,6 +307,39 @@ class PrometheusClientTest {
         assertEquals(10960018.0, values.getFirst().value());
         assertEquals(10960018.0, values.get(1).value());
         assertEquals(10960018.0, values.get(2).value());
+    }
+
+    @Test
+    void shouldReturnAllSeriesForMultiLabelMetric() throws Exception {
+        // Given - real jvm_memory_used_bytes fixture with 5 series (3 heap areas, 2 nonheap areas)
+        String multiSeriesResponse = Files.readString(
+                Path.of("src/test/resources/metrics/jvm_memory_used.json"));
+        moduleDispatcher.setCustomResponse(multiSeriesResponse);
+        List<String> metricNames = List.of("jvm_memory_used_bytes");
+
+        // When
+        Map<String, List<PrometheusClient.TimeSeries>> result = prometheusClient.queryRange(
+                metricNames, START_TIME, END_TIME, STEP);
+
+        // Then - ALL series must be returned, not only the first one
+        List<PrometheusClient.TimeSeries> allSeries = result.get("jvm_memory_used_bytes");
+        assertEquals(5, allSeries.size(), "All 5 series of the multi-label metric must be returned");
+
+        long heapSeries = allSeries.stream()
+                .filter(series -> "heap".equals(series.labels().get("area")))
+                .count();
+        long nonHeapSeries = allSeries.stream()
+                .filter(series -> "nonheap".equals(series.labels().get("area")))
+                .count();
+        assertEquals(3, heapSeries, "All heap series must be present");
+        assertEquals(2, nonHeapSeries, "All nonheap series must be present");
+
+        // Each series carries its own label set and data points
+        for (PrometheusClient.TimeSeries series : allSeries) {
+            assertEquals("jvm_memory_used_bytes", series.metricName());
+            assertTrue(series.labels().containsKey("id"), "Each series keeps its own labels");
+            assertFalse(series.values().isEmpty(), "Each series keeps its own data points");
+        }
     }
 
     @Test

--- a/benchmarking/benchmarking-common/src/test/java/de/cuioss/benchmarking/common/report/BenchmarkMetricsTest.java
+++ b/benchmarking/benchmarking-common/src/test/java/de/cuioss/benchmarking/common/report/BenchmarkMetricsTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.benchmarking.common.report;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link BenchmarkMetrics} validation.
+ */
+class BenchmarkMetricsTest {
+
+    @Test
+    void shouldAcceptPositiveValues() {
+        BenchmarkMetrics metrics = new BenchmarkMetrics("thrpt", "lat", 1000.0, 1.5, 55, "C");
+        assertEquals(1000.0, metrics.throughput());
+        assertEquals(1.5, metrics.latency());
+    }
+
+    @Test
+    void shouldAcceptZeroThroughputAndLatencyForDegradedRuns() {
+        // Failed/empty runs must produce an F-grade report instead of crashing
+        BenchmarkMetrics metrics = assertDoesNotThrow(
+                () -> new BenchmarkMetrics("N/A", "N/A", 0.0, 0.0, 0, "F"));
+        assertEquals("F", metrics.performanceGrade());
+        assertEquals(0.0, metrics.throughput());
+        assertEquals(0.0, metrics.latency());
+    }
+
+    @Test
+    void shouldRejectNegativeValues() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new BenchmarkMetrics("a", "b", -1.0, 1.0, 0, "F"));
+        assertThrows(IllegalArgumentException.class,
+                () -> new BenchmarkMetrics("a", "b", 1.0, -1.0, 0, "F"));
+        assertThrows(IllegalArgumentException.class,
+                () -> new BenchmarkMetrics("a", "b", 1.0, 1.0, -1, "F"));
+    }
+
+    @Test
+    void shouldRejectMissingNames() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new BenchmarkMetrics(null, "b", 1.0, 1.0, 0, "F"));
+        assertThrows(IllegalArgumentException.class,
+                () -> new BenchmarkMetrics("a", " ", 1.0, 1.0, 0, "F"));
+    }
+}

--- a/benchmarking/benchmarking-common/src/test/java/de/cuioss/benchmarking/common/report/MetricConversionUtilTest.java
+++ b/benchmarking/benchmarking-common/src/test/java/de/cuioss/benchmarking/common/report/MetricConversionUtilTest.java
@@ -18,7 +18,6 @@ package de.cuioss.benchmarking.common.report;
 import org.junit.jupiter.api.Test;
 
 import static de.cuioss.benchmarking.common.constants.BenchmarkConstants.Metrics.Units.*;
-import static de.cuioss.benchmarking.common.constants.BenchmarkConstants.Report.Grades.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -123,20 +122,6 @@ class MetricConversionUtilTest {
                 "Average latency should be less than 0.4 ms, got: " + averageLatencyMs);
         assertTrue(averageLatencyMs > 0.3,
                 "Average latency should be more than 0.3 ms, got: " + averageLatencyMs);
-    }
-
-    @Test
-    void performanceGrade() {
-        assertEquals(A_PLUS, MetricConversionUtil.calculatePerformanceGrade(1_000_000),
-                "1M ops/s = A+");
-        assertEquals(A, MetricConversionUtil.calculatePerformanceGrade(100_000),
-                "100K ops/s = A");
-        assertEquals(B, MetricConversionUtil.calculatePerformanceGrade(10_000),
-                "10K ops/s = B");
-        assertEquals(C, MetricConversionUtil.calculatePerformanceGrade(1_000),
-                "1K ops/s = C");
-        assertEquals(D, MetricConversionUtil.calculatePerformanceGrade(100),
-                "100 ops/s = D");
     }
 
     @Test

--- a/benchmarking/benchmarking-common/src/test/java/de/cuioss/benchmarking/common/report/ReportDataGeneratorTest.java
+++ b/benchmarking/benchmarking-common/src/test/java/de/cuioss/benchmarking/common/report/ReportDataGeneratorTest.java
@@ -15,9 +15,13 @@
  */
 package de.cuioss.benchmarking.common.report;
 
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import de.cuioss.benchmarking.common.config.BenchmarkType;
 import de.cuioss.benchmarking.common.model.BenchmarkData;
 import de.cuioss.benchmarking.common.util.JsonSerializationHelper;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -108,5 +112,76 @@ class ReportDataGeneratorTest {
         List<Double> p50Values = datasets.get("50.0th");
         assertNotNull(p50Values, "P50 values should exist");
         assertFalse(p50Values.isEmpty(), "Should have at least one percentile value");
+    }
+
+    @Test
+    void nullOverviewProducesFGradeReportWithoutException(@TempDir Path tempDir) throws Exception {
+        // Failed runs (null/empty overview, no benchmarks) must produce a degraded
+        // F-grade report instead of crashing report generation (H-6)
+        BenchmarkData degraded = BenchmarkData.builder()
+                .metadata(null)
+                .overview(null)
+                .benchmarks(List.of())
+                .build();
+
+        ReportDataGenerator generator = new ReportDataGenerator();
+        assertDoesNotThrow(() ->
+                generator.generateDataFile(degraded, BenchmarkType.INTEGRATION, tempDir.toString()));
+
+        Path dataFile = tempDir.resolve("data/benchmark-data.json");
+        assertTrue(Files.exists(dataFile), "Degraded report data file must be written");
+
+        JsonObject json = JsonParser.parseString(Files.readString(dataFile)).getAsJsonObject();
+        JsonObject overview = json.getAsJsonObject("overview");
+        assertEquals("F", overview.get("performanceGrade").getAsString(),
+                "Degraded report must carry an F grade");
+        assertEquals(0, overview.get("performanceScore").getAsInt());
+        assertEquals("N/A", overview.get("throughput").getAsString());
+        assertEquals("N/A", overview.get("latency").getAsString());
+    }
+
+    @Test
+    void missingPercentileKeysAreTolerated() throws Exception {
+        // WRK reports only measured percentiles (e.g. 50/75/90/99); the chart data must
+        // tolerate missing standard keys instead of requiring fabricated values (H-5)
+        BenchmarkData.Benchmark benchmark = BenchmarkData.Benchmark.builder()
+                .name("jwtValidation")
+                .fullName("wrk.jwtValidation")
+                .mode("thrpt")
+                .rawScore(10000.0)
+                .score("10.0K ops/s")
+                .scoreUnit("ops/s")
+                .percentiles(Map.of(
+                        "50.0", 1.5,
+                        "75.0", 2.0,
+                        "90.0", 3.5,
+                        "99.0", 9.0))
+                .build();
+
+        ReportDataGenerator generator = new ReportDataGenerator();
+        java.lang.reflect.Method createChartDataMethod = ReportDataGenerator.class.getDeclaredMethod(
+                "createChartData", List.class);
+        createChartDataMethod.setAccessible(true);
+
+        @SuppressWarnings("unchecked") Map<String, Object> chartData =
+                (Map<String, Object>) assertDoesNotThrow(() ->
+                        createChartDataMethod.invoke(generator, List.of(benchmark)));
+
+        @SuppressWarnings("unchecked") Map<String, Object> percentilesData =
+                (Map<String, Object>) chartData.get("percentilesData");
+        @SuppressWarnings("unchecked") Map<String, List<Double>> dataByBenchmark =
+                (Map<String, List<Double>>) percentilesData.get("data");
+
+        List<Double> values = dataByBenchmark.get("jwtValidation");
+        assertNotNull(values, "Benchmark with P50 must be included in percentile chart data");
+
+        // Keys: 0.0, 50.0, 90.0, 95.0, 99.0, 99.9, 99.99, 100.0
+        assertNull(values.getFirst(), "Unmeasured P0 must be null, not fabricated");
+        assertEquals(1.5, values.get(1), "Measured P50 must be present");
+        assertEquals(3.5, values.get(2), "Measured P90 must be present");
+        assertNull(values.get(3), "Unmeasured P95 must be null, not fabricated");
+        assertEquals(9.0, values.get(4), "Measured P99 must be present");
+        assertNull(values.get(5), "Unmeasured P99.9 must be null, not fabricated");
+        assertNull(values.get(7), "Unmeasured P100 must be null, not fabricated");
     }
 }


### PR DESCRIPTION
## Summary

Fixes the benchmarking result-integrity findings from `doc/code-findings.adoc` (#526):

- **H-4** — JFR event metadata (payload size, success/error labels, issuer) now describes the token actually validated; previously ~50% of Mixed-benchmark events were mislabeled because a second, independently randomized token was validated.
- **H-5** — No fabricated percentiles: the normal-distribution estimator is gone; reports contain only measured wrk percentiles, and the overview falls back to the wrk-reported average latency when P50 is absent.
- **H-6** — Failed runs now produce the intended F-grade report instead of crashing: `BenchmarkMetrics` accepts zero (still rejects negative), covered by an end-to-end null-overview report test.
- **H-7** — Performance score/grade computed in exactly one place (`MetricsComputer`), with the micro (JMH) and integration (wrk) formulas preserved numerically; the dead fourth grading scheme is deleted.
- **M-21** — The "expired token" benchmark now measures the expiry path (real issuer RSA key, past `exp`) instead of unknown-issuer rejection; error benchmarks throw if a known-bad token unexpectedly validates.
- **M-22** — Prometheus parsing keeps all series per metric; heap memory selects the `area="heap"` series and JWT counters aggregate across series instead of reading an arbitrary first series.
- **M-23** — Unparseable wrk output fails the run (non-zero exit) instead of publishing zero-metrics reports; input validation happens before metadata parsing.
- **M-29** — Fork command lines forward an explicit property-prefix allowlist instead of every system property; secret-bearing keys emit a structured WARN (`Benchmarking-126`).
- **M-32** — The concurrency sweep honors the pom's `jmh.*` properties instead of silently ignoring them.

## Tests

`./mvnw -Ppre-commit clean verify` green on `benchmarking-common` (195 tests), `benchmark-core` (3), `benchmark-integration-wrk` (12), including new tests for the F-grade path, missing percentiles, multi-series Prometheus parsing, and fail-fast wrk parsing. `doc/LogMessages.adoc` updated for the new LogRecord.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012RwRgQHDskAEsKYkgKanH3

---
_Generated by [Claude Code](https://claude.ai/code/session_012RwRgQHDskAEsKYkgKanH3)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Benchmarks can now pick fork, warmup, measurement, and timing settings from system properties.
  * Metrics reporting now handles multiple data series per metric, improving Prometheus-based results.
  * WRK results and benchmark summaries now better reflect degraded or partial runs.

* **Bug Fixes**
  * Fixed benchmark scoring to allow zero values while still rejecting negatives.
  * Improved WRK processing to fail fast when input is missing or unparseable, instead of publishing zeroed reports.
  * Added safer JVM property forwarding with warnings for sensitive values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->