### PR TITLE
docs(client): Plan 04 — Client capability document set (CLIENT-N)

### DIFF
--- a/doc/README.adoc
+++ b/doc/README.adoc
@@ -42,6 +42,28 @@ The token validation capability — its requirements, architecture, security mod
 
 * xref:validation/faq/keycloak.adoc[Keycloak FAQ]
 
+== Client
+
+The active OIDC capability — the server-side confidential-client engine that retrieves
+tokens, holds and refreshes them server-side, and drives the flows on top of the commons
+transport. It is the engine a Backend-For-Frontend (BFF) is built on; it is not itself a BFF.
+Spec-first: this document set is authored ahead of the `token-sheriff-client` module.
+
+* xref:client/requirements.adoc[Requirements] - `CLIENT-N`, grouped by aspect (Retrieval & flow / Token)
+* xref:client/architecture.adoc[Architecture] - Client/BFF engine seam and boundaries
+* xref:client/references.adoc[References] - Bibliography
+
+=== Security
+
+* xref:client/threat-model.adoc[Threat Model] - Attack catalog per aspect, each entry sourced
+* xref:client/best-practices.adoc[Best Practices] - Normative, sourced checklist
+
+=== Specifications
+
+* xref:client/specification/retrieval-flow.adoc[Retrieval & Flow] - Auth-code + PKCE, grants, client auth, `state`/`nonce`, mix-up, PAR
+* xref:client/specification/step-up-and-logout.adoc[Step-up & Logout] - RFC 9470 step-up; RP-initiated logout
+* xref:client/specification/token-handling.adoc[Token Handling] - Server-side lifecycle delta (references the validation module)
+
 == Reference
 
 * xref:LogMessages.adoc[Log Messages] - Global registry of all log messages

