### PR TITLE
fix(transport): adopt cui-http 2.0.0 HttpHandler API (allowInsecureHttp)

### DIFF
--- a/doc/LogMessages.adoc
+++ b/doc/LogMessages.adoc
@@ -81,6 +81,7 @@ For more details about security events related to these log messages, see the Se
 |TokenSheriff-126 |JWKS |JWKS keys array is empty |Logged when JWKS keys array is empty
 |TokenSheriff-127 |JWKS |Failed to parse RSA key with ID %s: %s |Logged when RSA key parsing fails for a specific key ID
 |TokenSheriff-128 |JWKS |Failed to parse EC key with ID %s: %s |Logged when EC key parsing fails for a specific key ID
+|TokenSheriff-129 |JWKS |Using insecure HTTP protocol for well-known discovery endpoint: %s - HTTPS should be used in production |Logged when an insecure HTTP protocol is used for the OIDC well-known discovery endpoint instead of HTTPS
 |TokenSheriff-130 |JSON |Failed to parse JWKS JSON: %s |Logged when JSON parsing fails for JWKS content and an empty result is returned as fallback
 |TokenSheriff-131 |ISSUER |IssuerConfig for issuer '%s' has claimSubOptional=true. This is not conform to RFC 7519 which requires the 'sub' claim for ACCESS_TOKEN and ID_TOKEN types. Use this setting only when necessary and ensure appropriate alternative validation mechanisms. |Logged when an issuer configuration has the subject claim marked as optional, which violates RFC 7519 requirements
 |TokenSheriff-132 |JWKS |Invalid Base64 URL encoding detected for JWK field: %s |Logged when Base64 URL encoding validation fails for a JWK field

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.cuioss</groupId>
         <artifactId>cui-java-parent</artifactId>
-        <version>1.4.5</version>
+        <version>1.5.0</version>
         <relativePath />
     </parent>
     <groupId>de.cuioss.sheriff.token</groupId>

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/commons/transport/HttpJwksLoaderConfig.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/commons/transport/HttpJwksLoaderConfig.java
@@ -210,9 +210,10 @@ public class HttpJwksLoaderConfig {
         // Reuse existing HttpHandler configuration as base
         HttpHandler baseHandler = getHttpHandler();
 
-        // Create a new handler with the same configuration but different URL
+        // Create a new handler with the same configuration but different URL.
+        // asBuilder() copies the base handler's settings (including allowInsecureHttp),
+        // so the caller's security preference is preserved.
         return baseHandler.asBuilder()
-                .allowInsecureHttp(true)
                 .url(url)
                 .build();
     }

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/commons/transport/HttpJwksLoaderConfig.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/commons/transport/HttpJwksLoaderConfig.java
@@ -212,6 +212,7 @@ public class HttpJwksLoaderConfig {
 
         // Create a new handler with the same configuration but different URL
         return baseHandler.asBuilder()
+                .allowInsecureHttp(true)
                 .url(url)
                 .build();
     }
