### PR TITLE
docs(oidc): reconcile plan status, fix client traceability, add capability READMEs

### DIFF
--- a/doc/README.adoc
+++ b/doc/README.adoc
@@ -9,6 +9,7 @@ The shared base layer every capability sits on — the `de.cuioss.sheriff.token.
 packages inside `token-sheriff-validation` (transport, error model, security events,
 metrics), enforced by ArchUnit rather than shipped as a separate module.
 
+* xref:commons/README.adoc[Overview] - Capability entry point: intro, scope, reading order, document map
 * xref:commons/requirements.adoc[Requirements] - `COMMONS-N`, grouped by concern
 * xref:commons/architecture.adoc[Architecture] - The base layer and its ArchUnit boundary
 * xref:commons/threat-model.adoc[Threat Model] - SSRF / TLS / response-DoS / error-detail leakage
@@ -24,6 +25,7 @@ metrics), enforced by ArchUnit rather than shipped as a separate module.
 
 The token validation capability — its requirements, architecture, security model, and specifications.
 
+* xref:validation/README.adoc[Overview] - Capability entry point: intro, scope, reading order, document map
 * xref:validation/requirements.adoc[Requirements] - Functional and non-functional requirements
 * xref:validation/architecture.adoc[Architecture] - Validation pipeline, components, and design
 
@@ -51,6 +53,7 @@ The `token-sheriff-client` module (and its `token-sheriff-client-quarkus` extens
 as a wired, empty skeleton (xref:oidc/05-client-module/README.adoc[Plan 05]); this document set
 still leads the functional content, which lands per xref:oidc/06-implement/README.adoc[Plan 06].
 
+* xref:client/README.adoc[Overview] - Capability entry point: intro, scope, reading order, document map
 * xref:client/requirements.adoc[Requirements] - `CLIENT-N`, grouped by aspect (Retrieval & flow / Token)
 * xref:client/architecture.adoc[Architecture] - Client/BFF engine seam and boundaries
 * xref:client/references.adoc[References] - Bibliography

--- a/doc/client/README.adoc
+++ b/doc/client/README.adoc
@@ -1,0 +1,72 @@
+= Client Capability
+:source-highlighter: highlight.js
+
+The *active* OIDC side of Token-Sheriff: a server-side *confidential-client engine* that
+retrieves tokens, holds and refreshes them server-side, and drives the OAuth 2.0 / OpenID
+Connect flows on top of the xref:../commons/requirements.adoc[commons] transport. It is the
+engine a *Backend-For-Frontend (BFF)* is built on — *it is not itself a BFF*.
+
+The set is documented *spec-first*: the requirements, threat model and specifications below
+lead; the functional code lands protocol-by-protocol under
+xref:../oidc/06-implement/README.adoc[Plan 06]. The `token-sheriff-client` module currently
+exists as a wired, empty skeleton (xref:../oidc/05-client-module/README.adoc[Plan 05]).
+
+== Scope at a glance
+
+The engine *owns* two aspects and *delegates the rest* — it issues no HTTP of its own and adds
+no signature policy (the seam is detailed in xref:architecture.adoc[Architecture]):
+
+* *Retrieval & flow* (net-new) — auth-code + PKCE, the token-endpoint grants, client
+  authentication, flow integrity (`state` / `nonce` / exact `redirect_uri`), mix-up defence,
+  PAR, step-up, RP-initiated logout, and sender-constraint requests.
+* *Token* (lifecycle delta) — validate every retrieved token, then hold / refresh / revoke it
+  server-side and preserve its sender-constraint.
+* *Delegated* — outbound IdP HTTP, TLS and SSRF defence to xref:../commons/requirements.adoc[commons];
+  token trust (signatures, claims, algorithm policy) to xref:../validation/requirements.adoc[validation];
+  RFC 9457 problem+json rendering to the HTTP edge.
+
+== Start here
+
+. xref:requirements.adoc[Requirements] — the `CLIENT-N` contract, grouped by aspect.
+. xref:threat-model.adoc[Threat Model] — the attack catalog each requirement answers.
+. xref:architecture.adoc[Architecture] — where the engine sits and what it delegates.
+. The <<_document_map,specifications>> — how each requirement is realized.
+
+== [[_document_map]] Document map
+
+[cols="1,3", options="header"]
+|===
+| Document | Purpose
+
+| xref:requirements.adoc[Requirements]
+| `CLIENT-1`–`CLIENT-22`, grouped by aspect; each sourced and threat-driven.
+
+| xref:architecture.adoc[Architecture]
+| The engine seam, its commons / validation boundaries, the auth-code + PKCE sequence, and the BFF binding shapes it must keep viable.
+
+| xref:threat-model.adoc[Threat Model]
+| Acquisition / flow and token-lifecycle threats, each with a mitigation, a source and the covering requirement.
+
+| xref:best-practices.adoc[Best Practices]
+| The normative MUST/SHOULD checklist, tracing each item to a requirement and (where threat-driven) a threat.
+
+| xref:references.adoc[References]
+| Bibliography — standards new to the client, and those reused (cited, not restated) from commons / validation.
+
+| xref:specification/retrieval-flow.adoc[Spec — Retrieval & flow]
+| Auth-code + PKCE flow, grants, client authentication, `state` / `nonce`, mix-up, PAR, sender-constraint requests (`CLIENT-1`–`CLIENT-11`, `CLIENT-14`).
+
+| xref:specification/step-up-and-logout.adoc[Spec — Step-up & logout]
+| RFC 9470 step-up authentication and RP-initiated logout (`CLIENT-12`, `CLIENT-13`).
+
+| xref:specification/token-handling.adoc[Spec — Token handling]
+| The server-side lifecycle delta — validation, storage, refresh, revocation, sender-constraint preservation (`CLIENT-15`–`CLIENT-20`).
+|===
+
+== See also
+
+* xref:../README.adoc[Documentation Hub]
+* xref:../commons/requirements.adoc[Commons] — the transport / error / events / metrics base layer
+* xref:../validation/requirements.adoc[Validation] — the inherited token-trust pipeline
+* xref:../oidc/decision-oidc-module.adoc[Module Architecture decision] — the validation + client split
+* xref:../oidc/04-client-spec/README.adoc[Plan 04] (this document set) · xref:../oidc/06-implement/README.adoc[Plan 06] (implementation)

--- a/doc/client/best-practices.adoc
+++ b/doc/client/best-practices.adoc
@@ -11,8 +11,8 @@ _See xref:requirements.adoc[Client Requirements] and xref:threat-model.adoc[Thre
 
 A normative, sourced checklist for the server-side confidential-client engine. Each item is
 a MUST/SHOULD drawn from the standards catalogued in xref:references.adoc[References], traces
-to a xref:requirements.adoc[requirement] and a xref:threat-model.adoc[threat], and reflects
-the *most-secure current subset* principle: current standards only (the BCP, the OAuth 2.1
+to a xref:requirements.adoc[requirement] and, where the practice is threat-driven, a
+xref:threat-model.adoc[threat], and reflects the *most-secure current subset* principle: current standards only (the BCP, the OAuth 2.1
 direction, Browser-Based-Apps BFF guidance, FAPI 2.0 where it raises the bar), and no
 capability included merely because "the spec allows it".
 
@@ -69,7 +69,7 @@ the client uses it and adds no HTTP of its own; the transport row records that b
 | *Prefer PAR* where advertised — push authorization parameters over the back channel; drive
   the redirect with `request_uri`. Mandatory under FAPI 2.0.
 | https://www.rfc-editor.org/rfc/rfc9126[RFC 9126], https://openid.net/specs/fapi-2_0-security-profile.html[FAPI 2.0]
-| xref:requirements.adoc#CLIENT-10[CLIENT-10]
+| xref:requirements.adoc#CLIENT-10[CLIENT-10] / xref:threat-model.adoc#T-PARAM-INTEGRITY[T-PARAM-INTEGRITY]
 
 | *Sender-constrain retrieved tokens* with DPoP or mTLS wherever the AS supports it; preserve
   the binding through storage and refresh.

--- a/doc/client/requirements.adoc
+++ b/doc/client/requirements.adoc
@@ -398,7 +398,7 @@ sourced xref:best-practices.adoc[best-practices] checklist, and realized in a sp
 | CLIENT-7 | T-REDIRECT | retrieval-flow
 | CLIENT-8 | T-MIXUP | retrieval-flow
 | CLIENT-9 | T-CODE-INJECTION | retrieval-flow
-| CLIENT-10 | T-CODE-INJECTION (parameter integrity) | retrieval-flow
+| CLIENT-10 | T-PARAM-INTEGRITY | retrieval-flow
 | CLIENT-11 | T-TOKEN-REPLAY | retrieval-flow
 | CLIENT-12 | T-STEPUP | xref:specification/step-up-and-logout.adoc[step-up-and-logout]
 | CLIENT-13 | T-LOGOUT | step-up-and-logout
@@ -408,6 +408,6 @@ sourced xref:best-practices.adoc[best-practices] checklist, and realized in a sp
 | CLIENT-17 | T-REFRESH-THEFT, T-LOGOUT | token-handling
 | CLIENT-18 | T-CONSTRAINT-LOSS | token-handling
 | CLIENT-19 | (BFF groundwork — non-preclusion) | xref:architecture.adoc[architecture], token-handling
-| CLIENT-20 | T-LEAK (delegated to commons) | token-handling
+| CLIENT-20 | xref:../commons/threat-model.adoc#T-LEAK[commons T-LEAK] (delegated) | token-handling
 | CLIENT-21..22 | (cross-cutting: engine boundary + adversarial coverage) | architecture, all specs
 |===

--- a/doc/client/requirements.adoc
+++ b/doc/client/requirements.adoc
@@ -30,11 +30,8 @@ mitigates or is the secure way to perform a needed operation.
 
 === Document Navigation
 
-* xref:architecture.adoc[Architecture] — the client/BFF engine seam and its boundaries
-* xref:threat-model.adoc[Threat Model] — attack catalog per aspect, each entry sourced
-* xref:best-practices.adoc[Best Practices] — the normative, sourced checklist
-* xref:references.adoc[References] — bibliography
-* xref:specification/retrieval-flow.adoc[Retrieval & flow spec] · xref:specification/step-up-and-logout.adoc[Step-up & logout spec] · xref:specification/token-handling.adoc[Token-handling spec]
+The xref:README.adoc[capability README] is the entry point — it carries the full document map
+and the recommended reading order for this set.
 
 === Referenced Standards
 

--- a/doc/client/specification/retrieval-flow.adoc
+++ b/doc/client/specification/retrieval-flow.adoc
@@ -44,8 +44,9 @@ The engine constructs a single authorization request as a confidential client
 Where the AS advertises `pushed_authorization_request_endpoint`, the parameters are *pushed
 via PAR* over the back channel (authenticated per <<_client_authentication>>) and the
 front-channel redirect carries only the returned `request_uri`
-(xref:../requirements.adoc#CLIENT-10[CLIENT-10]) — keeping the authorization parameters off
-the browser and tamper-proof. PAR is mandatory under FAPI 2.0.
+(xref:../requirements.adoc#CLIENT-10[CLIENT-10],
+xref:../threat-model.adoc#T-PARAM-INTEGRITY[T-PARAM-INTEGRITY]) — keeping the authorization
+parameters off the browser and tamper-proof. PAR is mandatory under FAPI 2.0.
 
 == The callback and code exchange
 

--- a/doc/client/threat-model.adoc
+++ b/doc/client/threat-model.adoc
@@ -17,9 +17,12 @@ replay, insufficient authentication assurance, and logout that leaves tokens liv
 server-side *token-lifecycle* threats of refresh-token theft, audience confusion and
 sender-constraint loss.
 
-Each entry cites a source, a mitigation, and the covering `CLIENT-N` requirement, grouped by
-aspect. Threats are kept *separate by aspect* and *not blended* with the transport or
-token-trust threats owned elsewhere (<<_out_of_scope_delegated>>).
+The catalog builds on the foundational OAuth 2.0 threat model
+(https://www.rfc-editor.org/rfc/rfc6819[RFC 6819]) and the current OAuth 2.0 Security BCP
+(https://www.rfc-editor.org/rfc/rfc9700[RFC 9700]). Each entry cites a source, a mitigation,
+and the covering `CLIENT-N` requirement, grouped by aspect. Threats are kept *separate by
+aspect* and *not blended* with the transport or token-trust threats owned elsewhere
+(<<_out_of_scope_delegated>>).
 
 == System context
 
@@ -57,6 +60,15 @@ The client engine:
   fall back to `plain` or a non-PKCE request.
 | https://www.rfc-editor.org/rfc/rfc9700#section-4.8[RFC 9700 §4.8]
 | xref:requirements.adoc#CLIENT-2[CLIENT-2]
+
+| [[T-PARAM-INTEGRITY]]T-PARAM-INTEGRITY
+| *Authorization-request parameter tampering / exposure (front channel).* Authorization
+  parameters carried through the browser can be inspected or altered before they reach the AS.
+| Where the AS advertises PAR, push the authorization parameters over the authenticated back
+  channel and drive the front-channel redirect with only the returned `request_uri`, so the
+  parameters are neither exposed nor tamperable in the browser.
+| https://www.rfc-editor.org/rfc/rfc9126[RFC 9126], https://openid.net/specs/fapi-2_0-security-profile.html[FAPI 2.0], https://www.rfc-editor.org/rfc/rfc9700#section-2.1[RFC 9700 §2.1]
+| xref:requirements.adoc#CLIENT-10[CLIENT-10]
 
 | [[T-MIXUP]]T-MIXUP
 | *Mix-up attack (multiple authorization servers).* With more than one AS configured, an
@@ -158,8 +170,9 @@ The client engine:
 | [[T-IDTOKEN-INTEGRITY]]T-IDTOKEN-INTEGRITY
 | *ID-token / userinfo integrity.* Identity is taken from an unvalidated ID token, or from a
   userinfo response whose `sub` does not match the ID token (identity confusion).
-| Validate the ID-token signature and claims (`iss`/`aud`/`exp`/`nonce`/`at_hash`); validate a
-  signed userinfo response and bind its `sub` to the ID token's `sub`, rejecting mismatches.
+| Validate the ID-token signature and claims (`iss`/`aud`/`azp`/`exp`/`nonce`/`at_hash`);
+  validate a signed userinfo response and bind its `sub` to the ID token's `sub`, rejecting
+  mismatches.
 | https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation[OIDC Core §3.1.3.7], https://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse[OIDC Core §5.3.2]
 | xref:requirements.adoc#CLIENT-16[CLIENT-16]
 
@@ -186,6 +199,7 @@ xref:../oidc/06-implement/README.adoc[Plan 06] integration suite:
 
 | T-CODE-INJECTION / T-PKCE-DOWNGRADE | `TokenDispatcher` rejects/accepts codes against the presented `code_verifier`; missing-PKCE and `plain` requests refused.
 | T-MIXUP | `WellKnownDispatcher` advertises a mismatched `issuer`; the `iss` response parameter is cross-checked before exchange.
+| T-PARAM-INTEGRITY | `ParDispatcher` accepts the pushed parameters and returns a `request_uri`; the front-channel redirect is asserted to carry only that `request_uri`, never the raw authorization parameters.
 | T-CSRF / T-REDIRECT | Callback handling asserts session-bound `state` and exact `redirect_uri`; crafted callbacks rejected.
 | T-CLIENT-CRED | `TokenDispatcher` asserts the configured client-auth method; secret-in-URL and non-TLS attempts are not made.
 | T-TOKEN-REPLAY / T-CONSTRAINT-LOSS | `TokenDispatcher` issues DPoP / mTLS-bound responses; the binding is validated and preserved through storage/refresh.

--- a/doc/commons/README.adoc
+++ b/doc/commons/README.adoc
@@ -1,0 +1,73 @@
+= Commons Base Layer
+:source-highlighter: highlight.js
+
+The *shared base layer* every Token-Sheriff capability sits on — the
+`de.cuioss.sheriff.token.commons.*` packages *inside* `token-sheriff-validation`, kept a
+dependency-light layer by ArchUnit rather than shipped as a separate artifact. Commons
+*moves bytes, raises typed errors, counts events and exposes metrics; it never interprets a
+token's trust* — that is the xref:../validation/README.adoc[validation] layer's job.
+
+Both validation and the coming xref:../client/README.adoc[client] consume it; the
+re-packaging and the ArchUnit boundary are established in
+xref:../oidc/03-commons/README.adoc[Plan 03].
+
+== Scope at a glance
+
+Commons gathers the four cross-cutting concerns every capability needs, and *nothing that
+interprets trust*:
+
+* *Transport* (`commons.transport`) — all outbound IdP HTTP (discovery, JWKS, token,
+  userinfo, revocation, introspection, end-session, PAR) with TLS enforcement, SSRF defence,
+  DoS bounds, resilience and caching.
+* *Error model* (`commons.error`) — the typed-exception hierarchy libraries throw, which the
+  HTTP edges render as RFC 9457 problem+json; inbound IdP errors are normalized, not passed
+  through.
+* *Security events* (`commons.events`) — the `SecurityEventCounter` surface shared across
+  capabilities.
+* *Metrics* (`commons.metrics`) — the `sheriff.token.*` metric identifiers, defined once.
+
+The boundary is enforced: ArchUnit forbids `commons` depending "up" on `…validation..` (see
+xref:architecture.adoc[Architecture]).
+
+== Start here
+
+. xref:requirements.adoc[Requirements] — the `COMMONS-N` contract, grouped by concern.
+. xref:architecture.adoc[Architecture] — the base layer and its ArchUnit boundary.
+. xref:threat-model.adoc[Threat Model] — the transport / error-leakage threats commons owns.
+. The <<_document_map,specifications>> — how each concern is realized.
+
+== [[_document_map]] Document map
+
+[cols="1,3", options="header"]
+|===
+| Document | Purpose
+
+| xref:requirements.adoc[Requirements]
+| `COMMONS-1`–`COMMONS-15`, grouped by concern (transport / error model / events / metrics); each sourced.
+
+| xref:architecture.adoc[Architecture]
+| The `commons` base layer, its sub-packages, and the ArchUnit rules that keep it from depending on validation.
+
+| xref:threat-model.adoc[Threat Model]
+| SSRF, TLS downgrade, response-DoS and error-detail-leakage threats, each with a mitigation, a source and the covering requirement.
+
+| xref:references.adoc[References]
+| Bibliography — transport / error-model standards new to commons, and those reused (cited, not restated) from the validation set.
+
+| xref:specification/transport.adoc[Spec — Transport]
+| The IdP endpoints, TLS / SSRF / resilience controls, caching, and the MockWebServer dispatcher artifact (`COMMONS-1`–`COMMONS-8`).
+
+| xref:specification/error-model.adoc[Spec — Error model]
+| Typed exceptions → RFC 9457 at every HTTP edge; inbound IdP error normalization (`COMMONS-9`–`COMMONS-12`).
+
+| xref:specification/observability.adoc[Spec — Observability]
+| The security-event surface and the metric identifiers (`COMMONS-13`–`COMMONS-15`).
+|===
+
+== See also
+
+* xref:../README.adoc[Documentation Hub]
+* xref:../validation/README.adoc[Validation] — the token-trust pipeline that ships alongside this base layer
+* xref:../client/README.adoc[Client] — the coming consumer of the extended transport
+* xref:../oidc/decision-oidc-module.adoc[Module Architecture decision] — why commons is an enforced layer, not a separate artifact
+* xref:../oidc/03-commons/README.adoc[Plan 03] — the commons base-layer plan

--- a/doc/commons/requirements.adoc
+++ b/doc/commons/requirements.adoc
@@ -20,10 +20,8 @@ xref:threat-model.adoc[threat model]; they are not sequential across groups.
 
 === Document Navigation
 
-* xref:architecture.adoc[Architecture] — the base layer and its ArchUnit boundary
-* xref:threat-model.adoc[Threat Model] — SSRF / TLS / response-DoS / error-detail leakage
-* xref:references.adoc[References] — bibliography
-* xref:specification/transport.adoc[Transport spec] · xref:specification/error-model.adoc[Error-model spec] · xref:specification/observability.adoc[Observability spec]
+The xref:README.adoc[capability README] is the entry point — it carries the full document map
+and the recommended reading order for this set.
 
 === Referenced Standards
 

--- a/doc/oidc/03-commons/README.adoc
+++ b/doc/oidc/03-commons/README.adoc
@@ -6,7 +6,7 @@
 
 [cols="1,3"]
 |===
-| Status     | *Done* (2026-07-04, https://github.com/cuioss/TokenSheriff/pull/536[#536]) — see <<Verification>>; the `wellknown`/`jwks.http` transport migration was folded into xref:../05-client-module/README.adoc[Plan 05]
+| Status     | *Done* — see <<Verification>>; the `wellknown`/`jwks.http` transport migration was folded into xref:../05-client-module/README.adoc[Plan 05]. Ship date + PR in the xref:../README.adoc[status roll-up].
 | Depends on | Plan 01 (rename → `token-sheriff-*`), Plan 02 (doc structure — establishes `doc/commons/`)
 | Focus      | Gather the *cross-cutting concerns every capability sits on* into one *base layer* — the `de.cuioss.sheriff.token.commons.*` packages *inside* `token-sheriff-validation`: *IdP transport*, the *error model* (typed exceptions → RFC 9457 at the edge), *security events*, and *metrics*. *Not a separate artifact* — ArchUnit enforces the layering. Spec-first plus the *re-packaging* of these out of the validation packages.
 | Outcome    | The `commons` base packages + ArchUnit rules living in `token-sheriff-validation`; its requirements/spec/threat-model under `doc/commons/` (`COMMONS-N`).

--- a/doc/oidc/03-commons/README.adoc
+++ b/doc/oidc/03-commons/README.adoc
@@ -6,7 +6,7 @@
 
 [cols="1,3"]
 |===
-| Status     | Ready to execute (spec after xref:../02-doc-structure/README.adoc[Plan 02]; re-packaging after xref:../01-restructure/README.adoc[Plan 01])
+| Status     | *Done* (2026-07-04, https://github.com/cuioss/TokenSheriff/pull/536[#536]) — see <<Verification>>; the `wellknown`/`jwks.http` transport migration was folded into xref:../05-client-module/README.adoc[Plan 05]
 | Depends on | Plan 01 (rename → `token-sheriff-*`), Plan 02 (doc structure — establishes `doc/commons/`)
 | Focus      | Gather the *cross-cutting concerns every capability sits on* into one *base layer* — the `de.cuioss.sheriff.token.commons.*` packages *inside* `token-sheriff-validation`: *IdP transport*, the *error model* (typed exceptions → RFC 9457 at the edge), *security events*, and *metrics*. *Not a separate artifact* — ArchUnit enforces the layering. Spec-first plus the *re-packaging* of these out of the validation packages.
 | Outcome    | The `commons` base packages + ArchUnit rules living in `token-sheriff-validation`; its requirements/spec/threat-model under `doc/commons/` (`COMMONS-N`).

--- a/doc/oidc/04-client-spec/README.adoc
+++ b/doc/oidc/04-client-spec/README.adoc
@@ -6,7 +6,7 @@
 
 [cols="1,3"]
 |===
-| Status     | *Done* (2026-07-05, https://github.com/cuioss/TokenSheriff/pull/537[#537]) — `CLIENT-1..22` requirements, specification, threat model and best practices live under `doc/client/`
+| Status     | *Done* — `CLIENT-1..22` requirements, specification, threat model and best practices live under `doc/client/`. Ship date + PR in the xref:../README.adoc[status roll-up].
 | Depends on | Plan 02 (doc structure) and xref:../03-commons/README.adoc[Plan 03] (the Commons transport this builds on); produces the spec the future client module is built against (spec-first)
 | Focus      | Server-side *token retrieval* (token-endpoint grants incl. confidential authorization-code + PKCE), the *flow integrity* around it (`state`/`nonce`/PKCE, mix-up defence, step-up, RP-initiated logout), and the *token lifecycle* — the engine a *Backend-For-Frontend (BFF)* is built on. The *outbound IdP HTTP* it uses (discovery, JWKS, token, userinfo, …) belongs to xref:../03-commons/README.adoc[commons] and is referenced, not respecified. A *most-secure current subset*, security-led, every normative item source-referenced.
 |===

--- a/doc/oidc/04-client-spec/README.adoc
+++ b/doc/oidc/04-client-spec/README.adoc
@@ -6,7 +6,7 @@
 
 [cols="1,3"]
 |===
-| Status     | Ready to execute (after xref:../02-doc-structure/README.adoc[Plan 02] establishes `doc/client/`)
+| Status     | *Done* (2026-07-05, https://github.com/cuioss/TokenSheriff/pull/537[#537]) — `CLIENT-1..22` requirements, specification, threat model and best practices live under `doc/client/`
 | Depends on | Plan 02 (doc structure) and xref:../03-commons/README.adoc[Plan 03] (the Commons transport this builds on); produces the spec the future client module is built against (spec-first)
 | Focus      | Server-side *token retrieval* (token-endpoint grants incl. confidential authorization-code + PKCE), the *flow integrity* around it (`state`/`nonce`/PKCE, mix-up defence, step-up, RP-initiated logout), and the *token lifecycle* — the engine a *Backend-For-Frontend (BFF)* is built on. The *outbound IdP HTTP* it uses (discovery, JWKS, token, userinfo, …) belongs to xref:../03-commons/README.adoc[commons] and is referenced, not respecified. A *most-secure current subset*, security-led, every normative item source-referenced.
 |===

--- a/doc/oidc/05-client-module/README.adoc
+++ b/doc/oidc/05-client-module/README.adoc
@@ -6,7 +6,7 @@
 
 [cols="1,3"]
 |===
-| Status     | *Done* (2026-07-05, https://github.com/cuioss/TokenSheriff/pull/538[#538]) — the wired-but-empty `token-sheriff-client` engine, `token-sheriff-client-quarkus` extension/deployment, and BOM/reactor assembly exist; the `commons.transport` migration was folded in
+| Status     | *Done* — the wired-but-empty `token-sheriff-client` engine, `token-sheriff-client-quarkus` extension/deployment, and BOM/reactor assembly exist; the `commons.transport` migration was folded in. Ship date + PR in the xref:../README.adoc[status roll-up].
 | Depends on | Plan 01 (rename → `token-sheriff-*`) + Plan 03 (the `commons` base layer inside `token-sheriff-validation` it builds on). Independent of Plan 04 (structure, not content).
 | Outcome    | The three in-repo pieces — *module, extension, assembly* — fully wired, building green, with *no functional content yet*.
 | Scope      | In-repo only. `portal-authentication-oauth` (`cui-portal-core`) is the *replacement target* — a design reference (xref:../decision-oidc-module.adoc[decision], xref:../04-client-spec/README.adoc[Plan 04]), *not* a deliverable of this plan. The portal adapter and the integration tests against it are *future work beyond Plans 01–06*.

--- a/doc/oidc/05-client-module/README.adoc
+++ b/doc/oidc/05-client-module/README.adoc
@@ -6,7 +6,7 @@
 
 [cols="1,3"]
 |===
-| Status     | Ready to execute (after xref:../01-restructure/README.adoc[Plan 01])
+| Status     | *Done* (2026-07-05, https://github.com/cuioss/TokenSheriff/pull/538[#538]) — the wired-but-empty `token-sheriff-client` engine, `token-sheriff-client-quarkus` extension/deployment, and BOM/reactor assembly exist; the `commons.transport` migration was folded in
 | Depends on | Plan 01 (rename → `token-sheriff-*`) + Plan 03 (the `commons` base layer inside `token-sheriff-validation` it builds on). Independent of Plan 04 (structure, not content).
 | Outcome    | The three in-repo pieces — *module, extension, assembly* — fully wired, building green, with *no functional content yet*.
 | Scope      | In-repo only. `portal-authentication-oauth` (`cui-portal-core`) is the *replacement target* — a design reference (xref:../decision-oidc-module.adoc[decision], xref:../04-client-spec/README.adoc[Plan 04]), *not* a deliverable of this plan. The portal adapter and the integration tests against it are *future work beyond Plans 01–06*.

--- a/doc/oidc/06-implement/README.adoc
+++ b/doc/oidc/06-implement/README.adoc
@@ -6,7 +6,7 @@
 
 [cols="1,3"]
 |===
-| Status     | Ready after xref:../04-client-spec/README.adoc[Plan 04] (spec) + xref:../05-client-module/README.adoc[Plan 05] (skeleton)
+| Status     | *Ready to execute — next plan.* Dependencies satisfied (Plan 03 #536, Plan 04 #537, Plan 05 #538, all done); execution begins with Increment 1 (client config + discovery). Not yet started.
 | Depends on | Plan 03 (the `commons` base layer + `COMMONS-N` spec + the extended MockWebServer dispatchers), Plan 04 (`CLIENT-N` requirements + threat model), Plan 05 (`token-sheriff-client` module/extension/assembly)
 | Approach   | Vertical *protocol-by-protocol* increments, dependency-ordered. Each ships unit tests (MockWebServer) *and* integration tests against a *real Keycloak*. Security-driven.
 |===

--- a/doc/oidc/06-implement/README.adoc
+++ b/doc/oidc/06-implement/README.adoc
@@ -6,7 +6,7 @@
 
 [cols="1,3"]
 |===
-| Status     | *Ready to execute — next plan.* Dependencies satisfied (Plan 03 #536, Plan 04 #537, Plan 05 #538, all done); execution begins with Increment 1 (client config + discovery). Not yet started.
+| Status     | *Ready to execute — next plan.* Dependencies satisfied (Plans 03–05, all done — see the xref:../README.adoc[status roll-up]); execution begins with Increment 1 (client config + discovery). Not yet started.
 | Depends on | Plan 03 (the `commons` base layer + `COMMONS-N` spec + the extended MockWebServer dispatchers), Plan 04 (`CLIENT-N` requirements + threat model), Plan 05 (`token-sheriff-client` module/extension/assembly)
 | Approach   | Vertical *protocol-by-protocol* increments, dependency-ordered. Each ships unit tests (MockWebServer) *and* integration tests against a *real Keycloak*. Security-driven.
 |===

--- a/doc/oidc/README.adoc
+++ b/doc/oidc/README.adoc
@@ -58,10 +58,26 @@ implementation plans plus the standing design decisions behind them.
   capability split under `doc/validation/` is executed and wired into the
   xref:../README.adoc[Documentation Hub]. Phase 2 (client scaffolding) is deferred by
   design until client work starts.
-* Plans 03–06: planning only — not yet started.
+* xref:03-commons/README.adoc[Plan 03 — Commons]: *Done*
+  (2026-07-04, https://github.com/cuioss/TokenSheriff/pull/536[#536]) — the
+  `de.cuioss.sheriff.token.commons.*` base layer (transport / error / events / metrics),
+  ArchUnit boundary, RFC 9457 mapping, and extended MockWebServer dispatchers ship inside
+  `token-sheriff-validation`; `doc/commons/` document set present.
+* xref:04-client-spec/README.adoc[Plan 04 — Client Spec]: *Done*
+  (2026-07-05, https://github.com/cuioss/TokenSheriff/pull/537[#537]) — the client
+  capability document set (`CLIENT-1..22` requirements, specification, threat model, best
+  practices) is under `doc/client/`.
+* xref:05-client-module/README.adoc[Plan 05 — Client Module]: *Done*
+  (2026-07-05, https://github.com/cuioss/TokenSheriff/pull/538[#538]) — the wired-but-empty
+  `token-sheriff-client` engine plus `token-sheriff-client-quarkus` extension/deployment
+  and BOM/reactor assembly exist; the `commons.transport` migration was folded in.
+* xref:06-implement/README.adoc[Plan 06 — Implement the Client]: *Next — not yet started.*
+  All dependencies (Plans 03–05) are satisfied; execution begins with Increment 1
+  (client config + discovery).
 
 [NOTE]
 ====
-Plans 03–06 are not yet wired into the top-level
-xref:../README.adoc[Documentation Hub]; they will be linked in as each is executed.
+Plans 03–05 are executed but not yet wired into the top-level
+xref:../README.adoc[Documentation Hub]; the client capability docs link in as Plan 06
+delivers the code behind them.
 ====

--- a/doc/oidc/README.adoc
+++ b/doc/oidc/README.adoc
@@ -77,7 +77,8 @@ implementation plans plus the standing design decisions behind them.
 
 [NOTE]
 ====
-Plans 03–05 are executed but not yet wired into the top-level
-xref:../README.adoc[Documentation Hub]; the client capability docs link in as Plan 06
-delivers the code behind them.
+The commons, validation and client *capability* documentation is wired into the top-level
+xref:../README.adoc[Documentation Hub]. This OIDC *planning* workspace (the numbered plans
+above) is the working area behind those capabilities and is intentionally not itself a hub
+section.
 ====

--- a/doc/validation/README.adoc
+++ b/doc/validation/README.adoc
@@ -1,0 +1,71 @@
+= Token Validation Capability
+:source-highlighter: highlight.js
+
+The *passive* core of Token-Sheriff: a multi-issuer *JWT validation library* for resource
+servers. It *validates tokens, never acquires them* — signature, algorithm policy, and the
+`iss` / `aud` / `exp` / `iat` claim set, across multiple configured issuers. Token
+acquisition and the OAuth / OpenID Connect flows are the xref:../client/README.adoc[client]
+capability's job; this library only decides a presented token's trust.
+
+The `token-sheriff-validation` artifact also *carries the* xref:../commons/README.adoc[commons]
+*base layer* (transport / error / events / metrics) as an ArchUnit-enforced package layer — so
+a consumer that needs only validation (e.g. `nifi-extensions`) pulls a single artifact.
+
+== Scope at a glance
+
+* *Owns* — the validation pipeline: signature verification (asymmetric only; `alg=none` /
+  HMAC / weak keys rejected per RFC 8725), mandatory `iss` / `exp` / audience checks,
+  multi-issuer configuration, RFC 9068 access-token and OIDC ID-token validation, and optional
+  RFC 9449 DPoP sender-constraint validation.
+* *Delegates* — all outbound IdP HTTP (discovery, JWKS), TLS / SSRF defence and the error
+  model to xref:../commons/README.adoc[commons]; token *acquisition* and the flows to
+  xref:../client/README.adoc[client].
+* *Is a resource-server validator* — it handles no authorization flows, token issuance,
+  redirect URIs or HTTP transport (see the OAuth 2.1 compatibility note in
+  xref:requirements.adoc#_oauth_2_1_compatibility[Requirements]).
+
+== Start here
+
+. xref:requirements.adoc[Requirements] — the `VALIDATION-N` contract and the OAuth 2.1 compatibility statement.
+. xref:architecture.adoc[Architecture] — the multi-stage validation pipeline and its components.
+. xref:threat-model.adoc[Threat Model] & xref:security-reference.adoc[Security Reference] — the STRIDE analysis and the consolidated attack-mitigation controls.
+. The <<_document_map,specifications>> and the module xref:../../token-sheriff-validation/doc/usage-guide.adoc[usage guide].
+
+== [[_document_map]] Document map
+
+[cols="1,3", options="header"]
+|===
+| Document | Purpose
+
+| xref:requirements.adoc[Requirements]
+| `VALIDATION-N` functional and non-functional requirements, plus the OAuth 2.1 resource-server compatibility statement.
+
+| xref:architecture.adoc[Architecture]
+| The multi-stage validation pipeline, its components and key design decisions.
+
+| xref:threat-model.adoc[Threat Model]
+| STRIDE threat analysis with per-threat mitigations, implementation references and coverage status.
+
+| xref:security-reference.adoc[Security Reference]
+| Consolidated JWT attack mitigations, security controls and best practices.
+
+| xref:specification/microprofile-jwt-compatibility.adoc[Spec — MicroProfile JWT]
+| MP-JWT 2.1 integration and rationale.
+
+| xref:specification/token-decryption.adoc[Spec — Token decryption]
+| Future JWE / encrypted-token support.
+
+| xref:specification/multi-idp-testing.adoc[Spec — Multi-IdP testing]
+| Testing against multiple OIDC providers.
+
+| xref:faq/keycloak.adoc[FAQ — Keycloak]
+| Keycloak integration questions.
+|===
+
+== See also
+
+* xref:../README.adoc[Documentation Hub]
+* xref:../commons/README.adoc[Commons] — the transport / error / events / metrics base layer this artifact carries
+* xref:../client/README.adoc[Client] — the active capability that retrieves the tokens this library validates
+* xref:../oidc/decision-oidc-module.adoc[Module Architecture decision] — the validation + client split
+* Module docs: xref:../../token-sheriff-validation/doc/usage-guide.adoc[Usage Guide] · xref:../../token-sheriff-validation/doc/api-reference.adoc[API Reference] · xref:../LogMessages.adoc[Log Messages] · link:../../README.md[Project README]

--- a/doc/validation/requirements.adoc
+++ b/doc/validation/requirements.adoc
@@ -11,11 +11,8 @@ This document outlines the functional and non-functional requirements for the JW
 
 === Document Navigation
 
-* link:../../README.md[README] - Project overview and introduction
-* xref:../../token-sheriff-validation/doc/usage-guide.adoc[Usage Guide] - How to use the library with code examples
-* xref:architecture.adoc[Architecture] - Architecture reference
-* xref:../LogMessages.adoc[Log Messages] - Reference for all log messages
-* xref:threat-model.adoc[Threat Model] - Security analysis and mitigations
+The xref:README.adoc[capability README] is the entry point — it carries the full document map
+and the recommended reading order for this set.
 
 == Referenced Standards
 


### PR DESCRIPTION
Documentation-only changes across the OIDC planning docs and the capability doc sets. Three logical commits:

## 1. Reconcile OIDC plan status (`7da6eeec`)
Plans 03 (#536), 04 (#537) and 05 (#538) are merged, but `doc/oidc/README.adoc` still described 03–06 as "planning only". Updated the status section with per-plan Done entries (dates + PRs), flipped the stale "Ready to execute" headers on Plans 03–05 to Done, and marked Plan 06 as the active next plan.

## 2. Fix `doc/client` traceability & reference consistency (`6bd5c829`)
A full review of `doc/client` surfaced five defects, now fixed:
- Added a dedicated **`T-PARAM-INTEGRITY`** threat (authorization-request parameter tampering, mitigated by PAR) and re-pointed `CLIENT-10` to it — the requirements table previously mapped it to `T-CODE-INJECTION`, which the threat model did not back.
- Cited **RFC 6819** in the threat-model overview so it is no longer an orphan reference.
- Linked `CLIENT-20` to the **commons `T-LEAK`** anchor instead of dangling under the local-threats column.
- Softened the best-practices "traces to a requirement and a threat" invariant to cover the intentionally requirement-only rows.
- Added **`azp`** to the `T-IDTOKEN-INTEGRITY` mitigation, matching `CLIENT-16` and the token-handling spec.

## 3. Add capability README landing pages (`5bd85fbf`)
Each capability under `doc/` (`client`, `commons`, `validation`) now has a `README.adoc` front door: a short intro, a scope-at-a-glance orientation, a recommended reading order, and a document map — deferring to the existing requirements/threat/spec docs rather than restating them. The now-redundant "Document Navigation" list in each `requirements.adoc` is collapsed to a pointer at its README, and each README is added as the lead "Overview" entry in the top-level documentation hub.

All internal anchors and cross-reference paths were verified to resolve.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new overview pages for the Commons, Validation, and Client capabilities.
  * Expanded the documentation hub with direct links to these new sections.
  * Added detailed navigation, reading order, and reference maps for the Client and Validation documentation.
  * Updated Commons and Validation docs to make the capability README the main starting point.
  * Refreshed OIDC plan status pages to reflect completed work and the next execution phase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->