--- a/doc/client/architecture.adoc
+++ b/doc/client/architecture.adoc
@@ -1,0 +1,190 @@
+= Client Architecture
+:toc: left
+:toclevels: 3
+:toc-title: Table of Contents
+:sectnums:
+:source-highlighter: highlight.js
+
+== Overview
+
+_See xref:requirements.adoc[Client Requirements], xref:threat-model.adoc[Threat Model],
+xref:best-practices.adoc[Best Practices] and the
+xref:../oidc/decision-oidc-module.adoc[module-architecture decision]._
+
+The `client` capability is the *active* OIDC side: a server-side *confidential-client engine*
+that retrieves tokens, holds and refreshes them server-side, and drives the flows on top of
+the xref:../commons/architecture.adoc[commons] transport. It is the engine a
+*Backend-For-Frontend (BFF)* is built on — *it is not itself a BFF*. This document maps the
+engine's components, its boundaries with commons and validation, and the sequences it drives.
+
+[IMPORTANT]
+====
+*We do not build a BFF here.* The BFF is a separate application layered on top of this
+engine. This capability's job is to specify the engine so that *building a BFF on top stays
+feasible and is not made unnecessarily complicated*. The BFF deployment shapes below are
+documented only as the *consumers the design must keep viable*
+(xref:requirements.adoc#CLIENT-19[CLIENT-19]), not as features delivered here.
+====
+
+== Position in the module architecture
+
+[source]
+----
+token-sheriff-validation                       (one artifact, two ArchUnit-enforced layers)
+  de.cuioss.sheriff.token.commons.              base: transport / error / events / metrics
+    transport/  error/  events/  metrics/         (deps: cui-http, cui-tooling)
+        ▲   ArchUnit: commons must NOT depend on …validation..
+  de.cuioss.sheriff.token.validation.           token validation (signatures, claims, pipeline)
+        ▲   Maven: client → validation, never the reverse
+token-sheriff-client                            THIS capability — flows / retrieval / lifecycle
+  de.cuioss.sheriff.token.client.               pure Java; deps: token-sheriff-validation
+        ▲
+token-sheriff-client-quarkus                    HTTP edge — RFC 9457 problem+json, CDI wiring
+----
+
+* The engine is *pure Java* (xref:requirements.adoc#CLIENT-21[CLIENT-21]) — no CDI /
+  MicroProfile / JAX-RS inside it. It depends on `token-sheriff-validation`, which
+  transitively provides the `commons` base layer.
+* The `client → validation` dependency direction is enforced by *Maven* once the module
+  exists (xref:../oidc/05-client-module/README.adoc[Plan 05]); it never reverses.
+* The HTTP edge (`token-sheriff-client-quarkus`, or a future RESTEasy / portal adapter) maps
+  the engine's typed exceptions to `application/problem+json`
+  (xref:requirements.adoc#CLIENT-20[CLIENT-20], `COMMONS-10`).
+
+NOTE: The Maven module, the `token-sheriff-client-quarkus` extension, and the BOM/reactor
+assembly are *not* created by this capability — that is
+xref:../oidc/05-client-module/README.adoc[Plan 05]. This document specifies the engine those
+modules will host.
+
+== The engine seam
+
+The engine owns three responsibilities and *delegates the rest*:
+
+[cols="1,3", options="header"]
+|===
+| Concern | Where it lives
+
+| *Retrieval & flow* — construct the authorization request (PKCE, `state`, `nonce`,
+  `acr_values`, PAR); exchange the code; authenticate to the token endpoint; request
+  sender-constrained tokens; drive step-up and RP-initiated logout.
+| *This engine* (`client`), xref:specification/retrieval-flow.adoc[retrieval-flow] +
+  xref:specification/step-up-and-logout.adoc[step-up-and-logout] specs.
+
+| *Server-side token lifecycle* — hold, refresh (with rotation), revoke; preserve
+  sender-constraint; keep tokens off the browser.
+| *This engine* (`client`), xref:specification/token-handling.adoc[token-handling] spec.
+
+| *Token trust* — signature, algorithm policy, `iss`/`aud`/`exp`/`iat`, DPoP proof.
+| *validation* module (inherited; `CLIENT-15` calls it, never re-implements it).
+
+| *Outbound IdP HTTP* — discovery, JWKS, token, userinfo, revocation, introspection,
+  end-session, PAR; TLS, SSRF, timeouts, resilience, caching.
+| *commons* transport (`COMMONS-1`–`COMMONS-8`); the engine issues *no* HTTP of its own.
+
+| *Error rendering* — typed exceptions → `application/problem+json`.
+| Engine *throws* (`COMMONS-9`); the *HTTP edge renders* (`COMMONS-10`).
+|===
+
+The seam is deliberately narrow: the engine is the *policy* layer (which parameters, which
+order, which checks); commons is the *transport* layer (bytes over hardened HTTP); validation
+is the *trust* layer.
+
+== Confidential authorization-code + PKCE sequence
+
+The core in-scope flow (xref:requirements.adoc#CLIENT-1[CLIENT-1], server-side, no tokens in
+the browser):
+
+[source]
+----
+Browser            Client engine (backend)        commons transport        Authorization Server
+   |  start login        |                                |                          |
+   |-------------------->|  build auth request:           |                          |
+   |                     |   PKCE S256, state, nonce,     |                          |
+   |                     |   exact redirect_uri,          |                          |
+   |                     |   [acr_values/max_age]         |                          |
+   |                     |  [PAR: push params]----------->|-- POST /par ------------>|
+   |                     |                                |<- request_uri -----------|
+   |<-- 302 to AS -------|  (authorize?request_uri=… or full params)                 |
+   |------------------------------- user authenticates at AS ---------------------->|
+   |<== form_post callback: code, state, iss =============================(no token in URL)
+   |-------------------->|  verify state (session-bound)  |                          |
+   |                     |  verify iss (mix-up defence)   |                          |
+   |                     |  exchange code --------------->|-- POST /token ---------->|
+   |                     |   client auth (private_key_jwt |   grant=authorization_code
+   |                     |    / mTLS / secret),           |   + code_verifier        |
+   |                     |   [DPoP proof]                 |<- tokens (+ id_token) ----|
+   |                     |  validate tokens (VALIDATION)  |                          |
+   |                     |  verify nonce, at_hash, sub    |                          |
+   |                     |  store server-side (BFF binding)                          |
+   |<-- session cookie --|  (opaque session-id  OR  encrypted token cookie)          |
+----
+
+The *browser never receives a usable token*. What the browser holds is the BFF's own
+session artifact — see <<_bff_binding_shapes>>.
+
+== [[_bff_binding_shapes]] BFF binding shapes (enabled, not built here)
+
+A BFF built on this engine binds the acquired tokens to the browser session one of two ways;
+in *both*, the token stays inaccessible to the browser, and the engine seam is *identical*
+(xref:requirements.adoc#CLIENT-19[CLIENT-19]):
+
+[cols="1,3", options="header"]
+|===
+| BFF deployment | How the token is bound to the browser session
+
+| *Stateful BFF — server-side token store*
+| The browser holds an opaque *session-id cookie*; tokens live in a *server-side store* and
+  the backend *proxies* every resource-server call.
+
+| *Stateless BFF — encrypted token cookie*
+| The access token reaches the browser only inside an *HttpOnly cookie encrypted with a
+  server-side symmetric key*; the backend *decrypts* it per request. No server-side store.
+|===
+
+What differs — a server-side store vs. an encrypted cookie — is the *BFF application's*
+concern (session cookie, symmetric-key management, backend-API CSRF, request proxying,
+login/consent UX, logout *receivers*). The engine must *enable either without forcing the
+choice*; it implements neither.
+
+== Boundaries enforced
+
+* *Engine → validation* (Maven): the engine validates every retrieved token via the
+  validation pipeline (`CLIENT-15`); it never re-implements signature/claim checks.
+* *Engine → commons* (transitive): all outbound IdP HTTP goes through commons transport; the
+  engine adds no HTTP, no SSRF/TLS logic (`COMMONS-1`–`COMMONS-8`).
+* *Engine throws, edge renders*: the pure-Java engine throws commons typed exceptions
+  (`COMMONS-9`); only the HTTP edge produces problem+json (`CLIENT-20`, `COMMONS-10`).
+* *Engine ≠ BFF*: the browser session / cookie layer is out of the engine entirely
+  (`CLIENT-19`).
+
+== Reference & replacement target: portal-authentication-oauth
+
+[NOTE]
+====
+*Design reference only.* `cui-portal-core`'s
+`modules/authentication/portal-authentication-oauth` is an existing confidential server-side
+OIDC client (CDI + MicroProfile Config + RESTEasy/JAX-RS) — effectively a BFF-style RP that
+already implements most of the in-scope flow (auth-code + PKCE `S256`, `state`, light
+`nonce`, `client_credentials`, refresh, discovery, userinfo, RP-initiated logout with
+`id_token_hint`; tokens held in the portal session).
+
+It grounds this capability's scope and is the *eventual replacement target* — the engine
+would supersede it via a thin portal adapter preserving the portal contract (`Oauth2Service`,
+`Oauth2AuthenticationFacade`, `OauthRedirector`, `OidcRpInitiatedLogoutParams`, result type
+`AuthenticatedUserInfo`; config namespace `authentication.oidc.*`). That replacement — the
+adapter and its integration tests — is *future work beyond Plans 01–06*; no current plan
+touches it. The modernization deltas it motivates (cryptographic ID-token validation via the
+validation module, `iss` mix-up defence, `private_key_jwt`/mTLS, PAR, DPoP/mTLS
+sender-constraining, stronger `nonce`, commons-hardened HTTP with SSRF defence) are each
+captured as sourced `CLIENT-N` requirements above.
+====
+
+== See also
+
+* xref:requirements.adoc[Client Requirements] — `CLIENT-N`, grouped by aspect
+* xref:threat-model.adoc[Client Threat Model]
+* xref:best-practices.adoc[Client Best Practices]
+* xref:specification/retrieval-flow.adoc[Retrieval & flow specification]
+* xref:specification/step-up-and-logout.adoc[Step-up & logout specification]
+* xref:specification/token-handling.adoc[Token-handling specification]
+* xref:../oidc/04-client-spec/README.adoc[Plan 04 — Client Spec]

--- a/doc/client/best-practices.adoc
+++ b/doc/client/best-practices.adoc
@@ -1,0 +1,147 @@
+= Client Best Practices
+:toc: left
+:toclevels: 3
+:toc-title: Table of Contents
+:sectnums:
+:source-highlighter: highlight.js
+
+== Overview
+
+_See xref:requirements.adoc[Client Requirements] and xref:threat-model.adoc[Threat Model]._
+
+A normative, sourced checklist for the server-side confidential-client engine. Each item is
+a MUST/SHOULD drawn from the standards catalogued in xref:references.adoc[References], traces
+to a xref:requirements.adoc[requirement] and a xref:threat-model.adoc[threat], and reflects
+the *most-secure current subset* principle: current standards only (the BCP, the OAuth 2.1
+direction, Browser-Based-Apps BFF guidance, FAPI 2.0 where it raises the bar), and no
+capability included merely because "the spec allows it".
+
+The checklist is organized by aspect. Transport hardening (TLS, SSRF, timeouts, JWKS
+caching) is *owned by* xref:../commons/requirements.adoc[commons] (`COMMONS-1`–`COMMONS-8`) —
+the client uses it and adds no HTTP of its own; the transport row records that boundary.
+
+== Retrieval & flow
+
+[cols="3,1,1", options="header"]
+|===
+| Practice (normative) | Source | Traces to
+
+| Use the confidential-client *authorization-code flow, server-side*; never implicit or
+  hybrid. Tokens are retrieved by the backend and never exposed to the browser.
+| https://www.rfc-editor.org/rfc/rfc9700#section-2.1[RFC 9700 §2.1], https://www.rfc-editor.org/rfc/rfc9700#section-2.1.2[§2.1.2], https://datatracker.ietf.org/doc/html/draft-ietf-oauth-browser-based-apps[Browser-Based Apps]
+| xref:requirements.adoc#CLIENT-1[CLIENT-1] / xref:threat-model.adoc#T-URL-LEAK[T-URL-LEAK]
+
+| Always use *PKCE `S256`*; confirm the AS advertises `S256`; refuse a `plain` or non-PKCE
+  downgrade.
+| https://www.rfc-editor.org/rfc/rfc7636[RFC 7636], https://www.rfc-editor.org/rfc/rfc9700#section-4.8[RFC 9700 §4.8]
+| xref:requirements.adoc#CLIENT-2[CLIENT-2] / xref:threat-model.adoc#T-PKCE-DOWNGRADE[T-PKCE-DOWNGRADE]
+
+| Restrict grants to the *secure subset* — `authorization_code`, `refresh_token`,
+  `client_credentials` (token-exchange only where a delegation use-case needs it). No ROPC,
+  no implicit.
+| https://www.rfc-editor.org/rfc/rfc9700#section-2.4[RFC 9700 §2.4], https://www.rfc-editor.org/rfc/rfc8693[RFC 8693]
+| xref:requirements.adoc#CLIENT-3[CLIENT-3]
+
+| Use the *strongest client authentication the AS offers* — `private_key_jwt` (RFC 7523) or
+  mTLS (RFC 8705) over `client_secret`; secrets only over TLS, never in a URL; protect at
+  rest; never log.
+| https://www.rfc-editor.org/rfc/rfc7523[RFC 7523], https://www.rfc-editor.org/rfc/rfc8705[RFC 8705], https://www.rfc-editor.org/rfc/rfc9700#section-2.2[RFC 9700 §2.2]
+| xref:requirements.adoc#CLIENT-4[CLIENT-4] / xref:threat-model.adoc#T-CLIENT-CRED[T-CLIENT-CRED]
+
+| Defeat callback CSRF with a *session-bound `state`*; reject a missing / mismatched value.
+| https://www.rfc-editor.org/rfc/rfc9700#section-4.7[RFC 9700 §4.7]
+| xref:requirements.adoc#CLIENT-5[CLIENT-5] / xref:threat-model.adoc#T-CSRF[T-CSRF]
+
+| For OIDC, send a *session-bound `nonce`* and verify it against the ID token — code/token
+  injection defence.
+| https://openid.net/specs/openid-connect-core-1_0.html#NonceNotes[OIDC Core §15.5.2], https://www.rfc-editor.org/rfc/rfc9700#section-4.5[RFC 9700 §4.5]
+| xref:requirements.adoc#CLIENT-6[CLIENT-6] / xref:threat-model.adoc#T-CODE-INJECTION[T-CODE-INJECTION]
+
+| Register and send a single *exact `redirect_uri`*; rely on exact string matching only.
+| https://www.rfc-editor.org/rfc/rfc9700#section-4.1[RFC 9700 §4.1]
+| xref:requirements.adoc#CLIENT-7[CLIENT-7] / xref:threat-model.adoc#T-REDIRECT[T-REDIRECT]
+
+| With multiple authorization servers, apply *mix-up defence*: validate the `iss` response
+  parameter (RFC 9207) and/or use a distinct `redirect_uri` per AS.
+| https://www.rfc-editor.org/rfc/rfc9207[RFC 9207], https://www.rfc-editor.org/rfc/rfc9700#section-4.4[RFC 9700 §4.4]
+| xref:requirements.adoc#CLIENT-8[CLIENT-8] / xref:threat-model.adoc#T-MIXUP[T-MIXUP]
+
+| *Prefer PAR* where advertised — push authorization parameters over the back channel; drive
+  the redirect with `request_uri`. Mandatory under FAPI 2.0.
+| https://www.rfc-editor.org/rfc/rfc9126[RFC 9126], https://openid.net/specs/fapi-2_0-security-profile.html[FAPI 2.0]
+| xref:requirements.adoc#CLIENT-10[CLIENT-10]
+
+| *Sender-constrain retrieved tokens* with DPoP or mTLS wherever the AS supports it; preserve
+  the binding through storage and refresh.
+| https://www.rfc-editor.org/rfc/rfc9449[RFC 9449], https://www.rfc-editor.org/rfc/rfc8705[RFC 8705], https://openid.net/specs/fapi-2_0-security-profile.html[FAPI 2.0]
+| xref:requirements.adoc#CLIENT-11[CLIENT-11] / xref:threat-model.adoc#T-TOKEN-REPLAY[T-TOKEN-REPLAY]
+
+| Support *step-up*: request `acr_values` / `max_age`; honour the
+  `insufficient_user_authentication` challenge; verify the resulting `acr` / `auth_time`.
+| https://www.rfc-editor.org/rfc/rfc9470[RFC 9470]
+| xref:requirements.adoc#CLIENT-12[CLIENT-12] / xref:threat-model.adoc#T-STEPUP[T-STEPUP]
+
+| *RP-initiated logout* with `id_token_hint`, exact-matched `post_logout_redirect_uri`, bound
+  `state`, and revocation of held tokens.
+| https://openid.net/specs/openid-connect-rpinitiated-1_0.html[OIDC RP-Initiated Logout]
+| xref:requirements.adoc#CLIENT-13[CLIENT-13] / xref:threat-model.adoc#T-LOGOUT[T-LOGOUT]
+
+| *Validate the token-endpoint response* (`token_type`, expected artifacts, response `iss`
+  where supported); keep tokens / codes out of URLs — `form_post` + token-endpoint exchange.
+| https://www.rfc-editor.org/rfc/rfc9700#section-4.3[RFC 9700 §4.3], https://www.rfc-editor.org/rfc/rfc9207[RFC 9207]
+| xref:requirements.adoc#CLIENT-14[CLIENT-14] / xref:threat-model.adoc#T-URL-LEAK[T-URL-LEAK]
+|===
+
+== Token
+
+[cols="3,1,1", options="header"]
+|===
+| Practice (normative) | Source | Traces to
+
+| *Validate every retrieved token* through the validation pipeline — signature, `iss`, `aud`,
+  `exp`, `iat` — before trust or storage. Do not re-implement or weaken validation.
+| https://www.rfc-editor.org/rfc/rfc9068[RFC 9068], https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation[OIDC Core §3.1.3.7]
+| xref:requirements.adoc#CLIENT-15[CLIENT-15] / xref:threat-model.adoc#T-AUD-CONFUSION[T-AUD-CONFUSION]
+
+| Validate the *ID token* cryptographically; for *userinfo*, verify the signature (if signed)
+  and *bind `sub`* to the ID token's `sub`. Never take identity from an unvalidated response.
+| https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation[OIDC Core §3.1.3.7], https://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse[OIDC Core §5.3.2]
+| xref:requirements.adoc#CLIENT-16[CLIENT-16] / xref:threat-model.adoc#T-IDTOKEN-INTEGRITY[T-IDTOKEN-INTEGRITY]
+
+| Hold tokens *server-side*; *rotate refresh tokens* and *revoke on misuse*; protect at rest;
+  prefer *short-lived access tokens*; revoke held tokens at logout.
+| https://www.rfc-editor.org/rfc/rfc9700#section-4.14[RFC 9700 §4.14], https://www.rfc-editor.org/rfc/rfc7009[RFC 7009]
+| xref:requirements.adoc#CLIENT-17[CLIENT-17] / xref:threat-model.adoc#T-REFRESH-THEFT[T-REFRESH-THEFT]
+
+| Keep the *sender-constraint intact* across storage, refresh and forwarding; keep storage
+  minimal.
+| https://www.rfc-editor.org/rfc/rfc9449[RFC 9449], https://www.rfc-editor.org/rfc/rfc8705[RFC 8705]
+| xref:requirements.adoc#CLIENT-18[CLIENT-18] / xref:threat-model.adoc#T-CONSTRAINT-LOSS[T-CONSTRAINT-LOSS]
+
+| Keep the engine seam *identical for both BFF token-binding shapes* (server-side store /
+  encrypted cookie); do not force the choice or implement the browser session layer here.
+| https://datatracker.ietf.org/doc/html/draft-ietf-oauth-browser-based-apps[Browser-Based Apps]
+| xref:requirements.adoc#CLIENT-19[CLIENT-19]
+|===
+
+== Transport (owned by commons — boundary note)
+
+[cols="3,1", options="header"]
+|===
+| Practice | Owner
+
+| Enforced TLS 1.2+, SSRF defence on advertised URLs, connect/read timeouts and response-size
+  limits, JWKS cache / rotation. *The client uses the commons transport and adds none of its
+  own HTTP.*
+| xref:../commons/requirements.adoc#COMMONS-1[COMMONS-1]–xref:../commons/requirements.adoc#COMMONS-8[COMMONS-8]
+
+| HTTP-surfaced client errors render as `application/problem+json` (RFC 9457) at the edge; the
+  engine throws typed exceptions only. Inbound IdP errors are normalized, not passed through.
+| xref:../commons/requirements.adoc#COMMONS-9[COMMONS-9]–xref:../commons/requirements.adoc#COMMONS-12[COMMONS-12] (xref:requirements.adoc#CLIENT-20[CLIENT-20])
+|===
+
+== See also
+
+* xref:requirements.adoc[Client Requirements] — `CLIENT-N`, grouped by aspect
+* xref:threat-model.adoc[Client Threat Model]
+* xref:references.adoc[References]

--- a/doc/client/references.adoc
+++ b/doc/client/references.adoc
@@ -1,0 +1,160 @@
+= Client References
+:toc: left
+:toclevels: 3
+:toc-title: Table of Contents
+:sectnums:
+:source-highlighter: highlight.js
+
+== Overview
+
+Bibliography for the `client` capability — the server-side confidential-client *token
+retrieval*, *flow integrity* and *token lifecycle* engine on which a Backend-For-Frontend
+(BFF) is built (see xref:architecture.adoc[Architecture]).
+
+The client capability owns two aspects — *Retrieval & flow* (net-new) and *Token* (the
+server-side lifecycle delta on top of the validation module). Its sources are therefore the
+OAuth 2.0 Security BCP, the browser-based-apps / BFF guidance, and the flow-integrity,
+client-authentication, sender-constraining, step-up and RP-initiated-logout standards.
+
+Standards owned by other capabilities are *cited here, not restated*:
+
+* *Transport* standards — discovery (RFC 8414, OIDC Discovery), JWKS (RFC 7517), the
+  extended IdP endpoints (token, userinfo, revocation, introspection, end-session, PAR
+  transport) and the *RFC 9457 error model* — belong to
+  xref:../commons/references.adoc[commons] (`COMMONS-N`). The client *uses* them and cites
+  the `COMMONS-N` requirements; it does not respecify fetching, TLS, SSRF or the problem+json
+  rendering.
+* *Token-trust* standards — signature/algorithm policy (RFC 8725), JWT access tokens
+  (RFC 9068), DPoP proof validation (RFC 9449), OIDC ID-token validation (OIDC Core) — belong
+  to the xref:../validation/requirements.adoc[validation requirements] and are *inherited* by
+  every token this client retrieves. The client adds only the acquisition/lifecycle delta.
+
+== Standards new to the client capability (normative)
+
+These standards are introduced by the client capability and are not part of the validation
+or commons bibliographies.
+
+[cols="1,3,1", options="header"]
+|===
+| Reference | Title | Aspect
+
+| https://www.rfc-editor.org/rfc/rfc9700[RFC 9700]
+| Best Current Practice for OAuth 2.0 Security — January 2025 *(primary BCP)*
+| Retrieval & flow
+
+| https://datatracker.ietf.org/doc/html/draft-ietf-oauth-browser-based-apps[OAuth 2.0 for Browser-Based Apps]
+| Server-side confidential client / BFF (stateful & stateless) guidance — IETF draft
+| Retrieval & flow (BFF groundwork)
+
+| https://www.rfc-editor.org/rfc/rfc6819[RFC 6819]
+| OAuth 2.0 Threat Model and Security Considerations — January 2013
+| Retrieval & flow (threat model)
+
+| https://www.rfc-editor.org/rfc/rfc7636[RFC 7636]
+| Proof Key for Code Exchange (PKCE) — September 2015
+| Retrieval & flow
+
+| https://www.rfc-editor.org/rfc/rfc8693[RFC 8693]
+| OAuth 2.0 Token Exchange — January 2020 *(candidate grant)*
+| Retrieval & flow (grants)
+
+| https://www.rfc-editor.org/rfc/rfc7523[RFC 7523]
+| JWT Profile for OAuth 2.0 Client Authentication and Authorization Grants (`private_key_jwt`) — May 2015
+| Retrieval & flow (client auth)
+
+| https://www.rfc-editor.org/rfc/rfc8705[RFC 8705]
+| OAuth 2.0 Mutual-TLS Client Authentication and Certificate-Bound Access Tokens — February 2021
+| Retrieval & flow (client auth, sender-constraining)
+
+| https://www.rfc-editor.org/rfc/rfc9126[RFC 9126]
+| OAuth 2.0 Pushed Authorization Requests (PAR) — September 2021
+| Retrieval & flow
+
+| https://www.rfc-editor.org/rfc/rfc9207[RFC 9207]
+| OAuth 2.0 Authorization Server Issuer Identification (`iss`, mix-up defence) — March 2022
+| Retrieval & flow
+
+| https://www.rfc-editor.org/rfc/rfc9470[RFC 9470]
+| OAuth 2.0 Step-Up Authentication Challenge Protocol — September 2023
+| Retrieval & flow (step-up)
+
+| https://openid.net/specs/openid-connect-rpinitiated-1_0.html[OpenID Connect RP-Initiated Logout 1.0]
+| RP-initiated logout via `end_session_endpoint` (`id_token_hint`, `post_logout_redirect_uri`, `state`)
+| Retrieval & flow (logout)
+|===
+
+== Reused — cite, don't restate
+
+These standards are already documented by the xref:../validation/requirements.adoc#_referenced_standards[validation]
+or xref:../commons/references.adoc[commons] bibliographies and apply unchanged here. The
+client cites them; it does not re-enumerate them.
+
+[cols="1,3,1", options="header"]
+|===
+| Reference | Title | Owned by
+
+| https://www.rfc-editor.org/rfc/rfc6749[RFC 6749]
+| OAuth 2.0 Authorization Framework — incl. §4.1 auth-code, §4.4 client credentials, §5.2 errors
+| validation / commons
+
+| https://openid.net/specs/openid-connect-core-1_0.html[OpenID Connect Core 1.0]
+| Authorization-code flow, `nonce`, `at_hash`, ID-token validation (§3.1.3.7), userinfo (§5.3)
+| validation
+
+| https://www.rfc-editor.org/rfc/rfc8725[RFC 8725]
+| JSON Web Token Best Current Practices — signature/algorithm policy for retrieved tokens
+| validation
+
+| https://www.rfc-editor.org/rfc/rfc9068[RFC 9068]
+| JWT Profile for OAuth 2.0 Access Tokens — claim set of retrieved access tokens
+| validation
+
+| https://www.rfc-editor.org/rfc/rfc9449[RFC 9449]
+| OAuth 2.0 Demonstrating Proof of Possession (DPoP) — proof validation of sender-constrained tokens
+| validation
+
+| https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1[OAuth 2.1 Authorization Framework]
+| Consolidated direction — mandatory PKCE, removal of implicit / ROPC, exact redirect-URI match
+| validation
+
+| https://openid.net/specs/fapi-2_0-security-profile.html[FAPI 2.0 Security Profile]
+| Raises the bar — PAR, sender-constrained tokens, strong client auth
+| validation
+
+| https://www.rfc-editor.org/rfc/rfc7517[RFC 7517]
+| JSON Web Key (JWK / JWKS) — key material for `private_key_jwt` and token validation
+| validation / commons
+
+| https://www.rfc-editor.org/rfc/rfc9457[RFC 9457]
+| Problem Details for HTTP APIs — the client engine throws typed exceptions; edges render problem+json
+| commons
+
+| https://www.rfc-editor.org/rfc/rfc8414[RFC 8414]
+| OAuth 2.0 Authorization Server Metadata — advertises the endpoints and PKCE / auth-method support the flow relies on
+| commons
+|===
+
+== Supporting sources (informative)
+
+[cols="1,3", options="header"]
+|===
+| Reference | Relevance
+
+| https://cheatsheetseries.owasp.org/cheatsheets/OAuth2_Cheat_Sheet.html[OWASP OAuth2 Cheat Sheet]
+| Practitioner checklist for confidential-client flow hardening
+
+| https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/05-Authorization_Testing/05-Testing_for_OAuth_Weaknesses[OWASP WSTG — Testing for OAuth Weaknesses]
+| Test angles for redirect-URI, `state`/CSRF, code-injection and mix-up weaknesses
+
+| `cui-portal-core` — `modules/authentication/portal-authentication-oauth`
+| Real-world confidential server-side OIDC client (CDI + MicroProfile Config + RESTEasy); the
+  design reference and eventual replacement target (future work beyond Plans 01–06)
+|===
+
+== See also
+
+* xref:requirements.adoc[Client Requirements] — `CLIENT-N`, grouped by aspect
+* xref:threat-model.adoc[Client Threat Model]
+* xref:best-practices.adoc[Client Best Practices]
+* xref:architecture.adoc[Client Architecture]
+* xref:specification/retrieval-flow.adoc[Retrieval & flow specification] · xref:specification/step-up-and-logout.adoc[Step-up & logout specification] · xref:specification/token-handling.adoc[Token-handling specification]

--- a/doc/client/requirements.adoc
+++ b/doc/client/requirements.adoc
@@ -1,0 +1,413 @@
+= Client Requirements
+:toc: left
+:toclevels: 3
+:toc-title: Table of Contents
+:sectnums:
+:source-highlighter: highlight.js
+
+== Overview
+
+Functional and non-functional requirements for the `client` capability — the server-side
+*confidential-client* engine that *retrieves tokens*, *holds and refreshes them
+server-side*, and drives the OAuth 2.0 / OpenID Connect *flows* on top of the
+xref:../commons/requirements.adoc[commons] transport. The engine is designed so a
+*Backend-For-Frontend (BFF)* can be built on top of it (see
+xref:architecture.adoc[Architecture]); it is not itself a BFF.
+
+Security is the leading topic: this is the *smallest, most secure current subset* of
+confidential-client OAuth 2.0 / OpenID Connect, not a spec-complete implementation. A
+capability is in scope only if it is required for secure operation or is the secure way to
+perform a needed operation — "the spec allows it" is not, by itself, a reason to include it
+(xref:best-practices.adoc[Best Practices]). Legacy / discouraged mechanisms are refused and
+sourced (<<_security_exclusions_legacy_discouraged>>).
+
+Requirement IDs use the `CLIENT-N` scheme (per xref:../oidc/02-doc-structure/README.adoc[Plan 02]),
+*grouped by aspect*: xref:#_retrieval_flow_requirements[Retrieval & flow] (net-new) and
+xref:#_token_requirements[Token] (the server-side lifecycle delta). IDs are stable
+identifiers referenced across documentation and the xref:threat-model.adoc[threat model];
+they are not sequential across groups. Every normative requirement traces to a threat it
+mitigates or is the secure way to perform a needed operation.
+
+=== Document Navigation
+
+* xref:architecture.adoc[Architecture] — the client/BFF engine seam and its boundaries
+* xref:threat-model.adoc[Threat Model] — attack catalog per aspect, each entry sourced
+* xref:best-practices.adoc[Best Practices] — the normative, sourced checklist
+* xref:references.adoc[References] — bibliography
+* xref:specification/retrieval-flow.adoc[Retrieval & flow spec] · xref:specification/step-up-and-logout.adoc[Step-up & logout spec] · xref:specification/token-handling.adoc[Token-handling spec]
+
+=== Referenced Standards
+
+New standards are catalogued in xref:references.adoc[References]. Standards reused from the
+validation bibliography (RFC 6749, OIDC Core, RFC 8725, RFC 9068, RFC 9449, OAuth 2.1,
+FAPI 2.0) and owned by commons (transport standards, RFC 9457) are cited inline below and
+not restated here.
+
+=== Aspect separation and what is referenced, not duplicated
+
+[cols="1,3", options="header"]
+|===
+| Not owned here | Where it lives
+
+| *Outbound IdP HTTP* — discovery, JWKS, token, userinfo, revocation, introspection,
+  end-session, PAR transport; TLS, SSRF defence, timeouts / size-limits, resilience.
+| xref:../commons/requirements.adoc[commons] (`COMMONS-1`–`COMMONS-8`). The client *uses*
+  the transport and cites `COMMONS-N`; it issues no outbound IdP HTTP of its own and adds no
+  SSRF/TLS controls.
+
+| *Token-signature / algorithm policy* — rejecting `alg=none`, HMAC and weak/short-key
+  algorithms; asymmetric signature verification; DPoP *proof* validation.
+| xref:../validation/requirements.adoc#VALIDATION-1[validation] (`VALIDATION-1.3`,
+  `VALIDATION-8.7`, RFC 8725). Inherited by every retrieved token; not restated here.
+
+| *RFC 9457 problem+json rendering* — the HTTP-edge mapping of typed exceptions.
+| xref:../commons/requirements.adoc#COMMONS-10[commons] (`COMMONS-10`). The client engine
+  throws typed exceptions (`COMMONS-9`); `token-sheriff-client-quarkus` and any RESTEasy edge
+  render problem+json (<<CLIENT-20>>).
+|===
+
+== Retrieval & flow requirements
+
+_The genuinely net-new aspect this capability owns: the confidential-client authorization-code
++ PKCE flow (server-side) and the use of the token endpoint. See
+xref:specification/retrieval-flow.adoc[Retrieval & flow specification] and
+xref:specification/step-up-and-logout.adoc[Step-up & logout specification]._
+
+[#CLIENT-1]
+=== CLIENT-1: Confidential-client authorization-code flow (server-side)
+
+The engine MUST implement the OAuth 2.0 authorization-code flow as a *confidential client*,
+entirely server-side: the authorization request is constructed with `response_type=code`,
+and the resulting code is exchanged for tokens at the token endpoint *by the backend*. No
+token is ever exposed to the browser. `response_mode=form_post` (or plain query on the
+back-channel exchange) is used so tokens never appear in a URL. This is the recommended
+pattern for browser-based apps (the BFF), superseding in-browser public-client OAuth.
+
+* Source: https://www.rfc-editor.org/rfc/rfc6749#section-4.1[RFC 6749 §4.1], https://www.rfc-editor.org/rfc/rfc9700#section-2.1[RFC 9700 §2.1], https://datatracker.ietf.org/doc/html/draft-ietf-oauth-browser-based-apps[OAuth 2.0 for Browser-Based Apps].
+
+[#CLIENT-2]
+=== CLIENT-2: PKCE with `S256`, and downgrade defence
+
+Every authorization-code request MUST use PKCE with the `S256` code-challenge method;
+`plain` MUST NOT be used. The engine MUST confirm the authorization server advertises
+`S256` support (`code_challenge_methods_supported` in discovery) and MUST NOT silently fall
+back to a non-PKCE or `plain` request — a PKCE downgrade is refused.
+
+* Source: https://www.rfc-editor.org/rfc/rfc7636[RFC 7636], https://www.rfc-editor.org/rfc/rfc9700#section-2.1.1[RFC 9700 §2.1.1], https://www.rfc-editor.org/rfc/rfc9700#section-4.8[RFC 9700 §4.8] (PKCE downgrade).
+
+[#CLIENT-3]
+=== CLIENT-3: Token-endpoint grants (secure subset)
+
+The engine MUST support the token-endpoint grants needed for a confidential BFF engine:
+`authorization_code` (with PKCE, <<CLIENT-2>>), `refresh_token` (server-side refresh,
+<<CLIENT-17>>), and `client_credentials` (service-to-service). Token Exchange
+(`urn:ietf:params:oauth:grant-type:token-exchange`, RFC 8693) is a *candidate* grant,
+included only where a delegation use-case requires it. The `password` (ROPC) and `implicit`
+grants MUST NOT be implemented (<<_security_exclusions_legacy_discouraged>>).
+
+* Source: https://www.rfc-editor.org/rfc/rfc6749#section-4.1[RFC 6749 §4.1], https://www.rfc-editor.org/rfc/rfc6749#section-4.4[RFC 6749 §4.4] (client credentials), https://www.rfc-editor.org/rfc/rfc8693[RFC 8693] (token exchange, candidate).
+
+[#CLIENT-4]
+=== CLIENT-4: Strong token-endpoint client authentication
+
+The engine MUST authenticate to the token endpoint (and PAR / revocation / introspection
+endpoints) and MUST prefer the *strongest method the authorization server offers*:
+`private_key_jwt` (RFC 7523) or mTLS (RFC 8705) over a shared `client_secret`. When a
+`client_secret` is used it MUST be sent only over TLS (<<CLIENT-14>>, transport TLS is
+`COMMONS-2`) and via `client_secret_basic` / `client_secret_post` — never in a URL. Client
+credentials MUST be protected at rest and MUST NOT be logged.
+
+* Source: https://www.rfc-editor.org/rfc/rfc7523[RFC 7523], https://www.rfc-editor.org/rfc/rfc8705[RFC 8705], https://www.rfc-editor.org/rfc/rfc9700#section-2.2[RFC 9700 §2.2] (client authentication), https://www.rfc-editor.org/rfc/rfc6749#section-2.3[RFC 6749 §2.3].
+
+[#CLIENT-5]
+=== CLIENT-5: Session-bound `state` (callback CSRF defence)
+
+Every authorization request MUST carry a `state` value bound to the initiating user session
+and unguessable. On the callback the engine MUST reject any response whose `state` is
+missing or does not match the session-bound value, defeating CSRF on the redirect endpoint.
+
+* Source: https://www.rfc-editor.org/rfc/rfc9700#section-4.7[RFC 9700 §4.7] (CSRF), https://www.rfc-editor.org/rfc/rfc6749#section-10.12[RFC 6749 §10.12].
+
+[#CLIENT-6]
+=== CLIENT-6: `nonce` binding (OpenID Connect)
+
+For OpenID Connect requests the engine MUST send a fresh, session-bound `nonce` and MUST
+verify it against the `nonce` claim of the returned ID token, rejecting a missing or
+mismatched value. This binds the ID token to the authorization request and is a second
+defence against code / token injection.
+
+* Source: https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest[OIDC Core §3.1.2.1], https://openid.net/specs/openid-connect-core-1_0.html#NonceNotes[OIDC Core §15.5.2], https://www.rfc-editor.org/rfc/rfc9700#section-4.5[RFC 9700 §4.5].
+
+[#CLIENT-7]
+=== CLIENT-7: Exact redirect-URI matching
+
+The `redirect_uri` sent in the authorization request MUST be registered with the
+authorization server and MUST be matched by *exact string comparison* — no pattern,
+wildcard, prefix or substring matching. The engine sends a single, exact, pre-registered
+`redirect_uri`.
+
+* Source: https://www.rfc-editor.org/rfc/rfc9700#section-4.1[RFC 9700 §4.1], https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1[OAuth 2.1] (exact redirect-URI matching).
+
+[#CLIENT-8]
+=== CLIENT-8: Issuer identification / mix-up defence (`iss`)
+
+When more than one authorization server is configured, the engine MUST defend against
+mix-up attacks: it MUST validate the `iss` authorization-response parameter (RFC 9207)
+against the issuer it initiated the flow with, and/or use a distinct `redirect_uri` per
+authorization server. A response whose `iss` does not match the initiating issuer MUST be
+rejected before the code is exchanged.
+
+* Source: https://www.rfc-editor.org/rfc/rfc9207[RFC 9207], https://www.rfc-editor.org/rfc/rfc9700#section-4.4[RFC 9700 §4.4] (mix-up).
+
+[#CLIENT-9]
+=== CLIENT-9: Authorization-code injection defence
+
+The engine MUST bind the authorization code to the browser session that requested it, so a
+code injected by an attacker cannot be redeemed: PKCE (`S256`, <<CLIENT-2>>) binds the code
+to the `code_verifier`, and for OpenID Connect the `nonce` (<<CLIENT-6>>) binds the ID
+token. A code presented without the matching `code_verifier` / session context MUST be
+rejected at exchange.
+
+* Source: https://www.rfc-editor.org/rfc/rfc9700#section-4.5[RFC 9700 §4.5] (authorization-code injection), https://www.rfc-editor.org/rfc/rfc7636[RFC 7636].
+
+[#CLIENT-10]
+=== CLIENT-10: Pushed Authorization Requests (PAR)
+
+Where the authorization server advertises PAR (`pushed_authorization_request_endpoint`), the
+engine SHOULD push the authorization request parameters over the back channel and drive the
+front-channel redirect with the returned `request_uri`, so authorization parameters are not
+exposed or tamperable in the browser. PAR is required by FAPI 2.0 and preferred by the BCP.
+
+* Source: https://www.rfc-editor.org/rfc/rfc9126[RFC 9126], https://openid.net/specs/fapi-2_0-security-profile.html[FAPI 2.0] (PAR mandatory), https://www.rfc-editor.org/rfc/rfc9700#section-2.1[RFC 9700 §2.1].
+
+[#CLIENT-11]
+=== CLIENT-11: Requesting sender-constrained tokens (DPoP / mTLS)
+
+The engine MUST be able to *request* sender-constrained tokens at the token endpoint — DPoP
+(RFC 9449) by presenting a DPoP proof, or mTLS (RFC 8705) certificate-bound tokens — so
+retrieved tokens cannot be replayed by a bearer that stole them. The *validation* of the
+resulting binding is inherited from the validation module (`VALIDATION-8.7`); this
+requirement is the client-side delta of *asking for* the constraint and preserving it
+(<<CLIENT-18>>).
+
+* Source: https://www.rfc-editor.org/rfc/rfc9449[RFC 9449], https://www.rfc-editor.org/rfc/rfc8705[RFC 8705], https://www.rfc-editor.org/rfc/rfc9700#section-4.10[RFC 9700 §4.10], https://openid.net/specs/fapi-2_0-security-profile.html[FAPI 2.0].
+
+[#CLIENT-12]
+=== CLIENT-12: Step-up authentication challenge (RFC 9470)
+
+The engine MUST support step-up authentication: it MUST be able to request a required
+authentication assurance (`acr_values` and/or `max_age`) on the authorization request, and
+MUST handle a resource server's `insufficient_user_authentication` challenge (RFC 9470) by
+re-driving authorization with the requested `acr_values` / `max_age` and then verifying the
+resulting `acr` / `auth_time` before treating the operation as sufficiently authenticated.
+
+* Source: https://www.rfc-editor.org/rfc/rfc9470[RFC 9470], https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest[OIDC Core §3.1.2.1] (`acr_values`, `max_age`).
+
+[#CLIENT-13]
+=== CLIENT-13: RP-initiated logout
+
+The engine MUST support RP-initiated logout: it triggers the IdP `end_session_endpoint`
+sending `id_token_hint`, an *exact-matched* registered `post_logout_redirect_uri`, and a
+session-bound `state`. Logout MUST also revoke the tokens it holds (<<CLIENT-17>>) so a
+logout does not leave live tokens behind. Front-/back-channel logout *receivers* and the
+Session-Management iframe are the BFF application's concern, not this engine's.
+
+* Source: https://openid.net/specs/openid-connect-rpinitiated-1_0.html[OpenID Connect RP-Initiated Logout 1.0], https://www.rfc-editor.org/rfc/rfc9700#section-4.1[RFC 9700 §4.1] (open-redirect on `post_logout_redirect_uri`).
+
+[#CLIENT-14]
+=== CLIENT-14: Token-response and no-secrets-in-URL handling
+
+The engine MUST validate the token-endpoint response before use: the `token_type`, the
+presence of the expected artifacts, and — where the authorization server supports it — the
+issuer identity of the response. Tokens and authorization codes MUST NOT be transmitted in
+URL query or fragment components; the code is exchanged at the token endpoint and the
+authorization response uses `form_post`. All token-endpoint traffic relies on the transport
+TLS enforcement owned by commons (`COMMONS-2`).
+
+* Source: https://www.rfc-editor.org/rfc/rfc9700#section-4.3[RFC 9700 §4.3] (credentials in URLs), https://www.rfc-editor.org/rfc/rfc9207[RFC 9207], https://www.rfc-editor.org/rfc/rfc6749#section-5.1[RFC 6749 §5.1] (token response).
+
+== Token requirements
+
+_The server-side lifecycle delta on top of the validation module — storage, refresh,
+revocation, sender-constraint preservation, and validation of ID-token / userinfo responses.
+References the validation module; adds no signature/algorithm policy. See
+xref:specification/token-handling.adoc[Token-handling specification]._
+
+[#CLIENT-15]
+=== CLIENT-15: Validate every retrieved token via the validation pipeline
+
+Every token the engine retrieves (access token, ID token) MUST be validated through the
+xref:../validation/requirements.adoc[validation] pipeline — signature, `iss`, `aud`, `exp`,
+`iat` — before it is trusted or stored. The client MUST NOT re-implement or weaken any part
+of that validation; the algorithm / signature policy (`VALIDATION-1.3`, RFC 8725) is
+inherited unchanged. This is the primary validation synergy: tokens are cryptographically
+validated, not merely received.
+
+* Source: https://www.rfc-editor.org/rfc/rfc9068[RFC 9068], https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation[OIDC Core §3.1.3.7], xref:../validation/requirements.adoc#VALIDATION-1[VALIDATION-1].
+
+[#CLIENT-16]
+=== CLIENT-16: ID-token and userinfo validation
+
+The ID token MUST be validated per OpenID Connect (signature via the validation pipeline;
+`iss`, `aud`, `azp`, `exp`, `nonce` (<<CLIENT-6>>) and, where present, `at_hash`). When the
+userinfo endpoint is used, the response MUST be validated (signature if signed) and its
+`sub` MUST be bound to the `sub` of the validated ID token — a userinfo response whose `sub`
+does not match MUST be rejected. Identity MUST NOT be taken from an unvalidated userinfo
+response.
+
+* Source: https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation[OIDC Core §3.1.3.7], https://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse[OIDC Core §5.3.2] (userinfo `sub` binding).
+
+[#CLIENT-17]
+=== CLIENT-17: Server-side token lifecycle — storage, refresh, revocation
+
+Retrieved tokens are held *server-side* and never returned to the browser in usable form
+(the BFF binding — server-side store or encrypted cookie — is the application's choice,
+<<CLIENT-19>>). The engine MUST: refresh access tokens with `refresh_token`, applying
+*refresh-token rotation* and *revoking on detected misuse / reuse*; revoke held tokens at
+logout (<<CLIENT-13>>) via the commons revocation transport (RFC 7009); protect tokens at
+rest; and prefer short-lived access tokens.
+
+* Source: https://www.rfc-editor.org/rfc/rfc9700#section-4.14[RFC 9700 §4.14] (refresh-token protection / rotation), https://www.rfc-editor.org/rfc/rfc7009[RFC 7009] (revocation), https://datatracker.ietf.org/doc/html/draft-ietf-oauth-browser-based-apps[Browser-Based Apps] (tokens held server-side).
+
+[#CLIENT-18]
+=== CLIENT-18: Preserve the sender-constraint through storage and forwarding
+
+Where a token is sender-constrained (DPoP or mTLS, <<CLIENT-11>>), the engine MUST keep the
+binding intact across server-side storage, refresh and any forwarding: the stored token
+stays associated with its proof key / certificate binding, and refresh preserves the
+constraint. Storage MUST be minimal — no wider copying of bound tokens than the lifecycle
+requires.
+
+* Source: https://www.rfc-editor.org/rfc/rfc9449[RFC 9449], https://www.rfc-editor.org/rfc/rfc8705[RFC 8705].
+
+[#CLIENT-19]
+=== CLIENT-19: BFF groundwork — enable either token-binding shape without forcing it
+
+The engine MUST NOT preclude *either* BFF token-binding deployment: a *stateful* BFF (opaque
+session-id cookie + server-side token store, backend proxies resource calls) or a *stateless*
+BFF (access token returned to the browser only inside an HttpOnly cookie encrypted with a
+server-side symmetric key). The engine seam — confidential-client retrieval, server-side
+lifecycle, validation — MUST be identical for both; the browser↔backend session cookie,
+symmetric-key management, backend-API CSRF and request proxying are the *BFF application's*
+concern and are *not* implemented here.
+
+* Source: https://datatracker.ietf.org/doc/html/draft-ietf-oauth-browser-based-apps[OAuth 2.0 for Browser-Based Apps] (stateful & stateless BFF).
+
+[#CLIENT-20]
+=== CLIENT-20: Errors via the commons typed-exception / RFC 9457 model
+
+The client engine (pure Java) MUST signal failure through the commons typed-exception
+hierarchy (`COMMONS-9`) and MUST NOT produce HTTP problem documents itself. HTTP-surfaced
+client errors MUST conform to the commons RFC 9457 error model: `token-sheriff-client-quarkus`
+(and any future RESTEasy edge, e.g. a portal adapter) maps the typed exceptions to
+`application/problem+json` (`COMMONS-10`), leaking no internal detail (`COMMONS-12`). Inbound
+IdP error responses are normalized by commons (`COMMONS-11`), not passed through verbatim.
+
+* Source: https://www.rfc-editor.org/rfc/rfc9457[RFC 9457], xref:../commons/requirements.adoc#COMMONS-9[COMMONS-9]–xref:../commons/requirements.adoc#COMMONS-12[COMMONS-12].
+
+== [[_security_exclusions_legacy_discouraged]] Security exclusions (legacy / discouraged, refused)
+
+Sourced non-goals *specific to the client capability*. The engine MUST NOT require or
+implement these. Each exclusion is threat-driven — it removes an acquisition/flow attack
+surface.
+
+[cols="2,3,1", options="header"]
+|===
+| Excluded | Reason | Source
+
+| *Implicit grant* (`response_type=token`)
+| Front-channel token exposure; superseded by confidential auth-code.
+| https://www.rfc-editor.org/rfc/rfc9700#section-2.1.2[RFC 9700 §2.1.2] (SHOULD NOT), removed in https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1[OAuth 2.1]
+
+| *Resource Owner Password Credentials (ROPC)* grant
+| Hands the client the user's password; no delegation.
+| https://www.rfc-editor.org/rfc/rfc9700#section-2.4[RFC 9700 §2.4] (MUST NOT), removed in OAuth 2.1
+
+| *Hybrid flows*
+| Unnecessary for a confidential BFF; re-introduce front-channel token exposure. Use plain `code`.
+| https://www.rfc-editor.org/rfc/rfc9700#section-2.1.2[RFC 9700 §2.1.2]
+
+| *In-browser token storage* (public-client OAuth)
+| The BFF holds tokens server-side precisely to avoid this.
+| https://datatracker.ietf.org/doc/html/draft-ietf-oauth-browser-based-apps[Browser-Based Apps]
+
+| *PKCE `plain`*
+| Offers no protection against a passive observer of the challenge; `S256` only.
+| https://www.rfc-editor.org/rfc/rfc7636#section-4.2[RFC 7636 §4.2], https://www.rfc-editor.org/rfc/rfc9700[RFC 9700]
+
+| *Tokens / codes in URL query or fragment*
+| Leak via history, logs, `Referer`. Use `form_post` + token-endpoint exchange.
+| https://www.rfc-editor.org/rfc/rfc9700#section-4.3[RFC 9700 §4.3]
+
+| *Weak client auth where `private_key_jwt`/mTLS is available; secrets over non-TLS*
+| Shared secrets are the weakest link; strong auth is available.
+| https://www.rfc-editor.org/rfc/rfc9700[RFC 9700], https://www.rfc-editor.org/rfc/rfc7523[RFC 7523], https://www.rfc-editor.org/rfc/rfc8705[RFC 8705]
+
+| *Unvalidated `jwks_uri` / metadata URLs* (SSRF)
+| Excluded here by *delegation*: SSRF defence on advertised URLs is owned by commons
+  (`COMMONS-3`); the client performs no outbound IdP HTTP of its own.
+| https://github.com/advisories/GHSA-7vw6-5q2f-7w5r[CVE-2026-1180], xref:../commons/requirements.adoc#COMMONS-3[COMMONS-3]
+|===
+
+NOTE: *Token-signature exclusions are not restated here.* Rejecting `alg=none`, HMAC and
+weak/short-key algorithms, and requiring asymmetric signature verification, is already
+mandated by the validation requirements (`VALIDATION-1.3`, RFC 8725) and inherited by every
+token this client retrieves (<<CLIENT-15>>). The client spec covers only the acquisition /
+flow exclusions above.
+
+== Non-functional requirements
+
+[#CLIENT-21]
+=== CLIENT-21: Framework-agnostic engine (pure Java)
+
+The engine MUST be pure Java, depending on `token-sheriff-validation` (which transitively
+provides the commons base layer) — no CDI, no MicroProfile Config, no JAX-RS in the engine
+itself. Framework bindings (Quarkus, and any RESTEasy/portal adapter) sit *outside* the
+engine, so the engine is reusable across framework contexts. The `client → validation`
+dependency direction is enforced by Maven once the module exists
+(xref:../oidc/05-client-module/README.adoc[Plan 05]).
+
+* Source: xref:../oidc/decision-oidc-module.adoc[Module Architecture decision] (client → validation, never the reverse).
+
+[#CLIENT-22]
+=== CLIENT-22: Thread safety and adversarial test coverage
+
+The engine MUST be thread-safe (shared per-issuer configuration, concurrent flows). Each
+`CLIENT-N` flow / token requirement MUST be exercised by unit tests driving the commons
+`generators` dispatchers in both default and *adversarial* modes (the token / userinfo /
+end-session / PAR dispatchers, `COMMONS-7`), plus real-IdP integration tests
+(xref:../oidc/06-implement/README.adoc[Plan 06]).
+
+* Source: https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/05-Authorization_Testing/05-Testing_for_OAuth_Weaknesses[OWASP WSTG — Testing for OAuth Weaknesses], xref:../commons/requirements.adoc#COMMONS-7[COMMONS-7].
+
+== Traceability
+
+Each requirement is threat-driven (xref:threat-model.adoc[threat model]), reflected in the
+sourced xref:best-practices.adoc[best-practices] checklist, and realized in a specification.
+
+[cols="1,2,2", options="header"]
+|===
+| Requirement | Threats (xref:threat-model.adoc[]) | Specification
+
+| CLIENT-1 | T-URL-LEAK | xref:specification/retrieval-flow.adoc[retrieval-flow]
+| CLIENT-2 | T-CODE-INJECTION, T-PKCE-DOWNGRADE | retrieval-flow
+| CLIENT-3 | T-CLIENT-CRED (grant hygiene) | retrieval-flow
+| CLIENT-4 | T-CLIENT-CRED | retrieval-flow
+| CLIENT-5 | T-CSRF | retrieval-flow
+| CLIENT-6 | T-CODE-INJECTION | retrieval-flow
+| CLIENT-7 | T-REDIRECT | retrieval-flow
+| CLIENT-8 | T-MIXUP | retrieval-flow
+| CLIENT-9 | T-CODE-INJECTION | retrieval-flow
+| CLIENT-10 | T-CODE-INJECTION (parameter integrity) | retrieval-flow
+| CLIENT-11 | T-TOKEN-REPLAY | retrieval-flow
+| CLIENT-12 | T-STEPUP | xref:specification/step-up-and-logout.adoc[step-up-and-logout]
+| CLIENT-13 | T-LOGOUT | step-up-and-logout
+| CLIENT-14 | T-URL-LEAK, T-TLS-TOKEN (delegated) | retrieval-flow
+| CLIENT-15 | T-AUD-CONFUSION | xref:specification/token-handling.adoc[token-handling]
+| CLIENT-16 | T-IDTOKEN-INTEGRITY | token-handling
+| CLIENT-17 | T-REFRESH-THEFT, T-LOGOUT | token-handling
+| CLIENT-18 | T-CONSTRAINT-LOSS | token-handling
+| CLIENT-19 | (BFF groundwork — non-preclusion) | xref:architecture.adoc[architecture], token-handling
+| CLIENT-20 | T-LEAK (delegated to commons) | token-handling
+| CLIENT-21..22 | (cross-cutting: engine boundary + adversarial coverage) | architecture, all specs
+|===

--- a/doc/client/specification/retrieval-flow.adoc
+++ b/doc/client/specification/retrieval-flow.adoc
@@ -1,0 +1,149 @@
+= Client Specification — Retrieval & Flow
+:toc: left
+:toclevels: 3
+:sectnums:
+:source-highlighter: highlight.js
+
+== Overview
+
+_Realizes xref:../requirements.adoc#CLIENT-1[CLIENT-1]–xref:../requirements.adoc#CLIENT-11[CLIENT-11]
+and xref:../requirements.adoc#CLIENT-14[CLIENT-14]. See xref:../threat-model.adoc[Threat Model],
+xref:../best-practices.adoc[Best Practices] and xref:../architecture.adoc[Architecture]._
+
+This specification covers the net-new aspect the client capability owns: the
+*confidential-client authorization-code + PKCE flow*, server-side, and the use of the token
+endpoint — grants, client authentication, flow-integrity parameters (`state` / `nonce` /
+exact `redirect_uri`), mix-up defence (`iss`), authorization-code-injection defence, PAR, and
+requesting sender-constrained tokens. Step-up and RP-initiated logout are specified
+separately (xref:step-up-and-logout.adoc[Step-up & logout]); the token lifecycle is
+xref:token-handling.adoc[Token handling].
+
+All outbound HTTP in every step below is performed by the
+xref:../../commons/specification/transport.adoc[commons transport] (`COMMONS-1`); the engine
+supplies parameters and interprets responses, and issues no HTTP of its own.
+
+== The authorization request
+
+The engine constructs a single authorization request as a confidential client
+(xref:../requirements.adoc#CLIENT-1[CLIENT-1]):
+
+[cols="1,3", options="header"]
+|===
+| Parameter | Rule
+
+| `response_type` | `code` only — never `token` or a hybrid combination (exclusions).
+| `response_mode` | `form_post` so the response (code, `state`, `iss`) never rides in a URL (xref:../requirements.adoc#CLIENT-14[CLIENT-14]).
+| `code_challenge` / `code_challenge_method` | PKCE with `S256`; the AS must advertise `S256` support, or the request is refused (xref:../requirements.adoc#CLIENT-2[CLIENT-2]).
+| `state` | Unguessable, bound to the initiating session; verified on callback (xref:../requirements.adoc#CLIENT-5[CLIENT-5]).
+| `nonce` | For OIDC: fresh, session-bound; verified against the ID token (xref:../requirements.adoc#CLIENT-6[CLIENT-6]).
+| `redirect_uri` | A single pre-registered value, matched by exact string comparison (xref:../requirements.adoc#CLIENT-7[CLIENT-7]).
+| `acr_values` / `max_age` | Optional step-up parameters (xref:step-up-and-logout.adoc[step-up spec], xref:../requirements.adoc#CLIENT-12[CLIENT-12]).
+| `scope` | The requested scopes (incl. `openid` for OIDC).
+|===
+
+Where the AS advertises `pushed_authorization_request_endpoint`, the parameters are *pushed
+via PAR* over the back channel (authenticated per <<_client_authentication>>) and the
+front-channel redirect carries only the returned `request_uri`
+(xref:../requirements.adoc#CLIENT-10[CLIENT-10]) — keeping the authorization parameters off
+the browser and tamper-proof. PAR is mandatory under FAPI 2.0.
+
+== The callback and code exchange
+
+On the redirect callback (delivered by `form_post`) the engine performs *ordered checks
+before it exchanges the code*:
+
+. *`state`* matches the session-bound value — else reject (CSRF,
+  xref:../threat-model.adoc#T-CSRF[T-CSRF]).
+. *`iss`* response parameter (RFC 9207) matches the issuer the flow was initiated with, when
+  more than one AS is configured — else reject before exchange (mix-up,
+  xref:../threat-model.adoc#T-MIXUP[T-MIXUP], xref:../requirements.adoc#CLIENT-8[CLIENT-8]).
+. The authorization *code* is exchanged at the token endpoint with the matching
+  `code_verifier` — a code without it cannot be redeemed
+  (xref:../threat-model.adoc#T-CODE-INJECTION[T-CODE-INJECTION],
+  xref:../requirements.adoc#CLIENT-9[CLIENT-9]).
+
+The exchange is a back-channel `POST` to the token endpoint (`grant_type=authorization_code`,
+`code`, `code_verifier`, `redirect_uri`), authenticated per <<_client_authentication>>, over
+TLS (`COMMONS-2`). The token response is validated (<<_token_response_validation>>) and every
+token is validated through the validation pipeline before use
+(xref:token-handling.adoc[token handling]).
+
+== Grants
+
+The engine supports the secure subset of token-endpoint grants
+(xref:../requirements.adoc#CLIENT-3[CLIENT-3]):
+
+[cols="1,3,1", options="header"]
+|===
+| Grant | Use | Status
+
+| `authorization_code` | The confidential BFF login flow (with PKCE). | Core
+| `refresh_token` | Server-side refresh of access tokens, with rotation (xref:token-handling.adoc[token handling]). | Core
+| `client_credentials` | Service-to-service token acquisition (no user). | Core
+| `urn:…:token-exchange` (RFC 8693) | Delegation / down-scoping where a use-case requires it. | Candidate
+| `password` (ROPC), `implicit` | — | *Excluded* (xref:../requirements.adoc#_security_exclusions_legacy_discouraged[exclusions])
+|===
+
+== [[_client_authentication]] Client authentication
+
+The engine authenticates to the token, PAR, revocation and introspection endpoints, choosing
+the *strongest method the AS offers* (xref:../requirements.adoc#CLIENT-4[CLIENT-4],
+xref:../threat-model.adoc#T-CLIENT-CRED[T-CLIENT-CRED]):
+
+[cols="1,2,1", options="header"]
+|===
+| Method | Notes | Source
+
+| `private_key_jwt` | Preferred — asymmetric client assertion; no shared secret in transit. | https://www.rfc-editor.org/rfc/rfc7523[RFC 7523]
+| mTLS | Preferred — certificate-bound; also enables certificate-bound tokens. | https://www.rfc-editor.org/rfc/rfc8705[RFC 8705]
+| `client_secret_basic` / `client_secret_post` | Fallback only; secret sent over TLS, never in a URL. | https://www.rfc-editor.org/rfc/rfc6749#section-2.3[RFC 6749 §2.3]
+|===
+
+Client credentials are protected at rest and never logged. When mTLS is used for client
+authentication, the same channel can carry the certificate binding for sender-constrained
+tokens (<<_sender_constrained_tokens>>).
+
+== [[_sender_constrained_tokens]] Requesting sender-constrained tokens
+
+The engine can *request* that retrieved tokens be sender-constrained
+(xref:../requirements.adoc#CLIENT-11[CLIENT-11],
+xref:../threat-model.adoc#T-TOKEN-REPLAY[T-TOKEN-REPLAY]):
+
+* *DPoP* (RFC 9449) — the engine presents a DPoP proof on the token request so the issued
+  access token is bound to its proof key (`cnf.jkt`).
+* *mTLS* (RFC 8705) — the token is bound to the client certificate.
+
+Validation of the resulting binding is *inherited* from the validation module
+(`VALIDATION-8.7`); this spec covers only the client-side act of *asking for* the constraint.
+The binding is then preserved through storage and refresh
+(xref:token-handling.adoc[token handling], xref:../requirements.adoc#CLIENT-18[CLIENT-18]).
+
+== [[_token_response_validation]] Token-response validation
+
+Before any token is used (xref:../requirements.adoc#CLIENT-14[CLIENT-14]):
+
+* the `token_type` and the presence of the expected artifacts are checked;
+* where the AS supports it, the *issuer identity* of the response is confirmed (RFC 9207);
+* every token is then validated through the validation pipeline
+  (xref:token-handling.adoc[token handling], xref:../requirements.adoc#CLIENT-15[CLIENT-15]).
+
+Tokens and codes are never transmitted in URL query or fragment components — the
+authorization response uses `form_post` and the code is exchanged at the token endpoint
+(xref:../threat-model.adoc#T-URL-LEAK[T-URL-LEAK]). All token-endpoint traffic relies on the
+commons TLS enforcement (xref:../threat-model.adoc#T-TLS-TOKEN[T-TLS-TOKEN], `COMMONS-2`).
+
+== Adversarial coverage
+
+Each check above is exercised against the commons `TokenDispatcher` / `WellKnownDispatcher` /
+`ParDispatcher` in *adversarial* mode
+(xref:../../commons/specification/transport.adoc#adversarial_dispatchers[commons transport
+spec], `COMMONS-7`) and the xref:../../oidc/06-implement/README.adoc[Plan 06] integration
+suite (xref:../requirements.adoc#CLIENT-22[CLIENT-22]): PKCE downgrade refused, `state` /
+`iss` / `redirect_uri` mismatches rejected, injected codes not redeemable, and the configured
+client-auth method asserted.
+
+== See also
+
+* xref:step-up-and-logout.adoc[Step-up & logout specification]
+* xref:token-handling.adoc[Token-handling specification]
+* xref:../architecture.adoc[Architecture] — the auth-code + PKCE sequence

--- a/doc/client/specification/step-up-and-logout.adoc
+++ b/doc/client/specification/step-up-and-logout.adoc
@@ -1,0 +1,101 @@
+= Client Specification — Step-Up & RP-Initiated Logout
+:toc: left
+:toclevels: 3
+:sectnums:
+:source-highlighter: highlight.js
+
+== Overview
+
+_Realizes xref:../requirements.adoc#CLIENT-12[CLIENT-12] and xref:../requirements.adoc#CLIENT-13[CLIENT-13].
+See xref:../threat-model.adoc[Threat Model], xref:../best-practices.adoc[Best Practices] and
+xref:../architecture.adoc[Architecture]._
+
+Two flows layered on the confidential authorization-code engine
+(xref:retrieval-flow.adoc[Retrieval & flow]): *step-up authentication* — raising the
+authentication assurance for a sensitive operation — and *RP-initiated logout* — ending the
+session at the IdP and revoking held tokens. Both drive the commons transport
+(`COMMONS-1`); the engine issues no HTTP of its own.
+
+== Step-up authentication (RFC 9470)
+
+Step-up lets a resource server demand a higher authentication assurance than the current
+session provides (xref:../requirements.adoc#CLIENT-12[CLIENT-12],
+xref:../threat-model.adoc#T-STEPUP[T-STEPUP]).
+
+=== Requesting an assurance level
+
+On an authorization request the engine can require an assurance level via:
+
+* `acr_values` — one or more requested authentication context class references;
+* `max_age` — the maximum acceptable age (seconds) of the end-user authentication.
+
+These are sent on the authorization request built in xref:retrieval-flow.adoc[Retrieval &
+flow].
+
+=== Handling the challenge
+
+When a resource server responds to an under-authenticated request with an
+`insufficient_user_authentication` challenge (RFC 9470 — a `WWW-Authenticate: Bearer
+error="insufficient_user_authentication"` carrying the required `acr_values` / `max_age`), the
+engine:
+
+. parses the challenge to recover the required `acr_values` / `max_age`;
+. *re-drives authorization* with those parameters (a fresh authorization-code flow, all the
+  flow-integrity checks of xref:retrieval-flow.adoc[Retrieval & flow] applying);
+. on return, *verifies* the resulting ID token's `acr` satisfies the requirement and
+  `auth_time` satisfies `max_age` — only then is the operation treated as sufficiently
+  authenticated.
+
+A response whose `acr` / `auth_time` does not satisfy the requirement MUST NOT be treated as
+a successful step-up.
+
+* Source: https://www.rfc-editor.org/rfc/rfc9470[RFC 9470], https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest[OIDC Core §3.1.2.1].
+
+== RP-initiated logout
+
+The engine triggers logout at the IdP's `end_session_endpoint` and revokes the tokens it
+holds (xref:../requirements.adoc#CLIENT-13[CLIENT-13],
+xref:../threat-model.adoc#T-LOGOUT[T-LOGOUT]).
+
+=== The end-session request
+
+The engine drives the `end_session_endpoint` with:
+
+[cols="1,3", options="header"]
+|===
+| Parameter | Rule
+
+| `id_token_hint` | The held ID token, identifying the session to end.
+| `post_logout_redirect_uri` | A *pre-registered* value matched by *exact string comparison* — never pattern / prefix, to prevent an open redirect.
+| `state` | Session-bound, verified on return, as on the authorization request.
+|===
+
+=== Revoking held tokens
+
+Logout is not complete until the tokens the engine holds are revoked, so a logout does not
+leave live tokens behind. The engine revokes the access and refresh tokens via the commons
+revocation transport (RFC 7009, `COMMONS-7`) and clears them from the server-side lifecycle
+(xref:token-handling.adoc[token handling], xref:../requirements.adoc#CLIENT-17[CLIENT-17]).
+
+=== Boundary: receivers are the BFF's concern
+
+RP-initiated logout *triggering* (above) and token revocation are the in-scope building
+blocks. *Front-channel / back-channel logout receivers* and the *Session-Management iframe*
+are browser-session concerns owned by the BFF application, not this engine
+(xref:../requirements.adoc#CLIENT-19[CLIENT-19]).
+
+* Source: https://openid.net/specs/openid-connect-rpinitiated-1_0.html[OpenID Connect RP-Initiated Logout 1.0], https://www.rfc-editor.org/rfc/rfc7009[RFC 7009] (revocation), https://www.rfc-editor.org/rfc/rfc9700#section-4.1[RFC 9700 §4.1] (open-redirect defence).
+
+== Adversarial coverage
+
+The commons `EndSessionDispatcher` *adversarial* mode returns open-redirect / mismatched
+`post_logout_redirect_uri` responses, which the engine rejects; revocation of held tokens is
+asserted after logout (xref:../requirements.adoc#CLIENT-22[CLIENT-22], `COMMONS-7`). Step-up
+is exercised by driving an `insufficient_user_authentication` challenge and asserting the
+re-driven `acr` / `auth_time` verification.
+
+== See also
+
+* xref:retrieval-flow.adoc[Retrieval & flow specification]
+* xref:token-handling.adoc[Token-handling specification]
+* xref:../architecture.adoc[Architecture]

--- a/doc/client/specification/token-handling.adoc
+++ b/doc/client/specification/token-handling.adoc
@@ -1,0 +1,126 @@
+= Client Specification — Token Handling
+:toc: left
+:toclevels: 3
+:sectnums:
+:source-highlighter: highlight.js
+
+== Overview
+
+_Realizes xref:../requirements.adoc#CLIENT-15[CLIENT-15]–xref:../requirements.adoc#CLIENT-20[CLIENT-20].
+See xref:../threat-model.adoc[Threat Model], xref:../best-practices.adoc[Best Practices] and
+xref:../architecture.adoc[Architecture]._
+
+The *Token* aspect is the server-side lifecycle *delta* on top of the validation module: how
+retrieved tokens are validated, held, refreshed, revoked, and kept sender-constrained. It
+*references the validation module* for all token-trust decisions and adds no
+signature/algorithm policy of its own. It is deliberately kept separate from
+xref:retrieval-flow.adoc[Retrieval & flow]: retrieval acquires tokens; token handling is what
+happens to them afterwards.
+
+== Validation is inherited, not re-implemented
+
+Every token the engine retrieves — access token and ID token — is validated through the
+xref:../../validation/requirements.adoc[validation] pipeline *before it is trusted or stored*
+(xref:../requirements.adoc#CLIENT-15[CLIENT-15],
+xref:../threat-model.adoc#T-AUD-CONFUSION[T-AUD-CONFUSION]):
+
+* signature verification and the algorithm policy (`VALIDATION-1.3`, RFC 8725 — asymmetric
+  only; `alg=none` / HMAC / weak keys rejected) are *inherited unchanged*;
+* `iss`, `aud`, `exp`, `iat` claim validation is performed by the pipeline;
+* DPoP-bound tokens are validated per `VALIDATION-8.7`.
+
+The client MUST NOT re-implement or weaken any of this. This is the primary *validation
+synergy*: tokens are cryptographically validated, not merely received — closing the biggest
+gap in the xref:../architecture.adoc[portal reference], where identity is taken from userinfo
+with no ID-token signature validation.
+
+== ID-token and userinfo validation
+
+For OpenID Connect (xref:../requirements.adoc#CLIENT-16[CLIENT-16],
+xref:../threat-model.adoc#T-IDTOKEN-INTEGRITY[T-IDTOKEN-INTEGRITY]):
+
+* the *ID token* is validated for signature (via the pipeline) and claims — `iss`, `aud`,
+  `azp`, `exp`, the session-bound `nonce` (xref:retrieval-flow.adoc[Retrieval & flow],
+  `CLIENT-6`), and `at_hash` where present;
+* when the *userinfo* endpoint is used, the response is validated (signature, if signed) and
+  its `sub` is *bound to the `sub` of the validated ID token* — a userinfo `sub` mismatch is
+  rejected;
+* identity MUST NOT be taken from an unvalidated ID token or userinfo response.
+
+* Source: https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation[OIDC Core §3.1.3.7], https://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse[OIDC Core §5.3.2].
+
+== Server-side token lifecycle
+
+Retrieved tokens are held *server-side* and never returned to the browser in usable form
+(xref:../requirements.adoc#CLIENT-17[CLIENT-17]). The lifecycle:
+
+[cols="1,3", options="header"]
+|===
+| Stage | Rule
+
+| *Store* | Held server-side; the BFF binding shape (server-side store or encrypted cookie) is the application's choice (<<_bff_groundwork_non_preclusion>>). Storage is minimal and protected at rest.
+| *Refresh* | Access tokens are refreshed with `refresh_token`; *refresh-token rotation* is applied, and a detected reuse of a rotated token triggers *revocation of the token family* (xref:../threat-model.adoc#T-REFRESH-THEFT[T-REFRESH-THEFT]).
+| *Revoke* | Tokens are revoked via the commons revocation transport (RFC 7009, `COMMONS-7`) on logout (xref:step-up-and-logout.adoc[step-up & logout]) and on detected misuse.
+| *Expiry* | Short-lived access tokens are preferred; refresh drives renewal.
+|===
+
+* Source: https://www.rfc-editor.org/rfc/rfc9700#section-4.14[RFC 9700 §4.14] (refresh-token protection / rotation), https://www.rfc-editor.org/rfc/rfc7009[RFC 7009] (revocation).
+
+== Preserving the sender-constraint
+
+Where a retrieved token is sender-constrained — DPoP (`cnf.jkt`) or mTLS-bound — the engine
+keeps the binding intact across storage, refresh and any forwarding
+(xref:../requirements.adoc#CLIENT-18[CLIENT-18],
+xref:../threat-model.adoc#T-CONSTRAINT-LOSS[T-CONSTRAINT-LOSS]): the stored token stays
+associated with its proof-key / certificate binding, refresh preserves the constraint, and
+storage is kept minimal so a bound token is never copied more widely than the lifecycle
+requires. A sender-constrained token MUST NOT be degraded to a replayable bearer token by the
+way it is stored or forwarded.
+
+* Source: https://www.rfc-editor.org/rfc/rfc9449[RFC 9449], https://www.rfc-editor.org/rfc/rfc8705[RFC 8705].
+
+== [[_bff_groundwork_non_preclusion]] BFF groundwork — non-preclusion
+
+The lifecycle above is the *BFF groundwork* this capability owns
+(xref:../requirements.adoc#CLIENT-19[CLIENT-19]). It MUST support *either* token-binding
+deployment without forcing the choice:
+
+* *stateful BFF* — an opaque session-id cookie + a server-side token store the engine's
+  lifecycle populates;
+* *stateless BFF* — the access token returned to the browser only inside an HttpOnly cookie
+  encrypted with a server-side symmetric key, decrypted per request.
+
+The engine seam — confidential retrieval, server-side lifecycle, validation — is identical
+for both. The browser↔backend session cookie, symmetric-key management, backend-API CSRF and
+request proxying are the *BFF application's* concern and are not implemented here.
+
+* Source: https://datatracker.ietf.org/doc/html/draft-ietf-oauth-browser-based-apps[OAuth 2.0 for Browser-Based Apps].
+
+== Error surfacing (delegated to commons)
+
+The engine (pure Java) signals every failure — validation rejection, refresh failure,
+normalized inbound IdP error — through the commons typed-exception hierarchy (`COMMONS-9`) and
+produces *no* HTTP problem documents itself (xref:../requirements.adoc#CLIENT-20[CLIENT-20]).
+HTTP-surfaced client errors conform to the commons RFC 9457 model: the
+`token-sheriff-client-quarkus` edge (and any future RESTEasy / portal adapter) maps the typed
+exceptions to `application/problem+json` (`COMMONS-10`), leaking no internal detail
+(`COMMONS-12`). Inbound IdP error responses (`error` / `error_description`, RFC 6749 §5.2) are
+normalized by commons (`COMMONS-11`), never passed through verbatim.
+
+* Source: https://www.rfc-editor.org/rfc/rfc9457[RFC 9457], xref:../../commons/specification/error-model.adoc[commons error-model spec].
+
+== Adversarial coverage
+
+The commons `TokenDispatcher` / `UserInfoDispatcher` *adversarial* modes emit tampered
+claims, `sub` mismatches, and reused rotated refresh tokens
+(xref:../../commons/specification/transport.adoc#adversarial_dispatchers[commons transport
+spec], `COMMONS-7`); the client tests assert the validation pipeline rejects tampered tokens,
+the userinfo `sub` binding is enforced, rotation triggers family revocation on reuse, and the
+sender-constraint survives a refresh (xref:../requirements.adoc#CLIENT-22[CLIENT-22]).
+
+== See also
+
+* xref:retrieval-flow.adoc[Retrieval & flow specification]
+* xref:step-up-and-logout.adoc[Step-up & logout specification]
+* xref:../../validation/requirements.adoc[Validation Requirements] — the inherited token-trust pipeline
+* xref:../../commons/specification/error-model.adoc[Commons error-model specification]

--- a/doc/client/threat-model.adoc
+++ b/doc/client/threat-model.adoc
@@ -1,0 +1,212 @@
+= Client Threat Model
+:toc: left
+:toclevels: 3
+:sectnums:
+:source-highlighter: highlight.js
+
+== Overview
+
+_See xref:requirements.adoc[Client Requirements], xref:best-practices.adoc[Best Practices]
+and xref:architecture.adoc[Architecture]._
+
+Threat model for the `client` capability — the server-side confidential-client engine that
+*retrieves tokens* and drives the OAuth 2.0 / OpenID Connect *flows*. Its threats are the
+*acquisition and flow* threats: authorization-code injection, mix-up between multiple
+authorization servers, callback CSRF, redirect-URI abuse, weak client credentials, token
+replay, insufficient authentication assurance, and logout that leaves tokens live — plus the
+server-side *token-lifecycle* threats of refresh-token theft, audience confusion and
+sender-constraint loss.
+
+Each entry cites a source, a mitigation, and the covering `CLIENT-N` requirement, grouped by
+aspect. Threats are kept *separate by aspect* and *not blended* with the transport or
+token-trust threats owned elsewhere (<<_out_of_scope_delegated>>).
+
+== System context
+
+The client engine:
+
+* Constructs authorization requests and exchanges authorization codes for tokens as a
+  *confidential client*, entirely server-side (no tokens in the browser).
+* Authenticates to the token / PAR / revocation / introspection endpoints and *requests*
+  sender-constrained tokens.
+* Holds retrieved tokens *server-side*, refreshes and revokes them, and validates them
+  through the validation pipeline.
+* Triggers RP-initiated logout and honours step-up challenges.
+* Issues *no outbound IdP HTTP of its own* — all fetching is done by
+  xref:../commons/threat-model.adoc[commons], whose transport threats (SSRF, TLS downgrade,
+  response-DoS) the flow *inherits* and does not restate.
+
+== Retrieval & flow aspect
+
+[cols="1,2,3,1,1", options="header"]
+|===
+| ID | Threat | Mitigation | Source | Requirement
+
+| [[T-CODE-INJECTION]]T-CODE-INJECTION
+| *Authorization-code injection.* An attacker injects a code obtained elsewhere into a
+  victim's session (or vice-versa) to have it redeemed under the wrong context.
+| Bind the code to the requesting session: PKCE `S256` binds it to the `code_verifier`; for
+  OIDC the session-bound `nonce` binds the ID token. Redeem only with the matching verifier.
+| https://www.rfc-editor.org/rfc/rfc9700#section-4.5[RFC 9700 §4.5], https://www.rfc-editor.org/rfc/rfc7636[RFC 7636]
+| xref:requirements.adoc#CLIENT-2[CLIENT-2], xref:requirements.adoc#CLIENT-6[CLIENT-6], xref:requirements.adoc#CLIENT-9[CLIENT-9]
+
+| [[T-PKCE-DOWNGRADE]]T-PKCE-DOWNGRADE
+| *PKCE downgrade.* An attacker strips or downgrades PKCE (to `plain` or none) so the code is
+  no longer bound to a verifier.
+| Require `S256`; confirm the AS advertises `code_challenge_methods_supported=S256`; never
+  fall back to `plain` or a non-PKCE request.
+| https://www.rfc-editor.org/rfc/rfc9700#section-4.8[RFC 9700 §4.8]
+| xref:requirements.adoc#CLIENT-2[CLIENT-2]
+
+| [[T-MIXUP]]T-MIXUP
+| *Mix-up attack (multiple authorization servers).* With more than one AS configured, an
+  attacker tricks the client into sending a code/response issued by AS-A to AS-B.
+| Validate the `iss` authorization-response parameter (RFC 9207) against the initiating
+  issuer and/or use a distinct `redirect_uri` per AS; reject on mismatch before exchange.
+| https://www.rfc-editor.org/rfc/rfc9207[RFC 9207], https://www.rfc-editor.org/rfc/rfc9700#section-4.4[RFC 9700 §4.4]
+| xref:requirements.adoc#CLIENT-8[CLIENT-8]
+
+| [[T-REDIRECT]]T-REDIRECT
+| *Insufficient redirect-URI validation.* Pattern / prefix matching lets an attacker steer
+  the response (and code) to an attacker-controlled URI.
+| Register and send a single, exact `redirect_uri`; rely on exact string matching only — no
+  wildcard / prefix / substring.
+| https://www.rfc-editor.org/rfc/rfc9700#section-4.1[RFC 9700 §4.1]
+| xref:requirements.adoc#CLIENT-7[CLIENT-7]
+
+| [[T-CSRF]]T-CSRF
+| *CSRF on the callback.* An attacker replays a crafted callback to bind their session /
+  authorization to the victim.
+| Send an unguessable, session-bound `state` on every request; reject a callback whose
+  `state` is missing or does not match.
+| https://www.rfc-editor.org/rfc/rfc9700#section-4.7[RFC 9700 §4.7]
+| xref:requirements.adoc#CLIENT-5[CLIENT-5]
+
+| [[T-CLIENT-CRED]]T-CLIENT-CRED
+| *Weak or leaked client credentials.* A shared `client_secret` is guessed, leaked from
+  config/logs, or intercepted, letting an attacker impersonate the client.
+| Prefer `private_key_jwt` / mTLS over `client_secret`; send secrets only over TLS and never
+  in a URL; protect credentials at rest; never log them; restrict grants to the secure subset.
+| https://www.rfc-editor.org/rfc/rfc7523[RFC 7523], https://www.rfc-editor.org/rfc/rfc8705[RFC 8705], https://www.rfc-editor.org/rfc/rfc9700#section-2.2[RFC 9700 §2.2]
+| xref:requirements.adoc#CLIENT-3[CLIENT-3], xref:requirements.adoc#CLIENT-4[CLIENT-4]
+
+| [[T-TOKEN-REPLAY]]T-TOKEN-REPLAY
+| *Token replay (no sender-constraining).* A stolen bearer access token is replayed by any
+  holder.
+| Request sender-constrained tokens — DPoP proof or mTLS certificate binding — at the token
+  endpoint; validation of the binding is inherited (`VALIDATION-8.7`).
+| https://www.rfc-editor.org/rfc/rfc9700#section-4.10[RFC 9700 §4.10], https://www.rfc-editor.org/rfc/rfc9449[RFC 9449], https://www.rfc-editor.org/rfc/rfc8705[RFC 8705], https://openid.net/specs/fapi-2_0-security-profile.html[FAPI 2.0]
+| xref:requirements.adoc#CLIENT-11[CLIENT-11]
+
+| [[T-STEPUP]]T-STEPUP
+| *Insufficient authentication assurance for a sensitive operation.* An operation proceeds
+  with a session authenticated at too low an assurance.
+| Request `acr_values` / `max_age`; honour the resource server's
+  `insufficient_user_authentication` challenge (RFC 9470) by re-driving authorization; verify
+  the resulting `acr` / `auth_time` before proceeding.
+| https://www.rfc-editor.org/rfc/rfc9470[RFC 9470]
+| xref:requirements.adoc#CLIENT-12[CLIENT-12]
+
+| [[T-LOGOUT]]T-LOGOUT
+| *Logout that leaves tokens live / open-redirect on `post_logout_redirect_uri`.* Logout
+  clears the browser session but held tokens stay usable, or the post-logout redirect is
+  abused as an open redirect.
+| Send `id_token_hint`; exact-match the registered `post_logout_redirect_uri`; bind `state`;
+  revoke the held tokens as part of logout.
+| https://openid.net/specs/openid-connect-rpinitiated-1_0.html[OIDC RP-Initiated Logout], https://www.rfc-editor.org/rfc/rfc9700#section-4.1[RFC 9700 §4.1]
+| xref:requirements.adoc#CLIENT-13[CLIENT-13], xref:requirements.adoc#CLIENT-17[CLIENT-17]
+
+| [[T-URL-LEAK]]T-URL-LEAK
+| *Tokens / codes exposed in URL query or fragment.* Credentials leak through browser
+  history, server logs, or the `Referer` header.
+| Use `response_mode=form_post`; exchange the code at the token endpoint over the back
+  channel; never place tokens/codes in a URL.
+| https://www.rfc-editor.org/rfc/rfc9700#section-4.3[RFC 9700 §4.3]
+| xref:requirements.adoc#CLIENT-1[CLIENT-1], xref:requirements.adoc#CLIENT-14[CLIENT-14]
+
+| [[T-TLS-TOKEN]]T-TLS-TOKEN
+| *Token-endpoint TLS downgrade / MITM.* An on-path attacker downgrades or MITMs a token /
+  PAR / revocation request to substitute responses or capture secrets.
+| *Delegated to commons* — TLS 1.2+ with certificate validation on every outbound request
+  (`COMMONS-2`); the flow relies on it and adds no transport of its own.
+| https://www.rfc-editor.org/rfc/rfc9700#section-2.6[RFC 9700 §2.6], xref:../commons/threat-model.adoc#T-TLS[commons T-TLS]
+| xref:requirements.adoc#CLIENT-14[CLIENT-14] (relies on xref:../commons/requirements.adoc#COMMONS-2[COMMONS-2])
+|===
+
+== Token aspect
+
+[cols="1,2,3,1,1", options="header"]
+|===
+| ID | Threat | Mitigation | Source | Requirement
+
+| [[T-REFRESH-THEFT]]T-REFRESH-THEFT
+| *Refresh-token theft (server-side).* A refresh token exfiltrated from the server-side store
+  is used to mint fresh access tokens indefinitely.
+| Rotate refresh tokens on each use; detect reuse of a rotated token and revoke the family;
+  sender-constrain where available; protect the at-rest store; minimal storage.
+| https://www.rfc-editor.org/rfc/rfc9700#section-4.14[RFC 9700 §4.14]
+| xref:requirements.adoc#CLIENT-17[CLIENT-17], xref:requirements.adoc#CLIENT-18[CLIENT-18]
+
+| [[T-AUD-CONFUSION]]T-AUD-CONFUSION
+| *Token replay / audience confusion.* A token issued for one audience is accepted where it
+  should not be, or a forged/expired token is trusted.
+| Validate every retrieved token through the validation pipeline — signature, `iss`, `aud`,
+  `exp`, `iat` — before trust or storage; never take identity from an unvalidated token.
+| https://www.rfc-editor.org/rfc/rfc9068[RFC 9068], https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation[OIDC Core §3.1.3.7]
+| xref:requirements.adoc#CLIENT-15[CLIENT-15]
+
+| [[T-IDTOKEN-INTEGRITY]]T-IDTOKEN-INTEGRITY
+| *ID-token / userinfo integrity.* Identity is taken from an unvalidated ID token, or from a
+  userinfo response whose `sub` does not match the ID token (identity confusion).
+| Validate the ID-token signature and claims (`iss`/`aud`/`exp`/`nonce`/`at_hash`); validate a
+  signed userinfo response and bind its `sub` to the ID token's `sub`, rejecting mismatches.
+| https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation[OIDC Core §3.1.3.7], https://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse[OIDC Core §5.3.2]
+| xref:requirements.adoc#CLIENT-16[CLIENT-16]
+
+| [[T-CONSTRAINT-LOSS]]T-CONSTRAINT-LOSS
+| *Sender-constraint loss in storage / forwarding.* A DPoP- or mTLS-bound token is stored or
+  forwarded in a way that drops its binding, degrading it to a replayable bearer token.
+| Keep the token associated with its proof-key / certificate binding across storage, refresh
+  and forwarding; preserve the constraint on refresh; keep storage minimal.
+| https://www.rfc-editor.org/rfc/rfc9449[RFC 9449], https://www.rfc-editor.org/rfc/rfc8705[RFC 8705]
+| xref:requirements.adoc#CLIENT-18[CLIENT-18]
+|===
+
+== Adversarial test coverage
+
+Each flow / token threat is exercised by the commons `generators` dispatchers in their
+*adversarial* mode (xref:../commons/specification/transport.adoc#adversarial_dispatchers[commons
+transport spec], `COMMONS-7`), driven by the client unit tests
+(xref:requirements.adoc#CLIENT-22[CLIENT-22]) and the
+xref:../oidc/06-implement/README.adoc[Plan 06] integration suite:
+
+[cols="1,3", options="header"]
+|===
+| Threat | Adversarial dispatcher behaviour driven by the client tests
+
+| T-CODE-INJECTION / T-PKCE-DOWNGRADE | `TokenDispatcher` rejects/accepts codes against the presented `code_verifier`; missing-PKCE and `plain` requests refused.
+| T-MIXUP | `WellKnownDispatcher` advertises a mismatched `issuer`; the `iss` response parameter is cross-checked before exchange.
+| T-CSRF / T-REDIRECT | Callback handling asserts session-bound `state` and exact `redirect_uri`; crafted callbacks rejected.
+| T-CLIENT-CRED | `TokenDispatcher` asserts the configured client-auth method; secret-in-URL and non-TLS attempts are not made.
+| T-TOKEN-REPLAY / T-CONSTRAINT-LOSS | `TokenDispatcher` issues DPoP / mTLS-bound responses; the binding is validated and preserved through storage/refresh.
+| T-LOGOUT | `EndSessionDispatcher` adversarial mode returns open-redirect / mismatched `post_logout_redirect_uri`, which are rejected; revocation of held tokens asserted.
+| T-REFRESH-THEFT | `TokenDispatcher` refresh mode drives rotation; a reused rotated token triggers family revocation.
+| T-IDTOKEN-INTEGRITY / T-AUD-CONFUSION | `TokenDispatcher` / `UserInfoDispatcher` emit tampered claims and `sub` mismatches; validation pipeline rejects; userinfo `sub` binding enforced.
+|===
+
+== [[_out_of_scope_delegated]] Out of scope (delegated)
+
+* *Transport threats* — SSRF via IdP-advertised URLs, TLS downgrade / MITM on any fetch, and
+  response-DoS on discovery / JWKS / token / userinfo — belong to the
+  xref:../commons/threat-model.adoc[commons threat model] (`T-SSRF`, `T-TLS`, `T-DOS`,
+  `T-DISCOVERY`). The flow *inherits* them; it does not restate them. `T-TLS-TOKEN` above is
+  listed only to record the flow's reliance on the commons TLS control.
+* *Token-trust threats* — forged signatures, `alg` confusion, claim tampering, expiry / replay
+  at validation time — belong to the xref:../validation/threat-model.adoc[validation threat
+  model]. The client retrieves tokens; validation decides their trust (`CLIENT-15`).
+* *Error-detail leakage* at the HTTP edge — the RFC 9457 no-leak control — is the commons
+  `T-LEAK` threat (`COMMONS-12`); the client engine only throws typed exceptions
+  (`CLIENT-20`).
+* *BFF application concerns* — the browser↔backend session cookie, symmetric-key management,
+  backend-API CSRF, request proxying, and front-/back-channel logout *receivers* — are the
+  BFF application's threat surface, not this engine's (`CLIENT-19`).


### PR DESCRIPTION
## Summary

Executes [Plan 04 — Client Spec](../blob/main/doc/oidc/04-client-spec/README.adoc) end to end: the full **client capability documentation set** under `doc/client/`, authored **spec-first** ahead of the `token-sheriff-client` module (Plan 05). It specifies the server-side **confidential-client token-retrieval engine** a Backend-For-Frontend (BFF) is built on — as a **most-secure current subset**, security-led, with every normative requirement and threat entry source-referenced.

This is documentation only. **No Maven module and no transport re-packaging** — those are Plan 05.

## Document set (`doc/client/`)

| File | Content |
|------|---------|
| `references.adoc` | Bibliography — standards new to the client capability + reused (cite-don't-restate) from validation/commons + informative sources |
| `requirements.adoc` | 22 `CLIENT-N` requirements **grouped by aspect** (Retrieval & flow / Token), each sourced; sourced exclusions table; BFF-groundwork non-preclusion; full traceability matrix |
| `threat-model.adoc` | Attack catalog per aspect; each entry → source + mitigation + covering `CLIENT-N`; adversarial-dispatcher coverage; delegated transport/token-trust threats noted |
| `best-practices.adoc` | Normative, sourced checklist by aspect |
| `architecture.adoc` | Client/BFF engine seam, both BFF binding shapes (stateful store / stateless encrypted cookie — non-preclusion), deps on validation+commons, `portal-authentication-oauth` reference |
| `specification/retrieval-flow.adoc` | Auth-code + PKCE, grants, client auth, `state`/`nonce`/exact redirect-URI, mix-up (`iss`), PAR, sender-constraining requests |
| `specification/step-up-and-logout.adoc` | RFC 9470 step-up; RP-initiated logout |
| `specification/token-handling.adoc` | Server-side token lifecycle delta — references the validation module |

## Aspect separation held

- **Token** aspect references the validation pipeline (`VALIDATION-1.3`, `VALIDATION-8.7`) — no duplicated signature/algorithm policy.
- **All outbound IdP HTTP** references commons (`COMMONS-1`–`COMMONS-8`) — no respecified transport / SSRF / TLS.
- **HTTP-surfaced errors** conform to the commons RFC 9457 model (`COMMONS-9`–`COMMONS-12`); the engine throws typed exceptions.
- Each security exclusion is documented and sourced; every requirement is threat-driven.

## Verification

- [x] Every requirement (22 `Source:` lines) and every threat entry cites a normative source with section anchor
- [x] Retrieval & flow covers confidential auth-code+PKCE, client auth, `state`/`nonce`/redirect-URI, mix-up (`iss`), sender-constraining, step-up (RFC 9470), RP-initiated logout
- [x] BFF groundwork sufficient (server-side lifecycle) without owning the browser session/cookie layer
- [x] `CLIENT-N` grouped by aspect; traceability matrix complete
- [x] Link sweep: 274 `xref:` targets resolve; all 22 `CLIENT-N` IDs defined and covered
- [x] Client capability wired into the `doc/README.adoc` hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015pY7FAJDoVqaw2QMHpHpCs)_