### PR TITLE
fix(validation): harden token domain model (M-3..M-7)

### DIFF
--- a/doc/LogMessages.adoc
+++ b/doc/LogMessages.adoc
@@ -63,7 +63,7 @@ For more details about security events related to these log messages, see the Se
 |TokenSheriff-104 |TOKEN |Invalid JWT Token format: expected 3 parts (JWS) or 5 parts (JWE) but got %s |Logged when the JWT token format is invalid
 |TokenSheriff-105 |TOKEN |Decoded part exceeds maximum size limit of %s bytes |Logged when a decoded part of the token exceeds the maximum size limit
 |TokenSheriff-106 |TOKEN |Unsupported algorithm: %s |Logged when an unsupported algorithm is encountered
-|TokenSheriff-107 |TOKEN |Token has a 'not before' claim that is more than 60 seconds in the future |Logged when a token has a 'not before' claim that is too far in the future
+|TokenSheriff-107 |TOKEN |Token has a 'not before' claim that is more than %s seconds in the future |Logged when a token has a 'not before' claim that is further in the future than the configured clock skew tolerance
 |TokenSheriff-108 |TOKEN |Unknown token type: %s |Logged when an unknown token type is encountered
 |TokenSheriff-109 |TOKEN |Token is missing required claim: %s |Logged when a token is missing a required claim
 |TokenSheriff-110 |TOKEN |Token has expired |Logged when a token has expired

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/IssuerConfig.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/IssuerConfig.java
@@ -362,8 +362,9 @@ public class IssuerConfig implements LoadingStatusProvider {
      *   <li>Delegates to the underlying {@link JwksLoader#getLoaderStatus()} method</li>
      * </ol>
      * <p>
-     * For HTTP-based loaders, this may trigger lazy loading of JWKS content if not already loaded.
-     * The method is designed to be fail-fast and thread-safe.
+     * This is a non-blocking status read: it never triggers loading of JWKS content itself,
+     * it only reports the loader's current state. The method is designed to be fail-fast
+     * and thread-safe.
      * <p>
      * The status reflects the combined state of configuration and runtime health:
      * <ul>

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/JWTValidationLogMessages.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/JWTValidationLogMessages.java
@@ -207,7 +207,7 @@ public final class JWTValidationLogMessages {
         public static final LogRecord TOKEN_NBF_FUTURE = LogRecordModel.builder()
                 .prefix(PREFIX)
                 .identifier(107)
-                .template("Token has a 'not before' claim that is more than 60 seconds in the future")
+                .template("Token has a 'not before' claim that is more than %s seconds in the future")
                 .build();
 
         public static final LogRecord UNKNOWN_TOKEN_TYPE = LogRecordModel.builder()

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/TokenType.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/TokenType.java
@@ -59,9 +59,9 @@ public enum TokenType {
     /**
      * Constructor for TokenType.
      *
-     * @param mandatoryClaims the mandatory claims
+     * @param mandatoryClaims the mandatory claims, stored as an unmodifiable view
      */
     TokenType(SortedSet<ClaimName> mandatoryClaims) {
-        this.mandatoryClaims = mandatoryClaims;
+        this.mandatoryClaims = Collections.unmodifiableSortedSet(mandatoryClaims);
     }
 }

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/TokenValidator.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/TokenValidator.java
@@ -119,8 +119,9 @@ import java.util.Map;
  *
  * // Access the performance monitor for detailed pipeline metrics
  * TokenValidatorMonitor performanceMonitor = tokenValidator.getPerformanceMonitor();
- * StripedRingBufferStatistics metrics = performanceMonitor.getValidationMetrics(MeasurementType.SIGNATURE_VALIDATION);
- * Duration p50SignatureTime = metrics.p50();
+ * Optional&lt;StripedRingBufferStatistics&gt; metrics =
+ *         performanceMonitor.getValidationMetrics(MeasurementType.SIGNATURE_VALIDATION);
+ * Optional&lt;Duration&gt; p50SignatureTime = metrics.map(StripedRingBufferStatistics::p50);
  * </pre>
  * <p>
  * Implements requirements:

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/cache/AccessTokenCache.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/cache/AccessTokenCache.java
@@ -23,11 +23,10 @@ import de.cuioss.sheriff.token.validation.metrics.MetricsTicker;
 import de.cuioss.sheriff.token.validation.metrics.MetricsTickerFactory;
 import de.cuioss.sheriff.token.validation.metrics.TokenValidatorMonitor;
 import de.cuioss.sheriff.token.validation.security.SecurityEventCounter;
+import de.cuioss.sheriff.token.validation.util.Sha256Util;
 import de.cuioss.tools.logging.CuiLogger;
 
 import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.time.OffsetDateTime;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -339,14 +338,8 @@ public class AccessTokenCache {
      * @return hex-encoded SHA-256 digest
      */
     private static String sha256Hex(String tokenString) {
-        try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            byte[] hash = digest.digest(tokenString.getBytes(StandardCharsets.UTF_8));
-            return HexFormat.of().formatHex(hash);
-        } catch (NoSuchAlgorithmException e) {
-            // SHA-256 is required by the Java specification; this should never happen
-            throw new IllegalStateException("SHA-256 algorithm not available", e);
-        }
+        byte[] hash = Sha256Util.digest(tokenString.getBytes(StandardCharsets.UTF_8));
+        return HexFormat.of().formatHex(hash);
     }
 
     /**

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/cache/CachedToken.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/cache/CachedToken.java
@@ -15,6 +15,7 @@
  */
 package de.cuioss.sheriff.token.validation.cache;
 
+import de.cuioss.sheriff.token.validation.domain.context.ValidationContext;
 import de.cuioss.sheriff.token.validation.domain.token.AccessTokenContent;
 import lombok.Builder;
 import lombok.Getter;
@@ -69,7 +70,7 @@ public final class CachedToken {
      * @return true if the token has expired even with clock skew tolerance, false otherwise
      */
     public boolean isExpired(OffsetDateTime currentTime, int clockSkewSeconds) {
-        return expirationTime.plusSeconds(clockSkewSeconds).isBefore(currentTime);
+        return ValidationContext.isExpired(expirationTime, clockSkewSeconds, currentTime);
     }
 
     /**

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/cache/package-info.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/cache/package-info.java
@@ -23,7 +23,7 @@
  * Key features:
  * <ul>
  *   <li>Thread-safe caching with configurable size limits</li>
- *   <li>LRU eviction policy for size management</li>
+ *   <li>Size-based eviction (arbitrary iteration order) for size management</li>
  *   <li>Automatic expiration checking and background cleanup</li>
  *   <li>Security event tracking for cache effectiveness monitoring</li>
  *   <li>No external dependencies (Quarkus compatible)</li>

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/domain/claim/mapper/JsonCollectionMapper.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/domain/claim/mapper/JsonCollectionMapper.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * A {@link ClaimMapper} implementation for mapping JSON values to collections.
@@ -50,14 +49,13 @@ public class JsonCollectionMapper implements ClaimMapper {
         List<String> values;
 
         if (value instanceof List<?> list) {
-            // Handle List (array) - create JSON array representation
-            originalValue = list.stream()
-                    .map(Object::toString)
-                    .map(s -> "\"" + s + "\"")
-                    .collect(Collectors.joining(",", "[", "]"));
+            // Handle List (array): convert elements once, use the list's toString() as
+            // original value (consistent with the Keycloak mappers). No attempt is made to
+            // reconstruct the exact JSON source representation.
             values = list.stream()
                     .map(Object::toString)
                     .toList();
+            originalValue = values.toString();
         } else {
             // Handle all other types by wrapping them in a single-element list
             originalValue = value.toString();

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/domain/claim/mapper/JsonCollectionMapper.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/domain/claim/mapper/JsonCollectionMapper.java
@@ -22,6 +22,7 @@ import de.cuioss.sheriff.token.validation.json.MapRepresentation;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -53,6 +54,7 @@ public class JsonCollectionMapper implements ClaimMapper {
             // original value (consistent with the Keycloak mappers). No attempt is made to
             // reconstruct the exact JSON source representation.
             values = list.stream()
+                    .filter(Objects::nonNull)
                     .map(Object::toString)
                     .toList();
             originalValue = values.toString();

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/domain/claim/mapper/KeycloakDefaultGroupsMapper.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/domain/claim/mapper/KeycloakDefaultGroupsMapper.java
@@ -19,7 +19,6 @@ import de.cuioss.sheriff.token.validation.domain.claim.ClaimValue;
 import de.cuioss.sheriff.token.validation.json.MapRepresentation;
 import de.cuioss.tools.logging.CuiLogger;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -45,9 +44,9 @@ import java.util.Optional;
  * <p>
  * The mapper handles:
  * <ul>
- *   <li>Missing {@code groups} claim - returns empty list</li>
- *   <li>Empty groups array - returns empty list</li>
- *   <li>Non-array groups value - returns empty list</li>
+ *   <li>Missing {@code groups} claim - returns {@code null} (claim treated as absent)</li>
+ *   <li>Non-array {@code groups} value - returns {@code null} (claim treated as absent)</li>
+ *   <li>Empty groups array - returns claim value with empty list</li>
  *   <li>Group names with or without path prefixes</li>
  * </ul>
  *
@@ -71,9 +70,8 @@ public class KeycloakDefaultGroupsMapper implements ClaimMapper {
         }
 
         List<String> groupsList = groupsValue.get();
-        String originalValue = groupsList.toString();
 
         LOGGER.debug("Successfully mapped groups: %s", groupsList);
-        return ClaimValue.forList(originalValue, Collections.unmodifiableList(groupsList));
+        return KeycloakMapperSupport.toListClaimValue(groupsList);
     }
 }

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/domain/claim/mapper/KeycloakDefaultRolesMapper.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/domain/claim/mapper/KeycloakDefaultRolesMapper.java
@@ -19,7 +19,6 @@ import de.cuioss.sheriff.token.validation.domain.claim.ClaimValue;
 import de.cuioss.sheriff.token.validation.json.MapRepresentation;
 import de.cuioss.tools.logging.CuiLogger;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -47,10 +46,10 @@ import java.util.Optional;
  * <p>
  * The mapper handles:
  * <ul>
- *   <li>Missing {@code realm_access} object - returns empty list</li>
- *   <li>Missing {@code roles} array within {@code realm_access} - returns empty list</li>
- *   <li>Empty roles array - returns empty list</li>
- *   <li>Non-array roles value - returns empty list</li>
+ *   <li>Missing {@code realm_access} object - returns {@code null} (claim treated as absent)</li>
+ *   <li>Missing {@code roles} array within {@code realm_access} - returns {@code null} (claim treated as absent)</li>
+ *   <li>Non-array {@code roles} value - returns {@code null} (claim treated as absent)</li>
+ *   <li>Empty roles array - returns claim value with empty list</li>
  * </ul>
  *
  * @since 1.0
@@ -83,9 +82,8 @@ public class KeycloakDefaultRolesMapper implements ClaimMapper {
         }
 
         List<String> rolesList = rolesValue.get();
-        String originalValue = rolesList.toString();
 
         LOGGER.debug("Successfully mapped roles: %s", rolesList);
-        return ClaimValue.forList(originalValue, Collections.unmodifiableList(rolesList));
+        return KeycloakMapperSupport.toListClaimValue(rolesList);
     }
 }

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/domain/claim/mapper/KeycloakMapperSupport.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/domain/claim/mapper/KeycloakMapperSupport.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.token.validation.domain.claim.mapper;
+
+import de.cuioss.sheriff.token.validation.domain.claim.ClaimValue;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Package-private support methods shared by the Keycloak default mappers
+ * ({@link KeycloakDefaultRolesMapper}, {@link KeycloakDefaultGroupsMapper}).
+ *
+ * @since 1.0
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+final class KeycloakMapperSupport {
+
+    /**
+     * Converts an extracted string list into a list-typed {@link ClaimValue}.
+     * <p>
+     * The list's {@code toString()} representation is used as the original string and the
+     * list itself is wrapped unmodifiable.
+     *
+     * @param values the extracted string values, must not be {@code null}
+     * @return a list-typed claim value wrapping the given values
+     */
+    static ClaimValue toListClaimValue(List<String> values) {
+        return ClaimValue.forList(values.toString(), Collections.unmodifiableList(values));
+    }
+}

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/domain/claim/mapper/StringSplitterMapper.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/domain/claim/mapper/StringSplitterMapper.java
@@ -21,6 +21,7 @@ import de.cuioss.tools.string.Splitter;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -55,8 +56,14 @@ public class StringSplitterMapper implements ClaimMapper {
    
     private final Character splitChar;
 
+    /**
+     * Creates a new mapper splitting on the given character.
+     *
+     * @param splitChar the character to split by, must not be {@code null}
+     * @throws NullPointerException if splitChar is {@code null}
+     */
     public StringSplitterMapper(Character splitChar) {
-        this.splitChar = splitChar;
+        this.splitChar = Objects.requireNonNull(splitChar, "splitChar must not be null");
     }
 
     @Override

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/domain/context/ValidationContext.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/domain/context/ValidationContext.java
@@ -69,7 +69,11 @@ public class ValidationContext {
     private final Integer maxTokenAgeSeconds;
 
     /**
-     * Creates a new ValidationContext with token age validation.
+     * Creates a new ValidationContext, capturing the current time via {@link OffsetDateTime#now()}.
+     * <p>
+     * Convenience constructor for callers that do not already hold a timestamp. Prefer the
+     * three-argument constructor when a consistent timestamp is already available (as the
+     * validation pipelines do), so that all steps of an operation share the same time.
      *
      * @param clockSkewSeconds the clock skew tolerance in seconds
      * @param maxTokenAgeSeconds the maximum token age in seconds, or null to disable
@@ -84,7 +88,12 @@ public class ValidationContext {
     }
 
     /**
-     * Creates a new ValidationContext with all parameters for testing purposes.
+     * Creates a new ValidationContext with an explicitly provided current time.
+     * <p>
+     * This is the primary constructor used by the validation pipelines: they capture the
+     * current time once at the start of validation and pass it in, so cache checks and all
+     * validation steps operate on a single consistent timestamp. It is equally useful in
+     * tests to validate against a fixed point in time.
      *
      * @param currentTime the current time to use for validation
      * @param clockSkewSeconds the clock skew tolerance in seconds
@@ -121,7 +130,23 @@ public class ValidationContext {
      * @return true if the token is expired (even accounting for clock skew), false otherwise
      */
     public boolean isExpired(OffsetDateTime expirationTime) {
-        return expirationTime.plusSeconds(clockSkewSeconds).isBefore(currentTime);
+        return isExpired(expirationTime, clockSkewSeconds, currentTime);
+    }
+
+    /**
+     * Shared expiry predicate: checks whether an expiration time (extended by the clock skew
+     * tolerance) lies before the given reference time.
+     * <p>
+     * Centralizes the expiry semantics used by both the validation pipeline and the access
+     * token cache, ensuring both apply clock skew identically.
+     *
+     * @param expirationTime the token's expiration time
+     * @param clockSkewSeconds the clock skew tolerance in seconds
+     * @param now the reference time to check against
+     * @return true if the token is expired (even accounting for clock skew), false otherwise
+     */
+    public static boolean isExpired(OffsetDateTime expirationTime, int clockSkewSeconds, OffsetDateTime now) {
+        return expirationTime.plusSeconds(clockSkewSeconds).isBefore(now);
     }
 
     /**

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/domain/token/BaseTokenContent.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/domain/token/BaseTokenContent.java
@@ -36,8 +36,10 @@ import java.util.Map;
  *   <li>{@link UnvalidatedRefreshToken} - For OAuth2 refresh tokens</li>
  * </ul>
  * <p>
- * The class is immutable and thread-safe, implementing equality and string representation
- * via Lombok's {@code @EqualsAndHashCode} and {@code @ToString}.
+ * The class is immutable and thread-safe: the claims map is defensively copied into an
+ * unmodifiable map in the constructor, so callers can neither mutate the stored claims
+ * through the constructor argument nor through {@link #getClaims()}. Equality and string
+ * representation are implemented via Lombok's {@code @EqualsAndHashCode} and {@code @ToString}.
  * <p>
  * For more details on token structure, see the
  * <a href="https://github.com/cuioss/TokenSheriff/tree/main/doc/validation/architecture.adoc#token-structure">Token Structure</a>
@@ -66,6 +68,10 @@ public abstract sealed class BaseTokenContent implements TokenContent
 
     /**
      * Constructor for BaseTokenContent.
+     * <p>
+     * The given claims map is defensively copied into an unmodifiable map, guaranteeing
+     * immutability even when the token content is shared across threads (e.g. via the
+     * access token cache). The map must not contain {@code null} keys or values.
      *
      * @param claims    the token claims
      * @param rawToken  the raw token string
@@ -73,7 +79,7 @@ public abstract sealed class BaseTokenContent implements TokenContent
      */
     protected BaseTokenContent(Map<String, ClaimValue> claims, String rawToken,
             TokenType tokenType) {
-        this.claims = claims;
+        this.claims = Map.copyOf(claims);
         this.rawToken = rawToken;
         this.tokenType = tokenType;
     }

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/domain/token/UnvalidatedRefreshToken.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/domain/token/UnvalidatedRefreshToken.java
@@ -60,13 +60,24 @@ public final class UnvalidatedRefreshToken implements MinimalTokenContent {
     private static final long serialVersionUID = 1L;
 
     @Getter
+    @ToString.Exclude
     private final String rawToken;
 
+    @ToString.Exclude
     private final Map<String, ClaimValue> claims;
 
+    /**
+     * Creates a new UnvalidatedRefreshToken.
+     * <p>
+     * The given claims map is defensively copied into an unmodifiable map. It must not
+     * contain {@code null} keys or values.
+     *
+     * @param rawToken the raw refresh token string
+     * @param claims   the (unvalidated) claims extracted from the token, may be empty
+     */
     public UnvalidatedRefreshToken(String rawToken, Map<String, ClaimValue> claims) {
         this.rawToken = rawToken;
-        this.claims = claims;
+        this.claims = Map.copyOf(claims);
     }
 
     /**
@@ -75,9 +86,9 @@ public final class UnvalidatedRefreshToken implements MinimalTokenContent {
      * When the identity provider returns a JWT-formatted refresh token, this provides
      * access to the raw claims. These claims are <em>not</em> validated in any way.
      * <p>
-     * Never {@code null}, but may be empty.
+     * Never {@code null}, but may be empty. The returned map is unmodifiable.
      *
-     * @return unvalidated claims map (package-private access)
+     * @return unmodifiable map of unvalidated claims
      */
     public Map<String, ClaimValue> getClaims() {
         return claims;

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/json/JwtHeader.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/json/JwtHeader.java
@@ -81,38 +81,38 @@ String apv
 
     /**
      * Gets the algorithm parameter as Optional.
-     * 
-     * @return Optional containing the algorithm, empty if null or empty
+     *
+     * @return Optional containing the algorithm, empty if null or blank
      */
     public Optional<String> getAlg() {
-        return Optional.ofNullable(alg).filter(s -> !s.trim().isEmpty());
+        return nonBlank(alg);
     }
 
     /**
      * Gets the type parameter as Optional.
-     * 
-     * @return Optional containing the type, empty if null
+     *
+     * @return Optional containing the type, empty if null or blank
      */
     public Optional<String> getTyp() {
-        return Optional.ofNullable(typ);
+        return nonBlank(typ);
     }
 
     /**
      * Gets the key ID parameter as Optional.
-     * 
-     * @return Optional containing the key ID, empty if null
+     *
+     * @return Optional containing the key ID, empty if null or blank
      */
     public Optional<String> getKid() {
-        return Optional.ofNullable(kid);
+        return nonBlank(kid);
     }
 
     /**
      * Gets the JSON Web Key parameter as Optional.
-     * 
-     * @return Optional containing the JWK, empty if null
+     *
+     * @return Optional containing the JWK, empty if null or blank
      */
     public Optional<String> getJwk() {
-        return Optional.ofNullable(jwk);
+        return nonBlank(jwk);
     }
 
     /**
@@ -121,43 +121,43 @@ String apv
      * @return Optional containing the encryption algorithm, empty if null or blank
      */
     public Optional<String> getEnc() {
-        return Optional.ofNullable(enc).filter(s -> !s.isBlank());
+        return nonBlank(enc);
     }
 
     /**
      * Gets the compression algorithm parameter as Optional (JWE only).
      *
-     * @return Optional containing the compression algorithm, empty if null
+     * @return Optional containing the compression algorithm, empty if null or blank
      */
     public Optional<String> getZip() {
-        return Optional.ofNullable(zip);
+        return nonBlank(zip);
     }
 
     /**
      * Gets the ephemeral public key parameter as Optional (JWE ECDH-ES only).
      *
-     * @return Optional containing the ephemeral public key JSON, empty if null
+     * @return Optional containing the ephemeral public key JSON, empty if null or blank
      */
     public Optional<String> getEpk() {
-        return Optional.ofNullable(epk);
+        return nonBlank(epk);
     }
 
     /**
      * Gets the Agreement PartyUInfo parameter as Optional (JWE ECDH-ES only).
      *
-     * @return Optional containing the apu value, empty if null
+     * @return Optional containing the apu value, empty if null or blank
      */
     public Optional<String> getApu() {
-        return Optional.ofNullable(apu);
+        return nonBlank(apu);
     }
 
     /**
      * Gets the Agreement PartyVInfo parameter as Optional (JWE ECDH-ES only).
      *
-     * @return Optional containing the apv value, empty if null
+     * @return Optional containing the apv value, empty if null or blank
      */
     public Optional<String> getApv() {
-        return Optional.ofNullable(apv);
+        return nonBlank(apv);
     }
 
     /**
@@ -169,6 +169,16 @@ String apv
      * @return {@code true} if this is a JWE header, {@code false} if JWS
      */
     public boolean isJwe() {
-        return enc != null && !enc.isBlank();
+        return getEnc().isPresent();
+    }
+
+    /**
+     * Wraps a header parameter in an Optional, treating null and blank values as absent.
+     *
+     * @param value the raw header parameter value
+     * @return Optional containing the value, empty if null or blank
+     */
+    private static Optional<String> nonBlank(String value) {
+        return Optional.ofNullable(value).filter(s -> !s.isBlank());
     }
 }

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/json/MapRepresentation.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/json/MapRepresentation.java
@@ -21,8 +21,10 @@ import de.cuioss.tools.string.MoreStrings;
 import java.io.IOException;
 import java.io.Serial;
 import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -55,10 +57,12 @@ public record MapRepresentation(Map<String, Object> data) implements Serializabl
     private static final long serialVersionUID = 1L;
 
     /**
-     * Compact constructor that guarantees data is never null.
+     * Compact constructor that rejects null data.
+     * <p>
+     * Callers that want an empty representation should pass {@link Map#of()}.
      */
     public MapRepresentation {
-        data = data != null ? data : Map.of();
+        Objects.requireNonNull(data, "data must not be null");
     }
 
     /**
@@ -74,7 +78,7 @@ public record MapRepresentation(Map<String, Object> data) implements Serializabl
      * @throws IOException if the JSON content cannot be parsed
      */
     public static MapRepresentation fromJson(DslJson<Object> dslJson, String jsonContent) throws IOException {
-        return fromJson(dslJson, MoreStrings.nullToEmpty(jsonContent).getBytes());
+        return fromJson(dslJson, MoreStrings.nullToEmpty(jsonContent).getBytes(StandardCharsets.UTF_8));
     }
 
     /**
@@ -202,6 +206,10 @@ public record MapRepresentation(Map<String, Object> data) implements Serializabl
 
     /**
      * Gets a string list from an array claim.
+     * <p>
+     * Non-String elements of the array are silently dropped: the returned list contains
+     * only the elements that are actual JSON strings, which may therefore be shorter than
+     * the source array (or empty).
      *
      * @param key the key to look up
      * @return Optional containing the string list, or empty if not found or not convertible

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/metrics/TokenValidatorMonitor.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/metrics/TokenValidatorMonitor.java
@@ -46,8 +46,8 @@ import java.util.concurrent.TimeUnit;
  * <p>
  * <strong>Usage Example:</strong>
  * <pre>
- * // Create monitor with default window size (100 samples)
- * TokenValidatorMonitor monitor = new TokenValidatorMonitor();
+ * // Create monitor via its configuration (default window size, all measurement types)
+ * TokenValidatorMonitor monitor = TokenValidatorMonitorConfig.defaultEnabled().createMonitor();
  *
  * // Record a measurement
  * long startNanos = System.nanoTime();

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/pipeline/NonValidatingJwtParser.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/pipeline/NonValidatingJwtParser.java
@@ -462,10 +462,9 @@ public class NonValidatingJwtParser {
      * @throws IOException if decoding fails
      */
     private JwtHeader decodeJwtHeader(String encodedHeader) throws IOException {
-        String decodedJson = decodeBase64UrlPart(encodedHeader);
+        byte[] jsonBytes = decodeBase64UrlPart(encodedHeader);
         DslJson<Object> dslJson = config.getDslJson();
 
-        byte[] jsonBytes = decodedJson.getBytes();
         JwtHeader header = dslJson.deserialize(JwtHeader.class, jsonBytes, jsonBytes.length);
 
         if (header == null) {
@@ -486,19 +485,23 @@ public class NonValidatingJwtParser {
      * @throws IOException if decoding fails
      */
     private MapRepresentation decodePayload(String encodedPayload) throws IOException {
-        String decodedJson = decodeBase64UrlPart(encodedPayload);
+        byte[] jsonBytes = decodeBase64UrlPart(encodedPayload);
         DslJson<Object> dslJson = config.getDslJson();
 
-        return MapRepresentation.fromJson(dslJson, decodedJson);
+        return MapRepresentation.fromJson(dslJson, jsonBytes);
     }
 
     /**
-     * Decodes a Base64Url encoded part to JSON string.
+     * Decodes a Base64Url encoded part to its raw (UTF-8 encoded JSON) bytes.
+     * <p>
+     * Returning the raw bytes avoids a lossy byte-to-String-to-byte round trip and
+     * guarantees that no platform-default charset is involved (JWT JSON is always UTF-8
+     * per RFC 7515).
      *
      * @param encodedPart the Base64Url encoded part
-     * @return the decoded JSON string
+     * @return the decoded JSON bytes
      */
-    private String decodeBase64UrlPart(String encodedPart) {
+    private byte[] decodeBase64UrlPart(String encodedPart) {
         try {
             byte[] decodedBytes = Base64.getUrlDecoder().decode(encodedPart);
 
@@ -512,7 +515,7 @@ public class NonValidatingJwtParser {
                 );
             }
 
-            return new String(decodedBytes, StandardCharsets.UTF_8);
+            return decodedBytes;
         } catch (IllegalArgumentException e) {
             throw new TokenValidationException(
                     SecurityEventCounter.EventType.FAILED_TO_DECODE_JWT,

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/pipeline/TokenBuilder.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/pipeline/TokenBuilder.java
@@ -21,7 +21,9 @@ import de.cuioss.sheriff.token.validation.domain.claim.ClaimValue;
 import de.cuioss.sheriff.token.validation.domain.claim.mapper.ClaimMapper;
 import de.cuioss.sheriff.token.validation.domain.token.AccessTokenContent;
 import de.cuioss.sheriff.token.validation.domain.token.IdTokenContent;
+import de.cuioss.sheriff.token.validation.exception.TokenValidationException;
 import de.cuioss.sheriff.token.validation.json.MapRepresentation;
+import de.cuioss.sheriff.token.validation.security.SecurityEventCounter;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -80,6 +82,7 @@ public class TokenBuilder {
      *
      * @param decodedJwt the decoded JWT
      * @return an Optional containing the AccessTokenContent if it could be created, empty otherwise
+     * @throws TokenValidationException if a claim value is malformed and cannot be mapped
      */
     public Optional<AccessTokenContent> createAccessToken(DecodedJwt decodedJwt) {
         MapRepresentation body = decodedJwt.body();
@@ -99,6 +102,7 @@ public class TokenBuilder {
      *
      * @param decodedJwt the decoded JWT
      * @return an Optional containing the IdTokenContent if it could be created, empty otherwise
+     * @throws TokenValidationException if a claim value is malformed and cannot be mapped
      */
     public Optional<IdTokenContent> createIdToken(DecodedJwt decodedJwt) {
         MapRepresentation body = decodedJwt.body();
@@ -126,8 +130,20 @@ public class TokenBuilder {
             ClaimMapper mapper = allMappers.get(key);
 
             if (mapper != null) {
-                // Use the configured mapper (either built-in or custom)
-                ClaimValue claimValue = mapper.map(mapRepresentation, key);
+                // Use the configured mapper (either built-in or custom).
+                // Mappers throw IllegalArgumentException on malformed claim values (e.g. a
+                // string-typed 'exp'). Translate to TokenValidationException to honor the
+                // documented contract of TokenValidator.
+                ClaimValue claimValue;
+                try {
+                    claimValue = mapper.map(mapRepresentation, key);
+                } catch (IllegalArgumentException e) {
+                    throw new TokenValidationException(
+                            SecurityEventCounter.EventType.MISSING_CLAIM,
+                            "Malformed claim '" + key + "': " + e.getMessage(),
+                            e
+                    );
+                }
                 if (claimValue != null) {
                     claims.put(key, claimValue);
                 }

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/pipeline/TokenBuilder.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/pipeline/TokenBuilder.java
@@ -131,13 +131,15 @@ public class TokenBuilder {
 
             if (mapper != null) {
                 // Use the configured mapper (either built-in or custom).
-                // Mappers throw IllegalArgumentException on malformed claim values (e.g. a
-                // string-typed 'exp'). Translate to TokenValidationException to honor the
-                // documented contract of TokenValidator.
+                // Mappers (including custom SPI implementations) can throw arbitrary runtime
+                // exceptions on malformed claim values (e.g. a string-typed 'exp'). Translate
+                // to TokenValidationException to honor the documented contract of TokenValidator.
                 ClaimValue claimValue;
                 try {
                     claimValue = mapper.map(mapRepresentation, key);
-                } catch (IllegalArgumentException e) {
+                } catch (TokenValidationException e) {
+                    throw e;
+                } catch (RuntimeException e) {
                     throw new TokenValidationException(
                             SecurityEventCounter.EventType.MISSING_CLAIM,
                             "Malformed claim '" + key + "': " + e.getMessage(),

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/pipeline/validator/ExpirationValidator.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/pipeline/validator/ExpirationValidator.java
@@ -32,8 +32,10 @@ import lombok.RequiredArgsConstructor;
  *   <li>Not before time (nbf) - tokens must not be used before their valid time</li>
  * </ul>
  * <p>
- * The validator includes a 60-second clock skew tolerance for the not-before validation
- * to account for time differences between token issuer and validator.
+ * The validator applies the per-issuer configurable clock skew tolerance (provided via the
+ * {@link de.cuioss.sheriff.token.validation.domain.context.ValidationContext}) to the
+ * expiration and not-before validation, accounting for time differences between token
+ * issuer and validator.
  *
  * @apiNote This class is internal to Token-Sheriff and not part of the public API.
  * @since 1.0
@@ -98,7 +100,7 @@ public class ExpirationValidator {
         }
 
         if (context.isNotBeforeInvalid(notBefore.get())) {
-            LOGGER.warn(JWTValidationLogMessages.WARN.TOKEN_NBF_FUTURE);
+            LOGGER.warn(JWTValidationLogMessages.WARN.TOKEN_NBF_FUTURE, context.getClockSkewSeconds());
             securityEventCounter.increment(SecurityEventCounter.EventType.TOKEN_NBF_FUTURE);
             throw new TokenValidationException(
                     SecurityEventCounter.EventType.TOKEN_NBF_FUTURE,

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/util/JwkThumbprintUtil.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/util/JwkThumbprintUtil.java
@@ -19,8 +19,6 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
 import java.util.Map;
 
@@ -35,15 +33,13 @@ import java.util.Map;
  *   <li>Base64url encoding without padding</li>
  * </ol>
  * <p>
- * Uses only {@link MessageDigest} and {@link Base64} — no external dependencies.
+ * Uses only {@link Sha256Util} and {@link Base64} — no external dependencies.
  *
  * @since 1.0
  * @see <a href="https://datatracker.ietf.org/doc/html/rfc7638">RFC 7638 - JSON Web Key (JWK) Thumbprint</a>
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class JwkThumbprintUtil {
-
-    private static final String SHA_256 = "SHA-256";
 
     /**
      * Computes the JWK Thumbprint (RFC 7638) for the given JWK represented as a Map.
@@ -56,7 +52,7 @@ public final class JwkThumbprintUtil {
     public static String computeThumbprint(Map<String, Object> jwkMap) {
         String kty = getRequired(jwkMap, "kty");
         String minimalJson = buildMinimalJson(jwkMap, kty);
-        byte[] hash = sha256(minimalJson.getBytes(StandardCharsets.UTF_8));
+        byte[] hash = Sha256Util.digest(minimalJson.getBytes(StandardCharsets.UTF_8));
         return Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
     }
 
@@ -108,13 +104,5 @@ public final class JwkThumbprintUtil {
             throw new IllegalArgumentException("JWK is missing required field for thumbprint: " + key);
         }
         return value.toString();
-    }
-
-    private static byte[] sha256(byte[] input) {
-        try {
-            return MessageDigest.getInstance(SHA_256).digest(input);
-        } catch (NoSuchAlgorithmException e) {
-            throw new IllegalStateException("SHA-256 not available", e);
-        }
     }
 }

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/util/Sha256Util.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/util/Sha256Util.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.token.validation.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * Small utility wrapping {@link MessageDigest} SHA-256 digest computation.
+ * <p>
+ * SHA-256 is required to be present by the Java Security Standard Algorithm Names
+ * specification, so the checked {@link NoSuchAlgorithmException} is translated to an
+ * {@link IllegalStateException} (it can only occur on a broken JRE).
+ *
+ * @since 1.0
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class Sha256Util {
+
+    /**
+     * Computes the SHA-256 digest of the given input.
+     *
+     * @param input the bytes to digest, must not be {@code null}
+     * @return the 32-byte SHA-256 digest
+     * @throws IllegalStateException if the SHA-256 algorithm is not available (broken JRE)
+     */
+    public static byte[] digest(byte[] input) {
+        try {
+            return MessageDigest.getInstance("SHA-256").digest(input);
+        } catch (NoSuchAlgorithmException e) {
+            // SHA-256 is required by the Java specification; this should never happen
+            throw new IllegalStateException("SHA-256 algorithm not available", e);
+        }
+    }
+}

--- a/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/TokenTypeTest.java
+++ b/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/TokenTypeTest.java
@@ -15,14 +15,16 @@
  */
 package de.cuioss.sheriff.token.validation;
 
+import de.cuioss.sheriff.token.validation.domain.claim.ClaimName;
 import de.cuioss.test.generator.junit.EnableGeneratorController;
 import de.cuioss.test.juli.junit5.EnableTestLogger;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import java.util.SortedSet;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 @EnableGeneratorController
 @EnableTestLogger
@@ -42,5 +44,19 @@ class TokenTypeTest {
     void shouldHaveNonEmptyMandatoryClaims(TokenType tokenType) {
         assertFalse(tokenType.getMandatoryClaims().isEmpty(),
                 "Mandatory claims should not be empty for " + tokenType);
+    }
+
+    @ParameterizedTest
+    @EnumSource(TokenType.class)
+    @DisplayName("Mandatory claims should be unmodifiable")
+    void shouldExposeUnmodifiableMandatoryClaims(TokenType tokenType) {
+        SortedSet<ClaimName> mandatoryClaims = tokenType.getMandatoryClaims();
+
+        assertThrows(UnsupportedOperationException.class,
+                () -> mandatoryClaims.add(ClaimName.AUDIENCE),
+                "Adding to mandatory claims must be rejected for " + tokenType);
+        assertThrows(UnsupportedOperationException.class,
+                mandatoryClaims::clear,
+                "Clearing mandatory claims must be rejected for " + tokenType);
     }
 }

--- a/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/TokenValidatorTest.java
+++ b/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/TokenValidatorTest.java
@@ -39,6 +39,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 
+import java.time.OffsetDateTime;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -233,6 +235,27 @@ class TokenValidatorTest {
                     "Should indicate no issuer config");
             LogAsserts.assertLogMessagePresentContaining(TestLogLevel.WARN,
                     JWTValidationLogMessages.WARN.NO_ISSUER_CONFIG.resolveIdentifierString());
+        }
+
+        @ParameterizedTest
+        @TestTokenSource(value = TokenType.ACCESS_TOKEN, count = 2)
+        @DisplayName("Wrap malformed claim values as TokenValidationException")
+        void shouldWrapMalformedClaimAsTokenValidationException(TestTokenHolder tokenHolder) {
+            // scope must be a string or array; a numeric value (serialized from a DATETIME
+            // claim) is malformed and makes ScopeMapper throw IllegalArgumentException,
+            // which must not escape from TokenValidator
+            OffsetDateTime anyTime = OffsetDateTime.now();
+            tokenHolder.withClaim(ClaimName.SCOPE.getName(),
+                    ClaimValue.forDateTime(String.valueOf(anyTime.toEpochSecond()), anyTime));
+            String token = tokenHolder.getRawToken();
+
+            var request = AccessTokenRequest.of(token);
+            var exception = assertThrows(TokenValidationException.class,
+                    () -> tokenValidator.createAccessToken(request),
+                    "Malformed claim must surface as TokenValidationException");
+
+            assertTrue(exception.getMessage().contains("scope"),
+                    "Exception message should name the malformed claim: " + exception.getMessage());
         }
     }
 

--- a/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/domain/claim/ClaimNameTest.java
+++ b/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/domain/claim/ClaimNameTest.java
@@ -100,7 +100,7 @@ class ClaimNameTest implements ShouldHandleObjectContracts<ClaimName> {
                 Arguments.of(
                         ClaimName.AUDIENCE,
                         createJsonObjectWithArrayClaim("aud", List.of("client1", "client2")),
-                        ClaimValue.forList("[\"client1\",\"client2\"]", List.of("client1", "client2"))
+                        ClaimValue.forList("[client1, client2]", List.of("client1", "client2"))
                 ),
 
                 Arguments.of(
@@ -175,7 +175,7 @@ class ClaimNameTest implements ShouldHandleObjectContracts<ClaimName> {
                 Arguments.of(
                         ClaimName.ROLES,
                         createJsonObjectWithArrayClaim("roles", List.of("admin", "user", "manager")),
-                        ClaimValue.forList("[\"admin\",\"user\",\"manager\"]", List.of("admin", "user", "manager"))
+                        ClaimValue.forList("[admin, user, manager]", List.of("admin", "user", "manager"))
                 ),
 
                 Arguments.of(
@@ -187,7 +187,7 @@ class ClaimNameTest implements ShouldHandleObjectContracts<ClaimName> {
                 Arguments.of(
                         ClaimName.GROUPS,
                         createJsonObjectWithArrayClaim("groups", List.of("group1", "group2", "group3")),
-                        ClaimValue.forList("[\"group1\",\"group2\",\"group3\"]", List.of("group1", "group2", "group3"))
+                        ClaimValue.forList("[group1, group2, group3]", List.of("group1", "group2", "group3"))
                 ),
 
                 Arguments.of(

--- a/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/domain/token/BaseTokenContentTest.java
+++ b/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/domain/token/BaseTokenContentTest.java
@@ -27,6 +27,7 @@ import de.cuioss.test.valueobjects.junit5.contracts.ShouldHandleObjectContracts;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 
+import java.util.HashMap;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -79,6 +80,35 @@ class BaseTokenContentTest implements ShouldHandleObjectContracts<AccessTokenCon
         Optional<ClaimValue> claimOption = content.getClaimOption(ClaimName.ISSUER);
 
         assertTrue(claimOption.isEmpty(), "Claim option should be empty");
+    }
+
+    @ParameterizedTest
+    @TestTokenSource(value = TokenType.ACCESS_TOKEN, count = 2)
+    @DisplayName("Expose claims as immutable map")
+    void shouldExposeImmutableClaimsMap(TestTokenHolder tokenHolder) {
+        var content = new AccessTokenContent(tokenHolder.getClaims(), tokenHolder.getRawToken());
+
+        var claims = content.getClaims();
+        var claimValue = ClaimValue.forPlainString("injected");
+        assertThrows(UnsupportedOperationException.class,
+                () -> claims.put("injected", claimValue),
+                "Claims map must be unmodifiable");
+        assertThrows(UnsupportedOperationException.class,
+                claims::clear,
+                "Claims map must be unmodifiable");
+    }
+
+    @ParameterizedTest
+    @TestTokenSource(value = TokenType.ACCESS_TOKEN, count = 2)
+    @DisplayName("Defensively copy the claims map passed to the constructor")
+    void shouldDefensivelyCopyClaims(TestTokenHolder tokenHolder) {
+        var mutableClaims = new HashMap<>(tokenHolder.getClaims());
+        var content = new AccessTokenContent(mutableClaims, tokenHolder.getRawToken());
+
+        mutableClaims.put("added-later", ClaimValue.forPlainString("value"));
+
+        assertFalse(content.getClaims().containsKey("added-later"),
+                "Mutating the source map must not affect the token content");
     }
 
     @Override

--- a/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/domain/token/UnvalidatedRefreshTokenTest.java
+++ b/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/domain/token/UnvalidatedRefreshTokenTest.java
@@ -69,6 +69,34 @@ class UnvalidatedRefreshTokenTest implements ShouldHandleObjectContracts<Unvalid
         assertEquals(testValue, refreshTokenContent.getClaims().get("test-claim").getOriginalString(), "Claim value should match");
     }
 
+    @ParameterizedTest
+    @TestTokenSource(value = TokenType.REFRESH_TOKEN, count = 2)
+    @DisplayName("toString must not leak the raw token or claims")
+    void toStringShouldNotLeakCredential(TestTokenHolder tokenHolder) {
+        tokenHolder.withClaim("secret-claim", ClaimValue.forPlainString("secret-claim-value"));
+        var refreshTokenContent = new UnvalidatedRefreshToken(tokenHolder.getRawToken(), tokenHolder.getClaims());
+
+        String stringRepresentation = refreshTokenContent.toString();
+
+        assertFalse(stringRepresentation.contains(tokenHolder.getRawToken()),
+                "toString must not contain the raw refresh token (credential)");
+        assertFalse(stringRepresentation.contains("secret-claim-value"),
+                "toString must not contain claim values");
+    }
+
+    @ParameterizedTest
+    @TestTokenSource(value = TokenType.REFRESH_TOKEN, count = 2)
+    @DisplayName("Expose claims as immutable map")
+    void shouldExposeImmutableClaimsMap(TestTokenHolder tokenHolder) {
+        var refreshTokenContent = new UnvalidatedRefreshToken(tokenHolder.getRawToken(), tokenHolder.getClaims());
+
+        var claims = refreshTokenContent.getClaims();
+        var claimValue = ClaimValue.forPlainString("injected");
+        assertThrows(UnsupportedOperationException.class,
+                () -> claims.put("injected", claimValue),
+                "Claims map must be unmodifiable");
+    }
+
     @Override
     public UnvalidatedRefreshToken getUnderTest() {
         Map<String, ClaimValue> anyClaims = new HashMap<>();

--- a/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/pipeline/validator/AuthorizedPartyValidatorTest.java
+++ b/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/pipeline/validator/AuthorizedPartyValidatorTest.java
@@ -168,18 +168,19 @@ class AuthorizedPartyValidatorTest {
     }
 
     @Test
-    @DisplayName("Should handle null claim value gracefully")
-    void shouldHandleNullClaimValueGracefully() {
+    @DisplayName("Should reject null claim values at token construction")
+    void shouldRejectNullClaimValuesAtTokenConstruction() {
+        // Since the claims map is defensively copied via Map.copyOf, null claim values are
+        // rejected at construction time - a null azp value can never reach the validator.
+        // The absent-claim case is covered by shouldFailValidationWhenAuthorizedPartyClaimIsMissing.
         TestTokenHolder tokenHolder = TestTokenGenerators.accessTokens().next();
         Map<String, ClaimValue> claims = new HashMap<>(tokenHolder.getClaims());
         claims.put(ClaimName.AUTHORIZED_PARTY.getName(), null);
         claims.remove(ClaimName.CLIENT_ID.getName());
-        AccessTokenContent token = new AccessTokenContent(claims, tokenHolder.getRawToken());
+        String rawToken = tokenHolder.getRawToken();
 
-        TokenValidationException exception = assertThrows(TokenValidationException.class,
-                () -> validator.validateAuthorizedParty(token));
-        assertEquals(SecurityEventCounter.EventType.MISSING_CLAIM, exception.getEventType());
-        assertTrue(exception.getMessage().contains("Missing required authorized party claim (azp or client_id)"));
-        assertEquals(1, securityEventCounter.getCount(SecurityEventCounter.EventType.MISSING_CLAIM));
+        assertThrows(NullPointerException.class,
+                () -> new AccessTokenContent(claims, rawToken),
+                "Null claim values must be rejected by the defensive copy");
     }
 }


### PR DESCRIPTION
## Summary

Fixes the token/domain-model findings from `doc/code-findings.adoc` (#526):

- **M-3** — Validated token claims were a shared mutable `HashMap` exposed via getter and shared across threads by the access-token cache (in-process cache-poisoning risk). `BaseTokenContent` and `UnvalidatedRefreshToken` now defensively copy with `Map.copyOf`.
- **M-4** — `TokenType`'s mandatory-claim sets were globally mutable (`TreeSet` exposed directly); now wrapped unmodifiable.
- **M-5** — `UnvalidatedRefreshToken.toString()` leaked the refresh-token credential and unvalidated claims; both are now `@ToString.Exclude` (matching `BaseTokenContent`).
- **M-6** — JWT header/payload JSON was re-encoded with the platform-default charset (corrupting non-ASCII claims on non-UTF-8 JVMs); the parser now hands the raw decoded `byte[]` straight to DSL-JSON, removing the charset round-trip entirely.
- **M-7** — A signed token with a malformed claim (e.g. non-string `scope`) escaped as raw `IllegalArgumentException` (HTTP 500) instead of the documented `TokenValidationException`; `TokenBuilder` now wraps mapper failures. Keycloak mapper javadoc aligned with actual behavior.
- **L-9..L-12** — Documentation drift fixes (LRU claim, WARN-107 now parameterized with the effective clock skew, non-compiling javadoc examples), shared expiry predicate between cache and pipeline, shared `Sha256Util`, shared Keycloak mapper tail, JSON escaping/null-rejection/blank-filtering robustness in `JsonCollectionMapper`/`MapRepresentation`/`StringSplitterMapper`/`JwtHeader`.

## Tests

`./mvnw -Ppre-commit clean verify -pl token-sheriff-validation` green — 1523 tests, 0 failures. New tests cover claims-map immutability, unmodifiable mandatory-claim sets, credential-free `toString`, and the end-to-end malformed-claim → `TokenValidationException` path. `doc/LogMessages.adoc` updated for the WARN-107 template change.

No conflicts with #527 (verified via dry-run merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012RwRgQHDskAEsKYkgKanH3

---
_Generated by [Claude Code](https://claude.ai/code/session_012RwRgQHDskAEsKYkgKanH3)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Token validation now handles malformed claim values more robustly, returning clearer validation errors instead of unexpected failures.
  * JWT parsing and cache handling were improved for better consistency and reliability.

* **Bug Fixes**
  * Missing or invalid group/role claims are now treated as absent, while empty arrays remain supported.
  * Blank JWT header values are now ignored consistently, and time-based token checks now respect configurable clock skew.

* **Documentation**
  * Updated API and log-message documentation to match the current behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->