### PR TITLE
docs(oidc): reconcile planning docs with executed state; fix JFR Dockerfile rename residual

### DIFF
--- a/doc/README.adoc
+++ b/doc/README.adoc
@@ -17,6 +17,7 @@ The token validation capability — its requirements, architecture, security mod
 
 === Specifications
 
+* xref:validation/specification/microprofile-jwt-compatibility.adoc[MicroProfile JWT Compatibility] - MP-JWT 2.1 integration and rationale
 * xref:validation/specification/token-decryption.adoc[Token Decryption] - Future JWE support
 * xref:validation/specification/multi-idp-testing.adoc[Multi-IDP Testing] - Testing with multiple OIDC providers
 

--- a/doc/oidc/01-restructure/README.adoc
+++ b/doc/oidc/01-restructure/README.adoc
@@ -163,7 +163,7 @@ Publish a stub for *every* old artifact (`-core`, `-quarkus`, `-quarkus-deployme
 
 * [x] `grep -rI "de.cuioss.sheriff.oauth"` → 0 (excluding the planning docs + recorded benchmark fixtures)
 * [x] `grep -rI "sheriff.oauth."` → 0
-* [x] `grep -rI "oauth-sheriff"` → 0 (lowercase; the repo/Pages/Sonar `OAuthSheriff` URLs were flipped in Phase 3)
+* [x] `grep -rI "oauth-sheriff"` → 0 (lowercase; the repo/Pages/Sonar `OAuthSheriff` URLs were flipped in Phase 3). _Post-release audit 2026-07-04: one functional residual had escaped this sweep — `Dockerfile.native.jfr` still `COPY`-ed from the deleted `oauth-sheriff-quarkus-parent/…` paths (JFR image build broken); fixed. Remaining hits are intentional: `rewrite.yml` (the migration recipe itself), recorded benchmark fixtures, and a historical note in the release skill._
 * [x] `grep -rIo "OAUTH-SHERIFF-[0-9]"` → 0; `VALIDATION-N` count = 51 (matches the prior IDs)
 * [x] `./mvnw -Ppre-commit clean verify` and `./mvnw clean install` green
 * [x] Relocation stubs published for every published old artifact (`-parent`, `-core`, `-quarkus`, `-quarkus-deployment`); an old-coordinate resolve redirects to `token-sheriff-validation` with a warning (verified). _`bom` was never published, so no stub. Note: an inert empty aggregator pom `oauth-sheriff-relocations:0.9.0` was also published (central-publishing ignores `maven.deploy.skip`) — harmless, immutable._

--- a/doc/oidc/01-restructure/migration-nifi-extensions.adoc
+++ b/doc/oidc/01-restructure/migration-nifi-extensions.adoc
@@ -8,7 +8,7 @@
 |===
 | Audience | Maintainers of `cuioss/nifi-extensions` (the one known consumer)
 | Context  | xref:README.adoc[Plan 01 — Restructure]
-| Status   | *Executable now.* Token-Sheriff `0.9.0` is published to Maven Central, and the old `de.cuioss.sheriff.oauth` coordinates have relocation stubs at `0.9.0` that redirect to the new ones.
+| Status   | *Done — executed and merged* via https://github.com/cuioss/nifi-extensions/pull/398[nifi-extensions#398] against Token-Sheriff `0.9.0` (verified: coordinates, imports, config keys, `generators` classifier — zero functional residuals). Kept as reference for any further consumer.
 |===
 
 toc::[]

--- a/doc/oidc/01-restructure/phase-3-checklist.adoc
+++ b/doc/oidc/01-restructure/phase-3-checklist.adoc
@@ -5,7 +5,9 @@
 This is the committed, self-detecting checklist for Phase 3 of the Token-Sheriff
 rename. Each row carries a read-only *Detect* command (the source of truth — run
 it to learn the real state) and an idempotent *Action*. Trust *Detect*, not the
-*State* column.
+*State* column. (State column last reconciled 2026-07-04 against the
+xref:README.adoc#_verification_checklist[Plan 01 verification]; only the OpenSSF
+row remains open.)
 
 [NOTE]
 ====
@@ -24,22 +26,22 @@ toc::[]
 |===
 | State | Detect (source of truth) | Action (idempotent)
 
-| TODO | `gh repo view cuioss/TokenSheriff --json name -q .name` → `TokenSheriff`
+| DONE | `gh repo view cuioss/TokenSheriff --json name -q .name` → `TokenSheriff`
 | *User:* rename the repo on GitHub (Settings → Rename, or `gh repo rename TokenSheriff --repo cuioss/OAuthSheriff --yes`). Old URLs redirect.
 
-| TODO | `git remote get-url origin` contains `TokenSheriff`
+| DONE | `git remote get-url origin` contains `TokenSheriff`
 | `git remote set-url origin https://github.com/cuioss/TokenSheriff.git`
 
-| TODO | `curl -sf "https://sonarcloud.io/api/project_badges/measure?project=cuioss_TokenSheriff&metric=alert_status"` returns a real badge (not "project not found")
+| DONE | `curl -sf "https://sonarcloud.io/api/project_badges/measure?project=cuioss_TokenSheriff&metric=alert_status"` returns a real badge (not "project not found")
 | *User:* in SonarCloud, rename the project key `cuioss_OAuth-Sheriff` → `cuioss_TokenSheriff` (`.github/project.yml sonar.project-key` already updated). Must precede merging the URL PR, else CI `sonar-build` targets a missing project.
 
-| TODO | `curl -sfI https://cuioss.github.io/TokenSheriff/ \| head -1` → `200`
+| DONE | `curl -sfI https://cuioss.github.io/TokenSheriff/ \| head -1` → `200`
 | *Automatic* — no manual step. The cui release workflow deploys Pages from `.github/project.yml pages.reference: TokenSheriff` (`deploy-at-release: true`), so the new path goes live with the next release (the 0.9.0 publish). Benchmark badges resolve from then.
 
 | TODO | OpenSSF project 11849 shows the `cuioss/TokenSheriff` URL
-| *User:* update the OpenSSF Best Practices entry (https://www.bestpractices.dev/projects/11849) repo URL to `cuioss/TokenSheriff`.
+| *User:* update the OpenSSF Best Practices entry (https://www.bestpractices.dev/projects/11849) repo URL to `cuioss/TokenSheriff` — the entry currently carries a `TokenSherif` typo to correct as well.
 
-| TODO | every badge/link URL in `README.md` returns HTTP 200 (loop-curl)
+| DONE | every badge/link URL in `README.md` returns HTTP 200 (loop-curl)
 | Merge the URL/Sonar/Pages PR (repo URLs, Sonar key, Pages refs flipped); fix any non-200 source.
 |===
 

--- a/doc/oidc/02-doc-structure/README.adoc
+++ b/doc/oidc/02-doc-structure/README.adoc
@@ -6,7 +6,7 @@
 
 [cols="1,3"]
 |===
-| Status     | Ready to execute (after xref:../01-restructure/README.adoc[Plan 01])
+| Status     | *Phase 1 done* — the validation capability split shipped via https://github.com/cuioss/TokenSheriff/pull/524[#524] (2026-07). Phase 2 (client scaffolding) deferred by design until client work starts.
 | Depends on | Plan 01 — Restructure (rename); run after it to pay link churn once
 | Scope      | Reshape `doc/` so validation, Commons and the coming OIDC client are peer capabilities, with a shared cross-cutting area
 |===
@@ -110,6 +110,7 @@ The error model is *owned by `commons`* (`doc/commons/specification/error-model.
 
 === Phase 2 — Scaffold the client capability (when client work starts)
 . Create `doc/client/` with stub `architecture.adoc`, `requirements.adoc` (`CLIENT-N`), `threat-model.adoc`, `specification/`.
+. Create `doc/shared/glossary.adoc` — the cross-capability glossary earns its keep only once a second capability exists, so it is scaffolded here, not in Phase 1.
 . Add the client module `doc/` dir for usage/config/dev. Client log records are added to the global `doc/LogMessages.adoc` — no separate client registry.
 . Wire both capabilities into the hub.
 
@@ -125,11 +126,11 @@ The error model is *owned by `commons`* (`doc/commons/specification/error-model.
 
 == Verification
 
-* [ ] `doc/validation/` holds the relocated conceptual docs; titles rescoped to the capability
-* [ ] Every `xref:`/`link:` to the moved docs resolves (root `README.md`, module docs, cross-doc) — zero broken links
-* [ ] `doc/README.adoc` hub presents capabilities as peer groups
-* [ ] Requirement IDs unchanged in count after the move; client namespace `CLIENT-N` reserved
-* [ ] Phase 2 deferred until client work starts (no empty client scaffolding merged early)
+* [x] `doc/validation/` holds the relocated conceptual docs; titles rescoped to the capability ("Token Validation Requirements/Architecture/Threat Model"); the `security/` subdir was flattened — `threat-model.adoc` and `security-reference.adoc` sit directly under `doc/validation/`
+* [x] Every `xref:`/`link:` to the moved docs resolves (root `README.md`, module docs, cross-doc) — link sweep 2026-07-04: zero broken links to the moved set
+* [x] `doc/README.adoc` hub presents capabilities as peer groups ("Token Validation" group; "Client" follows with Phase 2)
+* [x] Requirement IDs unchanged in count after the move (51 distinct `VALIDATION-N` IDs); client namespace `CLIENT-N` reserved
+* [x] Phase 2 deferred until client work starts (no empty client scaffolding merged early)
 
 == Seed data for planning (discovery 2026-06-24)
 
@@ -179,5 +180,5 @@ faq/keycloak.adoc      xref:faq/keycloak.adoc x1
 
 * *Two link syntaxes:* AsciiDoc `xref:`/`link:` in `.adoc`, Markdown `](path)` in `README.md` — both need rewriting.
 * *Up to 5 relative forms per target* → each is depth-dependent; a flat find/replace will break links.
-* *Moving the set together preserves most intra-set short forms* (e.g. `xref:architecture.adoc` inside `requirements.adoc` still resolves if both land in `validation/`). The open sub-decision is whether to keep a `validation/security/` subdir or flatten it — it changes the `security/…` intra-set refs.
+* *Moving the set together preserves most intra-set short forms* (e.g. `xref:architecture.adoc` inside `requirements.adoc` still resolves if both land in `validation/`). The open sub-decision — keep a `validation/security/` subdir or flatten it — was *resolved in execution: flattened* (`threat-model.adoc` and `security-reference.adoc` sit directly under `doc/validation/`).
 * Sequence after Plan 01 so these links are rewritten once.

--- a/doc/oidc/03-commons/README.adoc
+++ b/doc/oidc/03-commons/README.adoc
@@ -93,7 +93,7 @@ These give the same guarantee a module boundary would (base stays dependency-lig
 
 == Test support: extend the dispatcher artifact
 
-The existing `generators`-classifier test artifact (today `oauth-sheriff-core`, post-rename `token-sheriff-validation`) already ships MockWebServer dispatchers for the endpoints validation talks to — `WellKnownDispatcher`, `JwksResolveDispatcher` in `…test.dispatcher`, implementing `ModuleDispatcherElement` from `cui-test-mockwebserver-junit5` (see xref:../../../oauth-sheriff-core/doc/UnitTesting.adoc[Core Test Utilities]).
+The existing `generators`-classifier test artifact (`token-sheriff-validation`) already ships MockWebServer dispatchers for the endpoints validation talks to — `WellKnownDispatcher`, `JwksResolveDispatcher` in `…test.dispatcher`, implementing `ModuleDispatcherElement` from `cui-test-mockwebserver-junit5` (see xref:../../../token-sheriff-validation/doc/UnitTesting.adoc[Core Test Utilities]).
 
 Since `commons` adds the *other* IdP endpoints, *extend this same artifact* with dispatchers for them — so commons, validation and (later) client tests all share one OP simulation:
 

--- a/doc/oidc/README.adoc
+++ b/doc/oidc/README.adoc
@@ -17,8 +17,8 @@ implementation plans plus the standing design decisions behind them.
 * xref:03-commons/README.adoc[03 — Commons: the Shared Base Layer] -
   gather the base-layer cross-cutting concerns into a `de.cuioss.sheriff.token.commons.*`
   package layer *inside* `token-sheriff-validation` (ArchUnit-enforced, not a separate
-  artifact): IdP transport (discovery, JWKS, token, userinfo, revocation, end-session,
-  PAR) + the error model (typed exceptions → RFC 9457 at the edge) + security events +
+  artifact): IdP transport (discovery, JWKS, token, userinfo, revocation, introspection,
+  end-session, PAR) + the error model (typed exceptions → RFC 9457 at the edge) + security events +
   metrics. Spec (`COMMONS-N`) plus the re-packaging of these out of the validation packages,
   and extending the `generators` test artifact with MockWebServer dispatchers for the new endpoints.
 * xref:04-client-spec/README.adoc[04 — Client Requirements, Specification & Security] -
@@ -51,11 +51,17 @@ implementation plans plus the standing design decisions behind them.
 
 * xref:01-restructure/README.adoc[Plan 01 — Restructure]: *Done* — shipped as `0.9.0`
   (2026-06-29); repository renamed to Token-Sheriff and published to Maven Central with
-  relocation; consumer `nifi-extensions` migrated.
-* Plans 02–06: planning only — not yet started.
+  relocation; consumer `nifi-extensions` migrated. Only the OpenSSF Best Practices
+  entry update is still pending.
+* xref:02-doc-structure/README.adoc[Plan 02 — Documentation Structure]: *Phase 1 done*
+  (2026-07, https://github.com/cuioss/TokenSheriff/pull/524[#524]) — the validation
+  capability split under `doc/validation/` is executed and wired into the
+  xref:../README.adoc[Documentation Hub]. Phase 2 (client scaffolding) is deferred by
+  design until client work starts.
+* Plans 03–06: planning only — not yet started.
 
 [NOTE]
 ====
-Plans 02–06 are not yet wired into the top-level
+Plans 03–06 are not yet wired into the top-level
 xref:../README.adoc[Documentation Hub]; they will be linked in as each is executed.
 ====

--- a/token-sheriff-quarkus-parent/token-sheriff-quarkus-integration-tests/src/main/docker/Dockerfile.native.jfr
+++ b/token-sheriff-quarkus-parent/token-sheriff-quarkus-integration-tests/src/main/docker/Dockerfile.native.jfr
@@ -2,7 +2,7 @@
 # This approach is much faster as it avoids rebuilding the native image in Docker
 FROM quay.io/quarkus/ubi9-quarkus-micro-image:2.0@sha256:48087a7cc9e62e5eb86e787048ce898393efcbb758695effb65f3cb0caa79c3f
 
-LABEL org.opencontainers.image.title="OAuth Sheriff Integration Tests - JFR"
+LABEL org.opencontainers.image.title="Token-Sheriff Integration Tests - JFR"
 LABEL org.opencontainers.image.description="Quarkus native application with JFR profiling support"
 LABEL org.opencontainers.image.vendor="CUI"
 LABEL org.opencontainers.image.version="1.0.0-SNAPSHOT"
@@ -12,14 +12,14 @@ LABEL performance.jfr.enabled="true"
 WORKDIR /app
 
 # Copy pre-built native executable from Maven target directory
-COPY --chmod=0755 oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus-integration-tests/target/*-runner /app/application
+COPY --chmod=0755 token-sheriff-quarkus-parent/token-sheriff-quarkus-integration-tests/target/*-runner /app/application
 
 # Copy certificates and health check script
-COPY --chmod=0755 oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus-integration-tests/src/main/docker/health-check.sh /app/health-check.sh
-COPY --chmod=0644 oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus-integration-tests/src/main/docker/certificates/localhost.crt /app/certificates/localhost.crt
-COPY --chown=1001:1001 --chmod=0600 oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus-integration-tests/src/main/docker/certificates/localhost.key /app/certificates/localhost.key
-COPY --chmod=0644 oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus-integration-tests/src/main/docker/certificates/localhost-truststore.p12 /app/certificates/localhost-truststore.p12
-COPY --chown=1001:1001 --chmod=0600 oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus-integration-tests/src/main/docker/certificates/jwe-test-decryption-key.pem /app/certificates/jwe-test-decryption-key.pem
+COPY --chmod=0755 token-sheriff-quarkus-parent/token-sheriff-quarkus-integration-tests/src/main/docker/health-check.sh /app/health-check.sh
+COPY --chmod=0644 token-sheriff-quarkus-parent/token-sheriff-quarkus-integration-tests/src/main/docker/certificates/localhost.crt /app/certificates/localhost.crt
+COPY --chown=1001:1001 --chmod=0600 token-sheriff-quarkus-parent/token-sheriff-quarkus-integration-tests/src/main/docker/certificates/localhost.key /app/certificates/localhost.key
+COPY --chmod=0644 token-sheriff-quarkus-parent/token-sheriff-quarkus-integration-tests/src/main/docker/certificates/localhost-truststore.p12 /app/certificates/localhost-truststore.p12
+COPY --chown=1001:1001 --chmod=0600 token-sheriff-quarkus-parent/token-sheriff-quarkus-integration-tests/src/main/docker/certificates/jwe-test-decryption-key.pem /app/certificates/jwe-test-decryption-key.pem
 
 # Create JFR output directory with proper permissions
 RUN mkdir -p /tmp/jfr-output && chmod 777 /tmp/jfr-output

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus-deployment/README.adoc
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus-deployment/README.adoc
@@ -49,7 +49,7 @@ Main deployment processor handling build-time configuration:
 === DevUI Components
 Development interface components:
 
-* link:src/main/java/de/cuioss/sheriff/token/quarkus/deployment/TokenSheriffDevUIJsonRPCService.java[TokenSheriffDevUIJsonRPCService] - JSON-RPC service for DevUI communication
+* link:../token-sheriff-validation-quarkus/src/main/java/de/cuioss/sheriff/token/quarkus/runtime/TokenSheriffDevUIRuntimeService.java[TokenSheriffDevUIRuntimeService] - JSON-RPC service for DevUI communication (runtime module; registered here via `JsonRPCProvidersBuildItem` in `TokenSheriffProcessor`)
 * Web components in `src/main/resources/dev-ui/` for interactive JWT debugging
 
 For detailed component architecture, implementation details, and testing framework, see xref:../doc/development/devui-implementation.adoc[DevUI Implementation Documentation].


### PR DESCRIPTION
Full review of `doc/oidc/` (all plans + the module-architecture decision) against the actual repository state. The plans themselves are sound — the findings are staleness and rename residuals, all fixed here.

## Functional fix

- **`Dockerfile.native.jfr` could not build since the 0.9.0 rename**: all `COPY` paths still pointed at the deleted `oauth-sheriff-quarkus-parent/oauth-sheriff-quarkus-integration-tests/…` directories. This Dockerfile is actively used (`docker-compose.jfr.yml`, `start-integration-container.sh`, `benchmark-integration-wrk`). Paths flipped to `token-sheriff-quarkus-parent/token-sheriff-quarkus-integration-tests/…`; image title label aligned with the distroless variant.

## doc/oidc reconciliation

- **`doc/oidc/README.adoc` + Plan 02**: statuses claimed "Plans 02–06: planning only — not yet started", but Plan 02 Phase 1 (the `doc/validation/` capability split) shipped in #524. Statuses updated; Plan 02's verification checkboxes ticked with the verified evidence (51 distinct `VALIDATION-N` IDs preserved, hub regrouped, link sweep clean); the open sub-decision recorded as resolved (security/ subdir flattened).
- **Plan 02**: `doc/shared/glossary.adoc` was in the target structure but no execution phase created it — now explicitly scaffolded in Phase 2.
- **Plan 03**: broken xref `../../../oauth-sheriff-core/doc/UnitTesting.adoc` → renamed `token-sheriff-validation` path.
- **Plan 01**: verification note documents the JFR-Dockerfile residual found and fixed here; the nifi-extensions migration guide marked *executed* (cuioss/nifi-extensions#398); Phase 3 checklist State column reconciled (all DONE except the pending OpenSSF entry).
- **`doc/oidc/README.adoc`**: Plan 03 transport summary now includes *introspection* (consistent with Plan 03 and the decision doc).

## Related link fixes outside doc/oidc (found by the review's link sweep)

- **Doc hub**: adds the missing MicroProfile JWT Compatibility spec link (root README links it; the hub didn't).
- **`token-sheriff-validation-quarkus-deployment/README.adoc`**: dead link to the removed `TokenSheriffDevUIJsonRPCService` — now points at `TokenSheriffDevUIRuntimeService` (the actual JSON-RPC provider registered by `TokenSheriffProcessor`).

Verified: repo-wide relative-link sweep over all `.adoc`/`.md` → zero broken targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pxtegfb8ULfaQTWvxtYhT

---
_Generated by [Claude Code](https://claude.ai/code/session_013pxtegfb8ULfaQTWvxtYhT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the project branding in the native image metadata and updated build references to use the current project paths.
  * Fixed documentation that still referenced outdated names and added notes clarifying completed vs. pending migration checks.

* **Documentation**
  * Expanded and refreshed several planning guides to reflect current migration status, verification results, and deferred work.
  * Updated architecture docs to include introspection in the shared endpoint list and to align DevUI service references with the current implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->