@@ -285,7 +286,9 @@ public class HttpJwksLoaderConfig {
          * Constructor initializing the HttpHandlerBuilder.
          */
         public HttpJwksLoaderConfigBuilder() {
-            this.httpHandlerBuilder = HttpHandler.builder();
+            // Permit http:// endpoints; this layer emits its own security warning
+            // (INSECURE_HTTP_JWKS) for insecure schemes rather than rejecting them outright.
+            this.httpHandlerBuilder = HttpHandler.builder().allowInsecureHttp(true);
         }
 
         /**

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/commons/transport/HttpJwksLoaderConfig.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/commons/transport/HttpJwksLoaderConfig.java
@@ -213,9 +213,16 @@ public class HttpJwksLoaderConfig {
         // Create a new handler with the same configuration but different URL.
         // asBuilder() copies the base handler's settings (including allowInsecureHttp),
         // so the caller's security preference is preserved.
-        return baseHandler.asBuilder()
+        HttpHandler handler = baseHandler.asBuilder()
                 .url(url)
                 .build();
+
+        // Emit the insecure-HTTP warning for JWKS URLs discovered via well-known lookup,
+        // mirroring the direct-configuration path in build().
+        if ("http".equalsIgnoreCase(handler.getUri().getScheme())) {
+            LOGGER.warn(TransportLogMessages.WARN.INSECURE_HTTP_JWKS, handler.getUri().toString());
+        }
+        return handler;
     }
 
     /**
@@ -275,6 +282,7 @@ public class HttpJwksLoaderConfig {
         private Duration keyRotationGracePeriod = DEFAULT_KEY_ROTATION_GRACE_PERIOD;
         private int maxRetiredKeySets = DEFAULT_MAX_RETIRED_KEY_SETS;
         private ParserConfig parserConfig;
+        private boolean allowInsecureHttp = true;
 
         // Pending well-known values — WellKnownConfig creation is deferred to build()
         private String pendingWellKnownUrl;
@@ -287,9 +295,25 @@ public class HttpJwksLoaderConfig {
          * Constructor initializing the HttpHandlerBuilder.
          */
         public HttpJwksLoaderConfigBuilder() {
-            // Permit http:// endpoints; this layer emits its own security warning
-            // (INSECURE_HTTP_JWKS) for insecure schemes rather than rejecting them outright.
-            this.httpHandlerBuilder = HttpHandler.builder().allowInsecureHttp(true);
+            this.httpHandlerBuilder = HttpHandler.builder();
+        }
+
+        /**
+         * Controls whether plaintext {@code http://} endpoints are permitted.
+         * <p>
+         * Defaults to {@code true}, which preserves the "allow but warn" contract:
+         * cleartext endpoints are accepted but a {@code TokenSheriff-139}
+         * ({@code INSECURE_HTTP_JWKS}) warning is emitted. Set to {@code false} to
+         * enforce HTTPS and have {@link #build()} reject {@code http://} endpoints,
+         * which is recommended for production to protect against man-in-the-middle
+         * attacks on JWKS resolution.
+         *
+         * @param allowInsecureHttp {@code false} to require HTTPS, {@code true} (default) to allow cleartext HTTP
+         * @return this builder instance
+         */
+        public HttpJwksLoaderConfigBuilder allowInsecureHttp(boolean allowInsecureHttp) {
+            this.allowInsecureHttp = allowInsecureHttp;
+            return this;
         }
 
         /**
@@ -575,7 +599,8 @@ public class HttpJwksLoaderConfig {
                 // Build WellKnownConfig with the resolved ParserConfig
                 var wkBuilder = WellKnownConfig.builder()
                         .retryConfig(RetryConfig.defaults())
-                        .parserConfig(resolvedParserConfig);
+                        .parserConfig(resolvedParserConfig)
+                        .allowInsecureHttp(allowInsecureHttp);
                 if (pendingWellKnownUrl != null) {
                     wkBuilder.wellKnownUrl(pendingWellKnownUrl);
                 } else {
@@ -585,6 +610,7 @@ public class HttpJwksLoaderConfig {
             } else {
                 // Build the HttpHandler for direct URL/URI configuration
                 try {
+                    httpHandlerBuilder.allowInsecureHttp(allowInsecureHttp);
                     jwksHttpHandler = httpHandlerBuilder.build();
 
                     // Check for insecure HTTP protocol

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/commons/transport/TransportLogMessages.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/commons/transport/TransportLogMessages.java
@@ -61,6 +61,12 @@ public final class TransportLogMessages {
                 .template("Invalid Base64 URL encoding detected for JWK field: %s")
                 .build();
 
+        public static final LogRecord INSECURE_HTTP_WELLKNOWN = LogRecordModel.builder()
+                .prefix(PREFIX)
+                .identifier(129)
+                .template("Using insecure HTTP protocol for well-known discovery endpoint: %s - HTTPS should be used in production")
+                .build();
+
         public static final LogRecord INSECURE_HTTP_JWKS = LogRecordModel.builder()
                 .prefix(PREFIX)
                 .identifier(139)

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/commons/transport/WellKnownConfig.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/commons/transport/WellKnownConfig.java
@@ -19,6 +19,7 @@ import de.cuioss.http.client.adapter.RetryConfig;
 import de.cuioss.http.client.handler.HttpHandler;
 import de.cuioss.http.client.handler.SecureSSLContextProvider;
 import de.cuioss.sheriff.token.commons.events.SecurityEventCounter;
+import de.cuioss.tools.logging.CuiLogger;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -43,6 +44,8 @@ import java.net.URI;
 @ToString
 @EqualsAndHashCode
 public class WellKnownConfig {
+
+    private static final CuiLogger LOGGER = new CuiLogger(WellKnownConfig.class);
 
     /**
      * Default connect timeout in seconds for well-known endpoint requests.
@@ -104,17 +107,32 @@ public class WellKnownConfig {
         private final HttpHandler.HttpHandlerBuilder httpHandlerBuilder;
         private RetryConfig retryConfig = RetryConfig.defaults();
         private ParserConfig parserConfig;
+        private boolean allowInsecureHttp = true;
 
         /**
          * Constructor initializing the HttpHandlerBuilder with sensible defaults.
          */
         public WellKnownConfigBuilder() {
             this.httpHandlerBuilder = HttpHandler.builder()
-                    // Permit http:// endpoints; this layer emits its own security warning
-                    // for insecure schemes rather than rejecting them outright.
-                    .allowInsecureHttp(true)
                     .connectionTimeoutSeconds(DEFAULT_CONNECT_TIMEOUT_SECONDS)
                     .readTimeoutSeconds(DEFAULT_READ_TIMEOUT_SECONDS);
+        }
+
+        /**
+         * Controls whether plaintext {@code http://} discovery endpoints are permitted.
+         * <p>
+         * Defaults to {@code true}, which preserves the "allow but warn" contract:
+         * cleartext endpoints are accepted but a {@code TokenSheriff-129}
+         * ({@code INSECURE_HTTP_WELLKNOWN}) warning is emitted. Set to {@code false} to
+         * enforce HTTPS and have {@link #build()} reject {@code http://} discovery
+         * endpoints, which is recommended for production.
+         *
+         * @param allowInsecureHttp {@code false} to require HTTPS, {@code true} (default) to allow cleartext HTTP
+         * @return this builder instance
+         */
+        public WellKnownConfigBuilder allowInsecureHttp(boolean allowInsecureHttp) {
+            this.allowInsecureHttp = allowInsecureHttp;
+            return this;
         }
 
         /**
@@ -218,7 +236,15 @@ public class WellKnownConfig {
          */
         public WellKnownConfig build() {
             try {
+                httpHandlerBuilder.allowInsecureHttp(allowInsecureHttp);
                 HttpHandler httpHandler = httpHandlerBuilder.build();
+
+                // Emit a security warning when the discovery endpoint uses cleartext HTTP,
+                // mirroring the JWKS insecure-HTTP warning so insecure endpoints are not silent.
+                if ("http".equalsIgnoreCase(httpHandler.getUri().getScheme())) {
+                    LOGGER.warn(TransportLogMessages.WARN.INSECURE_HTTP_WELLKNOWN, httpHandler.getUri().toString());
+                }
+
                 ParserConfig finalParserConfig = parserConfig != null ? parserConfig : ParserConfig.builder().build();
                 return new WellKnownConfig(httpHandler, retryConfig, finalParserConfig);
             } catch (IllegalArgumentException | IllegalStateException e) {

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/commons/transport/WellKnownConfig.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/commons/transport/WellKnownConfig.java
@@ -110,6 +110,9 @@ public class WellKnownConfig {
          */
         public WellKnownConfigBuilder() {
             this.httpHandlerBuilder = HttpHandler.builder()
+                    // Permit http:// endpoints; this layer emits its own security warning
+                    // for insecure schemes rather than rejecting them outright.
+                    .allowInsecureHttp(true)
                     .connectionTimeoutSeconds(DEFAULT_CONNECT_TIMEOUT_SECONDS)
                     .readTimeoutSeconds(DEFAULT_READ_TIMEOUT_SECONDS);
         }

--- a/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/commons/transport/HttpJwksLoaderConfigTest.java
+++ b/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/commons/transport/HttpJwksLoaderConfigTest.java
@@ -16,6 +16,7 @@
 package de.cuioss.sheriff.token.commons.transport;
 
 import de.cuioss.http.client.adapter.RetryConfig;
+import de.cuioss.http.client.handler.HttpHandler;
 import de.cuioss.http.client.handler.SecureSSLContextProvider;
 import de.cuioss.test.juli.LogAsserts;
 import de.cuioss.test.juli.TestLogLevel;
@@ -38,6 +39,44 @@ class HttpJwksLoaderConfigTest {
 
     private static final String VALID_URL = "https://example.com/.well-known/jwks.json";
     private static final int REFRESH_INTERVAL = 60;
+
+    @Test
+    @DisplayName("Should reject http:// JWKS URL when allowInsecureHttp(false)")
+    void shouldRejectInsecureHttpWhenDisallowed() {
+        var builder = HttpJwksLoaderConfig.builder()
+                .jwksUrl("http://example.com/.well-known/jwks.json")
+                .issuerIdentifier("test-issuer")
+                .allowInsecureHttp(false);
+        assertThrows(IllegalArgumentException.class, builder::build,
+                "http:// JWKS URL must be rejected when insecure HTTP is disallowed");
+    }
+
+    @Test
+    @DisplayName("Should allow https:// JWKS URL when allowInsecureHttp(false)")
+    void shouldAllowHttpsWhenInsecureDisallowed() {
+        HttpJwksLoaderConfig config = HttpJwksLoaderConfig.builder()
+                .jwksUrl(VALID_URL)
+                .issuerIdentifier("test-issuer")
+                .allowInsecureHttp(false)
+                .build();
+        assertTrue(config.getHttpHandler().getUrl().toString().startsWith("https://"),
+                "https:// JWKS URL must be accepted when insecure HTTP is disallowed");
+    }
+
+    @Test
+    @DisplayName("Should warn when creating a handler for a discovered http:// JWKS URL")
+    void shouldWarnForDiscoveredInsecureJwksUrl() {
+        HttpJwksLoaderConfig config = HttpJwksLoaderConfig.builder()
+                .jwksUrl(VALID_URL)
+                .issuerIdentifier("test-issuer")
+                .build();
+
+        HttpHandler handler = config.getHttpHandler("http://internal.example/jwks.json");
+        assertTrue(handler.getUri().toString().startsWith("http://"),
+                "Discovered http:// JWKS URL is allowed by default");
+        LogAsserts.assertLogMessagePresentContaining(TestLogLevel.WARN,
+                TransportLogMessages.WARN.INSECURE_HTTP_JWKS.resolveIdentifierString());
+    }
 
     @Test
     @DisplayName("Should create config with default values")

--- a/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/commons/transport/WellKnownConfigTest.java
+++ b/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/commons/transport/WellKnownConfigTest.java
@@ -16,6 +16,9 @@
 package de.cuioss.sheriff.token.commons.transport;
 
 import de.cuioss.http.client.handler.SecureSSLContextProvider;
+import de.cuioss.test.juli.LogAsserts;
+import de.cuioss.test.juli.TestLogLevel;
+import de.cuioss.test.juli.junit5.EnableTestLogger;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -24,11 +27,49 @@ import java.net.URI;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@EnableTestLogger
 @DisplayName("Tests WellKnownConfig")
 class WellKnownConfigTest {
 
     private static final String TEST_WELL_KNOWN_URL = "https://example.com/.well-known/openid-configuration";
     private static final URI TEST_WELL_KNOWN_URI = URI.create(TEST_WELL_KNOWN_URL);
+    private static final String INSECURE_WELL_KNOWN_URL = "http://example.com/.well-known/openid-configuration";
+
+    @Test
+    @DisplayName("Should warn about insecure HTTP well-known discovery URL")
+    void shouldWarnAboutInsecureHttpWellKnownUrl() {
+        WellKnownConfig config = WellKnownConfig.builder()
+                .wellKnownUrl(INSECURE_WELL_KNOWN_URL)
+                .build();
+
+        assertTrue(config.getHttpHandler().getUri().toString().startsWith("http://"),
+                "Insecure HTTP well-known URL is allowed by default");
+        LogAsserts.assertLogMessagePresentContaining(TestLogLevel.WARN,
+                TransportLogMessages.WARN.INSECURE_HTTP_WELLKNOWN.resolveIdentifierString());
+        LogAsserts.assertLogMessagePresentContaining(TestLogLevel.WARN, INSECURE_WELL_KNOWN_URL);
+    }
+
+    @Test
+    @DisplayName("Should reject insecure HTTP well-known URL when allowInsecureHttp(false)")
+    void shouldRejectInsecureHttpWellKnownUrlWhenDisallowed() {
+        var builder = WellKnownConfig.builder()
+                .allowInsecureHttp(false)
+                .wellKnownUrl(INSECURE_WELL_KNOWN_URL);
+        assertThrows(IllegalArgumentException.class, builder::build,
+                "http:// well-known URL must be rejected when insecure HTTP is disallowed");
+    }
+
+    @Test
+    @DisplayName("Should allow https well-known URL when allowInsecureHttp(false)")
+    void shouldAllowHttpsWellKnownUrlWhenInsecureDisallowed() {
+        WellKnownConfig config = WellKnownConfig.builder()
+                .allowInsecureHttp(false)
+                .wellKnownUrl(TEST_WELL_KNOWN_URL)
+                .build();
+
+        assertNotNull(config.getHttpHandler());
+        assertTrue(config.getHttpHandler().getUri().toString().startsWith("https://"));
+    }
 
     @Test
     @DisplayName("Should create config with URL string")

--- a/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/jwks/http/HttpJwksLoaderFailureTest.java
+++ b/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/jwks/http/HttpJwksLoaderFailureTest.java
@@ -76,9 +76,10 @@ class HttpJwksLoaderFailureTest {
             LogAsserts.assertLogMessagePresentContaining(TestLogLevel.ERROR,
                     JWTValidationLogMessages.ERROR.JWKS_LOAD_FAILED.resolveIdentifierString());
 
-            // After migration: ETagAwareHttpAdapter logs HTTP-200 (CONFIGURATION_ERROR_DURING_REQUEST) for connection errors
-            LogAsserts.assertLogMessagePresentContaining(TestLogLevel.ERROR,
-                    HttpLogMessages.ERROR.CONFIGURATION_ERROR_DURING_REQUEST.resolveIdentifierString());
+            // cui-http 2.0.0 classifies an unreachable host as a network error and logs
+            // REQUEST_FAILED_MAX_ATTEMPTS at WARN once retries are exhausted.
+            LogAsserts.assertLogMessagePresentContaining(TestLogLevel.WARN,
+                    HttpLogMessages.WARN.REQUEST_FAILED_MAX_ATTEMPTS.resolveIdentifierString());
         }
     }
 


### PR DESCRIPTION
## Summary

Bumps `de.cuioss:cui-java-parent` from `1.4.5` to `1.5.0`, which upgrades the transitive `cui-http` dependency to `2.0.0`, and adapts the transport layer to the changed `HttpHandler` API.

In cui-http `2.0.0`, `HttpHandler.build()` now **rejects `http://` URLs** unless the builder explicitly opts in via `allowInsecureHttp(true)`. This broke JWKS/well-known loading against plain-HTTP endpoints (including all tests backed by the HTTP mock server) with `IllegalArgumentException: Invalid URL or HttpHandler configuration`.

## Changes

- **`pom.xml`** — parent `1.4.5` → `1.5.0` (pulls `cui-http` `2.0.0`, `cui-java-tools` `2.7.0`).
- **`HttpJwksLoaderConfig`** — enable `allowInsecureHttp(true)` on the direct-endpoint builder and on the per-URL handler factory. This layer already emits its own `INSECURE_HTTP_JWKS` warning for cleartext endpoints, so it keeps the established "allow but warn" contract instead of failing hard (behavior asserted by `KeyDisclosureVulnerabilityTest`).
- **`WellKnownConfig`** — enable `allowInsecureHttp(true)` on the well-known discovery builder for the same reason.
- **`HttpJwksLoaderFailureTest`** — an unreachable host is now classified as a network error (`REQUEST_FAILED_MAX_ATTEMPTS`, WARN) rather than a configuration error (`CONFIGURATION_ERROR_DURING_REQUEST`, ERROR); the assertion is updated to match cui-http `2.0.0` semantics.

## Verification

- `./mvnw clean install` — **BUILD SUCCESS** across all modules (1538 validation tests pass; the previously failing 69 http:// rejections and the network-error assertion are resolved).
- `./mvnw -Ppre-commit clean verify` — **BUILD SUCCESS** (static analysis / OpenRewrite markers clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NeeyPJhodXHv7R9hWiPq5p)_

## Summary by Sourcery

Upgrade HTTP transport dependencies and align JWKS/well-known loading with the new HttpHandler handling of insecure HTTP and network errors.

Bug Fixes:
- Restore support for loading JWKS and well-known configuration over insecure HTTP endpoints by enabling allowInsecureHttp in the transport configuration.

Enhancements:
- Align HttpHandler-based JWKS and well-known loaders with cui-http 2.0.0 by explicitly allowing insecure HTTP while retaining existing warning behavior.
- Update logging expectations to treat unreachable JWKS hosts as network failures with WARN-level retries instead of configuration errors.

Build:
- Bump cui-java-parent to 1.5.0, updating transitive cui-http and related HTTP tooling dependencies.

Tests:
- Adjust JWKS loader failure tests to assert the new WARN-level REQUEST_FAILED_MAX_ATTEMPTS classification for unreachable hosts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `allowInsecureHttp` option to allow `http://` JWKS and well-known discovery endpoints when explicitly configured.
  * Added security warnings for insecure (`http://`) JWKS and well-known URLs (with guidance to use HTTPS in production).

* **Bug Fixes**
  * Adjusted JWKS-loading failure logging to reflect retry exhaustion with warning-level output.

* **Tests**
  * Updated and expanded tests to cover the new insecure HTTP acceptance rules and warning behavior.

* **Chores**
  * Updated the parent project version in the build configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->