### PR TITLE
docs(client): add test-strategy specification (unit + Keycloak integration) and backtrack Plan 06

### DIFF
--- a/doc/client/README.adoc
+++ b/doc/client/README.adoc
@@ -31,6 +31,7 @@ no signature policy (the seam is detailed in xref:architecture.adoc[Architecture
 . xref:threat-model.adoc[Threat Model] — the attack catalog each requirement answers.
 . xref:architecture.adoc[Architecture] — where the engine sits and what it delegates.
 . The <<_document_map,specifications>> — how each requirement is realized.
+. xref:specification/test-strategy.adoc[Test Strategy] — how each requirement and threat is verified (unit + integration).
 
 == [[_document_map]] Document map
 
@@ -61,6 +62,9 @@ no signature policy (the seam is detailed in xref:architecture.adoc[Architecture
 
 | xref:specification/token-handling.adoc[Spec — Token handling]
 | The server-side lifecycle delta — validation, storage, refresh, revocation, sender-constraint preservation (`CLIENT-15`–`CLIENT-20`).
+
+| xref:specification/test-strategy.adoc[Spec — Test strategy]
+| The two-layer verification model (MockWebServer unit + real-Keycloak integration), the adversarial coverage, and the `CLIENT-N` → threat → test traceability matrix (`CLIENT-22`). Executed by xref:../oidc/06-implement/README.adoc[Plan 06].
 |===
 
 == See also

--- a/doc/client/architecture.adoc
+++ b/doc/client/architecture.adoc
@@ -152,4 +152,5 @@ captured as sourced `CLIENT-N` requirements above.
 * xref:specification/retrieval-flow.adoc[Retrieval & flow specification]
 * xref:specification/step-up-and-logout.adoc[Step-up & logout specification]
 * xref:specification/token-handling.adoc[Token-handling specification]
+* xref:specification/test-strategy.adoc[Test-strategy specification]
 * xref:../oidc/04-client-spec/README.adoc[Plan 04 — Client Spec]

--- a/doc/client/references.adoc
+++ b/doc/client/references.adoc
@@ -149,6 +149,15 @@ client cites them; it does not re-enumerate them.
 | `cui-portal-core` — `modules/authentication/portal-authentication-oauth`
 | Real-world confidential server-side OIDC client (CDI + MicroProfile Config + RESTEasy); the
   design reference and eventual replacement target (future work beyond Plans 01–06)
+
+| https://github.com/cuioss/cui-test-mockwebserver-junit5[cui-test-mockwebserver-junit5]
+| The CUI MockWebServer JUnit 5 framework (`@EnableMockWebServer`, `@ModuleDispatcher`,
+  `assertCallsAnswered`) used for the unit-layer OP simulation
+  (xref:specification/test-strategy.adoc[Test strategy])
+
+| `de.cuioss.http.security.database` attack databases
+| Curated OWASP / CVE / ModSecurity-CRS corpora driving adversarial input tests of the engine's
+  untrusted-input parsing (xref:specification/test-strategy.adoc[Test strategy])
 |===
 
 == See also

--- a/doc/client/requirements.adoc
+++ b/doc/client/requirements.adoc
@@ -373,7 +373,9 @@ The engine MUST be thread-safe (shared per-issuer configuration, concurrent flow
 `CLIENT-N` flow / token requirement MUST be exercised by unit tests driving the commons
 `generators` dispatchers in both default and *adversarial* modes (the token / userinfo /
 end-session / PAR dispatchers, `COMMONS-7`), plus real-IdP integration tests
-(xref:../oidc/06-implement/README.adoc[Plan 06]).
+(xref:../oidc/06-implement/README.adoc[Plan 06]). The two-layer verification model, the
+adversarial coverage, and the full `CLIENT-N` → threat → test traceability are specified in
+xref:specification/test-strategy.adoc[Test strategy].
 
 * Source: https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/05-Authorization_Testing/05-Testing_for_OAuth_Weaknesses[OWASP WSTG — Testing for OAuth Weaknesses], xref:../commons/requirements.adoc#COMMONS-7[COMMONS-7].
 
@@ -406,5 +408,5 @@ sourced xref:best-practices.adoc[best-practices] checklist, and realized in a sp
 | CLIENT-18 | T-CONSTRAINT-LOSS | token-handling
 | CLIENT-19 | (BFF groundwork — non-preclusion) | xref:architecture.adoc[architecture], token-handling
 | CLIENT-20 | xref:../commons/threat-model.adoc#T-LEAK[commons T-LEAK] (delegated) | token-handling
-| CLIENT-21..22 | (cross-cutting: engine boundary + adversarial coverage) | architecture, all specs
+| CLIENT-21..22 | (cross-cutting: engine boundary + adversarial coverage) | architecture, xref:specification/test-strategy.adoc[test-strategy], all specs
 |===

--- a/doc/client/requirements.adoc
+++ b/doc/client/requirements.adoc
@@ -408,5 +408,5 @@ sourced xref:best-practices.adoc[best-practices] checklist, and realized in a sp
 | CLIENT-18 | T-CONSTRAINT-LOSS | token-handling
 | CLIENT-19 | (BFF groundwork — non-preclusion) | xref:architecture.adoc[architecture], token-handling
 | CLIENT-20 | xref:../commons/threat-model.adoc#T-LEAK[commons T-LEAK] (delegated) | token-handling
-| CLIENT-21..22 | (cross-cutting: engine boundary + adversarial coverage) | architecture, xref:specification/test-strategy.adoc[test-strategy], all specs
+| CLIENT-21..22 | (cross-cutting: engine boundary + adversarial coverage) | xref:architecture.adoc[architecture], xref:specification/test-strategy.adoc[test-strategy], all specs
 |===

--- a/doc/client/specification/retrieval-flow.adoc
+++ b/doc/client/specification/retrieval-flow.adoc
@@ -141,10 +141,12 @@ Each check above is exercised against the commons `TokenDispatcher` / `WellKnown
 spec], `COMMONS-7`) and the xref:../../oidc/06-implement/README.adoc[Plan 06] integration
 suite (xref:../requirements.adoc#CLIENT-22[CLIENT-22]): PKCE downgrade refused, `state` /
 `iss` / `redirect_uri` mismatches rejected, injected codes not redeemable, and the configured
-client-auth method asserted.
+client-auth method asserted. The full unit + integration coverage and the `CLIENT-N` → threat →
+test traceability are specified in xref:test-strategy.adoc[Test strategy].
 
 == See also
 
 * xref:step-up-and-logout.adoc[Step-up & logout specification]
 * xref:token-handling.adoc[Token-handling specification]
+* xref:test-strategy.adoc[Test-strategy specification]
 * xref:../architecture.adoc[Architecture] — the auth-code + PKCE sequence

--- a/doc/client/specification/step-up-and-logout.adoc
+++ b/doc/client/specification/step-up-and-logout.adoc
@@ -92,10 +92,12 @@ The commons `EndSessionDispatcher` *adversarial* mode returns open-redirect / mi
 `post_logout_redirect_uri` responses, which the engine rejects; revocation of held tokens is
 asserted after logout (xref:../requirements.adoc#CLIENT-22[CLIENT-22], `COMMONS-7`). Step-up
 is exercised by driving an `insufficient_user_authentication` challenge and asserting the
-re-driven `acr` / `auth_time` verification.
+re-driven `acr` / `auth_time` verification. The full unit + integration coverage and the
+`CLIENT-N` → threat → test traceability are specified in xref:test-strategy.adoc[Test strategy].
 
 == See also
 
 * xref:retrieval-flow.adoc[Retrieval & flow specification]
 * xref:token-handling.adoc[Token-handling specification]
+* xref:test-strategy.adoc[Test-strategy specification]
 * xref:../architecture.adoc[Architecture]

--- a/doc/client/specification/test-strategy.adoc
+++ b/doc/client/specification/test-strategy.adoc
@@ -1,0 +1,400 @@
+= Client Specification — Test Strategy
+:toc: left
+:toclevels: 3
+:sectnums:
+:source-highlighter: highlight.js
+
+== Overview
+
+_Realizes xref:../requirements.adoc#CLIENT-22[CLIENT-22] (thread safety + adversarial test
+coverage) and is the test specification the xref:../../oidc/06-implement/README.adoc[Plan 06]
+implementation executes. See xref:../threat-model.adoc[Threat Model],
+xref:../requirements.adoc[Requirements], xref:../best-practices.adoc[Best Practices] and
+xref:../architecture.adoc[Architecture]._
+
+This specification defines *how the client engine is verified* — the test surface that every
+`CLIENT-N` requirement, and every threat in the xref:../threat-model.adoc[threat model], is
+proven against. It is the source of truth for the two-layer testing model
+xref:../../oidc/06-implement/README.adoc[Plan 06] carries out increment by increment; Plan 06
+backtracks to this document rather than re-deriving the model.
+
+The strategy has *two layers that are never conflated*:
+
+* *Unit layer* — in `token-sheriff-client/src/test`, using *CUI MockWebServer* to simulate a
+  controllable OpenID Provider. This is where the *mechanics* and the *adversarial* coverage
+  live, because only a controllable mock can emit malicious metadata, tampered tokens, PKCE
+  downgrades, wrong `iss`, injected codes, open-redirect logout responses, or oversized
+  bodies. The engine is pure Java (xref:../requirements.adoc#CLIENT-21[CLIENT-21]), so it is
+  unit-tested with no CDI / Quarkus in the loop.
+* *Integration layer* — Failsafe `*IT` tests running the *Quarkus-packaged* engine against
+  *real* OpenID Providers (Keycloak always-on; Dex and Zitadel profile-gated), reusing the
+  existing xref:../../oidc/06-implement/README.adoc[in-repo] Docker-Compose harness. This
+  proves each protocol *actually interoperates* with a real OP, across *happy*,
+  *corner / edge* and *attack* case classes.
+
+[IMPORTANT]
+====
+The user-facing rule (xref:../../oidc/06-implement/README.adoc[Plan 06]): *MockWebServer
+proves the mechanics and the attacks; Keycloak proves it really works.* Both layers are
+required for every protocol increment — neither substitutes for the other.
+====
+
+== The two test layers
+
+image::../../resources/diagrams/client-test-layers.svg["Client engine two-layer test strategy — the pure-Java token-sheriff-client engine is driven from the left by a CUI MockWebServer unit layer (adversarial dispatchers, attack databases, request verification) against a mock OP, and from the right by a Quarkus-packaged integration layer of Failsafe IT tests against real OPs (Keycloak, Dex, Zitadel) split into happy, corner/edge and attack case classes", align=center]
+
+The layers are complementary, not redundant:
+
+[cols="1,2,2", options="header"]
+|===
+| Question the layer answers | Unit (MockWebServer) | Integration (real Keycloak)
+
+| Does the engine *send* the right request?
+| Yes — assert the recorded request (PKCE `S256`, exact `redirect_uri`, client-auth method,
+  `id_token_hint`, DPoP proof).
+| Implicitly — the real OP rejects a wrong request.
+
+| Does the engine *reject* a malicious response?
+| *Primary home* — the adversarial dispatcher modes emit responses a conformant OP never
+  would.
+| Only the subset a real OP can naturally produce (e.g. a genuinely expired token).
+
+| Does the protocol *actually interoperate*?
+| No — a mock cannot prove conformance.
+| *Primary home* — the protocol runs end-to-end against a real OP.
+
+| Provider-quirk / real-world edge behaviour?
+| No.
+| *Primary home* — parameterized across Keycloak / Dex / Zitadel.
+|===
+
+== Unit layer — MockWebServer
+
+=== Placement and reuse
+
+The engine's unit tests live in `token-sheriff-client/src/test/java`, organized *by aspect /
+protocol* (mirroring the production packages) with the CUI `*Test` naming convention and AAA
+structure — the same layout as `token-sheriff-validation` (`@DisplayName`, `@Nested`,
+`ShouldHandleObjectContracts` value-object contracts for client config / response records).
+
+The OP simulators are *not re-authored*: `token-sheriff-validation` already publishes its test
+utilities as a *test-jar with classifier `generators`* (its `maven-jar-plugin` `test-jar`
+goal, xref:../../oidc/03-commons/README.adoc[Plan 03]). The client test module declares that
+test-jar dependency (a xref:../../oidc/06-implement/README.adoc[Plan 06] wiring step — the
+`token-sheriff-client` pom does not yet declare it) and reuses:
+
+* the OP-endpoint dispatchers — `TokenDispatcher`, `UserInfoDispatcher`,
+  `RevocationDispatcher`, `IntrospectionDispatcher`, `EndSessionDispatcher`, `ParDispatcher`,
+  and the relocated `WellKnownDispatcher` / `JwksResolveDispatcher`
+  (xref:../../commons/specification/transport.adoc#adversarial_dispatchers[commons transport
+  spec], `COMMONS-7`);
+* the shared adversarial payloads (`AdversarialResponses`, e.g. oversized-body DoS payloads)
+  and the token-tampering utility (`JwtTokenTamperingUtil`);
+* the key material / token helpers (`InMemoryKeyMaterialHandler`, `TestTokenHolder`) and the
+  generator bridge (`@EnableGeneratorController` + `@TestTokenSource`).
+
+=== Framework and conventions
+
+Follow the CUI xref:../references.adoc#_supporting_sources_informative[cui-http-testing]
+standards (`cui-test-mockwebserver-junit5`):
+
+* `@EnableMockWebServer` on the test class; wire a dispatcher via the conventional
+  `moduleDispatcher` field (Lombok `@Getter`) or a raw `MockWebServer` + `CombinedDispatcher`
+  aggregating several endpoint dispatchers for a multi-endpoint flow.
+* `@EnableMockWebServer(useHttps = true)` and injected `SSLContext` — the engine's outbound
+  HTTP is TLS-only (`COMMONS-2`), so mock endpoints are HTTPS.
+* Inject `URIBuilder` to construct endpoint URIs — never hard-code ports.
+* Drive dispatcher behaviour with the fluent `returnDefault()` / `returnError()` /
+  `returnMalformedBody()` / `returnOversizedBody()` mutators and verify with
+  `assertCallsAnswered(int)` / the call counter. (`@MockResponseConfig` is available for
+  trivial single-endpoint cases, but programmable dispatchers are the primary pattern.)
+* Assert structured security events with `LogAsserts` + `@EnableTestLogger` (the engine logs
+  via `CuiLogger` / `LogRecord`).
+
+=== What the unit layer owns
+
+[cols="1,3", options="header"]
+|===
+| Category | What the tests do
+
+| *Mechanics (happy path)*
+| Each protocol's request/response construction and interpretation against the dispatcher's
+  *default* mode — discovery, `client_credentials`, code exchange, refresh, userinfo,
+  revocation, end-session, PAR.
+
+| *Request verification*
+| Inspect the `RecordedRequest` and assert the engine *sent* the secure form: `S256`
+  `code_challenge_method` (xref:../requirements.adoc#CLIENT-2[CLIENT-2]), a single exact
+  `redirect_uri` (xref:../requirements.adoc#CLIENT-7[CLIENT-7]), the configured client-auth
+  method and *never a secret in a URL* (xref:../requirements.adoc#CLIENT-4[CLIENT-4]), the
+  `id_token_hint` / `state` on logout, the DPoP proof on a sender-constrained request. This is
+  coverage a response-only test cannot give.
+
+| *Adversarial (fail-closed)*
+| Drive each dispatcher's *adversarial* mode and assert the engine *rejects* — see
+  <<_adversarial_coverage>>. Every threat in the xref:../threat-model.adoc[threat model] MUST
+  have a unit test that fails closed.
+
+| *Thread safety* (xref:../requirements.adoc#CLIENT-22[CLIENT-22])
+| Concurrent flows over shared per-issuer configuration; assert no cross-flow leakage of
+  `state` / `nonce` / `code_verifier` / stored tokens.
+
+| *Boundary*
+| ArchUnit rules assert the engine contains no CDI / MicroProfile / JAX-RS
+  (xref:../requirements.adoc#CLIENT-21[CLIENT-21]) and depends on `validation` only, never the
+  reverse.
+|===
+
+=== [[_adversarial_coverage]] Adversarial coverage — dispatchers and attack databases
+
+Two adversarial mechanisms, applied where each fits:
+
+*Dispatcher adversarial modes* — for malicious *OP responses* (the bulk of the flow / token
+threats). Each dispatcher emits the response only a hostile or misconfigured OP would, and the
+test asserts rejection:
+
+[cols="1,3", options="header"]
+|===
+| Threat | Adversarial unit test (dispatcher mode)
+
+| xref:../threat-model.adoc#T-PKCE-DOWNGRADE[T-PKCE-DOWNGRADE]
+| `WellKnownDispatcher` omits `S256` from `code_challenge_methods_supported` → the request is
+  refused, never downgraded to `plain` / no-PKCE.
+
+| xref:../threat-model.adoc#T-CODE-INJECTION[T-CODE-INJECTION]
+| `TokenDispatcher` rejects a code presented without the matching `code_verifier`; an ID token
+  with a mismatched `nonce` is rejected.
+
+| xref:../threat-model.adoc#T-CSRF[T-CSRF] / xref:../threat-model.adoc#T-REDIRECT[T-REDIRECT]
+| Callback handling rejects a missing / mismatched `state`; only an exact `redirect_uri` is
+  accepted.
+
+| xref:../threat-model.adoc#T-MIXUP[T-MIXUP]
+| `WellKnownDispatcher` advertises a mismatched `issuer` / the `iss` response parameter differs
+  from the initiating issuer → rejected *before* the code is exchanged.
+
+| xref:../threat-model.adoc#T-PARAM-INTEGRITY[T-PARAM-INTEGRITY]
+| `ParDispatcher` returns a `request_uri`; the front-channel redirect is asserted to carry
+  *only* that `request_uri`, never the raw authorization parameters.
+
+| xref:../threat-model.adoc#T-AUD-CONFUSION[T-AUD-CONFUSION] / xref:../threat-model.adoc#T-IDTOKEN-INTEGRITY[T-IDTOKEN-INTEGRITY]
+| `TokenDispatcher` / `UserInfoDispatcher` emit tampered claims (via `JwtTokenTamperingUtil`)
+  and a userinfo `sub` mismatch → the validation pipeline rejects; the `sub` binding is
+  enforced.
+
+| xref:../threat-model.adoc#T-REFRESH-THEFT[T-REFRESH-THEFT]
+| `TokenDispatcher` refresh mode drives rotation; a reused rotated refresh token triggers
+  *family revocation*.
+
+| xref:../threat-model.adoc#T-LOGOUT[T-LOGOUT]
+| `EndSessionDispatcher` returns an open-redirect / mismatched `post_logout_redirect_uri` →
+  rejected; revocation of held tokens is asserted.
+
+| xref:../threat-model.adoc#T-CONSTRAINT-LOSS[T-CONSTRAINT-LOSS]
+| A DPoP / mTLS-bound token is asserted to keep its binding across storage and refresh.
+|===
+
+*Attack databases* — for untrusted *input parsing* inside the engine (callback query
+parameters, the RFC 9470 `WWW-Authenticate` challenge, `post_logout_redirect_uri`
+comparison). Rather than a handful of hand-picked payloads, drive the curated
+`de.cuioss.http.security.database` corpora (`OWASPTop10AttackDatabase`,
+`ApacheCVEAttackDatabase`, `ModSecurityCRSAttackDatabase`) through
+`@ArgumentsSource(...AttackDatabase.ArgumentsProvider.class)`, asserting the parser rejects
+each encoding-evasion / injection variant. This keeps the adversarial corpus comprehensive and
+maintained upstream.
+
+NOTE: The unit layer does *not* re-test what other modules own. Signature / algorithm policy
+and claim trust are the xref:../../validation/requirements.adoc[validation] pipeline's
+(`VALIDATION-*`); TLS / SSRF / size-limit transport hardening is `commons`'s
+(`COMMONS-1`–`COMMONS-8`). The client tests assert it *invokes* those controls and reacts
+correctly — they do not duplicate their internal tests.
+
+== Integration layer — real Keycloak
+
+=== Placement and harness
+
+Integration tests are Failsafe `*IT` classes that exercise the *Quarkus-packaged* engine
+(`token-sheriff-client-quarkus`) against real OPs. They extend the existing in-repo harness in
+the `token-sheriff-quarkus-integration-tests` module rather than standing up a new one:
+
+* a `docker-compose` topology (not Testcontainers) — *Keycloak always-on*, *Dex* and *Zitadel*
+  profile-gated, Postgres backing Zitadel;
+* `*IT` bound to `maven-failsafe-plugin` under an *opt-in* profile (`skipITs` defaults to
+  `true`; the `integration-tests` profile flips it and brings the compose stack up in
+  `pre-integration-test`, down in `post-integration-test`);
+* `BaseIntegrationTest` (RestAssured against the mapped HTTPS port) and the `TestRealm` /
+  `TestProviders` / `Capability` model, which already performs client-side token acquisition
+  (`obtainValidToken()`, `obtainDpopBoundToken()`) — the exact flows the client module
+  implements.
+
+image::../../resources/diagrams/multi-idp-test-topology.svg["Multi-IdP integration-test container topology — one Docker Compose network hosting the integration-test runner and the Keycloak (always-on) / Dex / Zitadel (profile-gated) providers, with Postgres backing Zitadel", align=center]
+
+Tests are *provider-agnostic* (parameterized over `TestProviders`) where the protocol is
+portable, and *Keycloak-specific* where it is not; provider-specific capabilities (PAR, DPoP)
+are gated via `TestRealm.Capability` so a provider that does not advertise a feature is skipped
+rather than failed.
+
+=== The three case classes
+
+Each protocol increment contributes to *three* integration case classes (the user-facing split
+this specification mandates):
+
+[cols="1,3", options="header"]
+|===
+| Case class | What it proves
+
+| *Happy cases*
+| The protocol interoperates with a real OP end-to-end: discovery against `.well-known`; a
+  `client_credentials` token validated by the pipeline; each client-auth method accepted; a
+  refresh cycle with rotation; a full auth-code + PKCE login and code exchange; PAR (where
+  advertised); userinfo fetch and `sub` binding; a DPoP-bound token; RP-initiated logout; and
+  the full-flow E2E (login → token → userinfo → refresh → logout).
+
+| *Corner / edge cases*
+| Real-world boundaries a mock glosses over: access-token expiry boundaries and clock skew;
+  concurrent / racing refresh; refresh-rotation continuity; optional / absent claims; provider
+  quirks across Keycloak / Dex / Zitadel; the `max_age` boundary for step-up; and graceful
+  behaviour when an *optional* capability (PAR, DPoP) is *not* advertised.
+
+| *Attack / adversarial cases*
+| The threat-model behaviour a *real* OP can exercise: a mismatched `state` / `nonce` rejected;
+  a wrong `iss` (mix-up, using two real providers) rejected before exchange; an injected /
+  replayed code refused; a tampered / expired token rejected by the pipeline; a reused rotated
+  refresh token triggering family revocation; a logout open-redirect via an unmatched
+  `post_logout_redirect_uri` rejected; a held token confirmed *revoked* after logout; and an
+  `insufficient_user_authentication` response whose re-driven `acr` / `auth_time` does not
+  satisfy the requirement *not* treated as a successful step-up.
+|===
+
+The division of labour with the unit layer is deliberate: adversarial *responses that only a
+mock can emit* (malformed metadata, oversized bodies, forged signatures) stay in the unit
+layer; the integration attack cases assert the *client's own rejection behaviour* and the
+protections a real OP naturally enforces.
+
+== [[_traceability]] Traceability matrix
+
+Each `CLIENT-N` requirement maps to its threat(s), its unit coverage, its integration
+coverage, and the xref:../../oidc/06-implement/README.adoc[Plan 06] increment that delivers it.
+
+[cols="1,1,2,2,1", options="header"]
+|===
+| Req | Threat(s) | Unit (MockWebServer) | Integration (real OP) | Inc.
+
+| xref:../requirements.adoc#CLIENT-1[CLIENT-1] | T-URL-LEAK
+| `form_post`; code exchanged on the back channel; no token in any URL
+| Full KC login + code exchange | 5, 11
+
+| xref:../requirements.adoc#CLIENT-2[CLIENT-2] | T-CODE-INJECTION, T-PKCE-DOWNGRADE
+| `S256` asserted on the request; no-`S256` discovery → refused; `plain` refused
+| PKCE login against KC | 5
+
+| xref:../requirements.adoc#CLIENT-3[CLIENT-3] | (grant hygiene)
+| `authorization_code` / `refresh_token` / `client_credentials` accepted; ROPC / implicit
+  absent
+| `client_credentials` + refresh against KC | 2, 4
+
+| xref:../requirements.adoc#CLIENT-4[CLIENT-4] | T-CLIENT-CRED
+| Configured client-auth method asserted on the recorded request; no secret in a URL
+| Each method accepted by KC | 3
+
+| xref:../requirements.adoc#CLIENT-5[CLIENT-5] | T-CSRF
+| Missing / mismatched `state` on the callback rejected
+| `state` round-trip on KC login | 5
+
+| xref:../requirements.adoc#CLIENT-6[CLIENT-6] | T-CODE-INJECTION
+| Mismatched ID-token `nonce` rejected
+| `nonce` verified against KC ID token | 5
+
+| xref:../requirements.adoc#CLIENT-7[CLIENT-7] | T-REDIRECT
+| Exact `redirect_uri` on the request; no wildcard / prefix
+| Exact-match against KC | 5
+
+| xref:../requirements.adoc#CLIENT-8[CLIENT-8] | T-MIXUP
+| Mismatched `issuer` / `iss` response parameter rejected before exchange
+| Cross-provider `iss` check (KC vs Dex) | 6
+
+| xref:../requirements.adoc#CLIENT-9[CLIENT-9] | T-CODE-INJECTION
+| Code without matching `code_verifier` not redeemable
+| (covered by the PKCE login) | 5
+
+| xref:../requirements.adoc#CLIENT-10[CLIENT-10] | T-PARAM-INTEGRITY
+| `ParDispatcher` `request_uri`; redirect carries only `request_uri`
+| PAR against KC (capability-gated) | 6
+
+| xref:../requirements.adoc#CLIENT-11[CLIENT-11] | T-TOKEN-REPLAY
+| DPoP proof / mTLS binding present on the token request
+| DPoP-bound token from KC (`createDpopRealm`) | 8
+
+| xref:../requirements.adoc#CLIENT-12[CLIENT-12] | T-STEPUP
+| Challenge parsed; re-driven; forged `acr` / `auth_time` not accepted
+| KC: assert `insufficient_user_authentication`, retry with `acr_values` / `max_age`, verify
+  `acr` / `auth_time` | 5
+
+| xref:../requirements.adoc#CLIENT-13[CLIENT-13] | T-LOGOUT
+| Open-redirect / mismatched `post_logout_redirect_uri` rejected; `id_token_hint` / `state`
+  sent
+| RP-initiated logout against KC (exact-matched URI) | 9
+
+| xref:../requirements.adoc#CLIENT-14[CLIENT-14] | T-URL-LEAK, T-TLS-TOKEN (delegated)
+| `token_type` / artifacts checked; response `iss` confirmed; codes / tokens never in a URL
+| Token-response validation against KC | 1, 5
+
+| xref:../requirements.adoc#CLIENT-15[CLIENT-15] | T-AUD-CONFUSION
+| Tampered token → pipeline rejects (`JwtTokenTamperingUtil`)
+| Real KC token validated by the pipeline | 2
+
+| xref:../requirements.adoc#CLIENT-16[CLIENT-16] | T-IDTOKEN-INTEGRITY
+| Userinfo `sub` mismatch rejected; ID-token claims validated
+| Userinfo from KC, `sub` bound to the ID token | 7
+
+| xref:../requirements.adoc#CLIENT-17[CLIENT-17] | T-REFRESH-THEFT, T-LOGOUT
+| Rotation; reused rotated token → family revocation; storage isolation
+| Refresh cycle + revocation against KC | 4, 9
+
+| xref:../requirements.adoc#CLIENT-18[CLIENT-18] | T-CONSTRAINT-LOSS
+| Binding survives storage and refresh
+| DPoP-bound token refresh keeps `cnf.jkt` against KC | 8
+
+| xref:../requirements.adoc#CLIENT-19[CLIENT-19] | (BFF groundwork)
+| Engine seam identical for stateful / stateless; no usable browser artifact returned
+| — (BFF application concern) | 9
+
+| xref:../requirements.adoc#CLIENT-20[CLIENT-20] | commons T-LEAK (delegated)
+| Engine throws typed exceptions; produces no problem+json itself
+| Quarkus edge maps to `application/problem+json`, leaking no detail | 10
+
+| xref:../requirements.adoc#CLIENT-21[CLIENT-21] | (engine boundary)
+| ArchUnit: no CDI / JAX-RS in the engine; `client → validation` only
+| — | all
+
+| xref:../requirements.adoc#CLIENT-22[CLIENT-22] | (cross-cutting)
+| Concurrent flows; *every* threat → a fail-closed adversarial unit test
+| The full `*IT` suite across providers | all
+|===
+
+== Per-increment definition of done (test view)
+
+This is the test-side complement of the xref:../../oidc/06-implement/README.adoc[Plan 06]
+per-increment definition of done. For each protocol increment:
+
+* [ ] *Unit — happy*: the protocol's mechanics against the dispatcher default mode, plus
+  request verification of the secure form the engine sends.
+* [ ] *Unit — adversarial*: every threat the increment touches has a fail-closed unit test
+  (dispatcher adversarial mode and/or attack-database input).
+* [ ] *Integration — happy*: the protocol interoperates with real Keycloak end-to-end.
+* [ ] *Integration — edge*: the increment's real-world boundary cases (see the case-class
+  table).
+* [ ] *Integration — attack*: the increment's threat behaviour a real OP can exercise.
+* [ ] *Traceability*: each `CLIENT-N` the increment delivers is linked to code + unit test +
+  integration test in <<_traceability>>.
+* [ ] Build green: `./mvnw -Ppre-commit clean verify` then `./mvnw clean install`; no source
+  artifacts; JaCoCo coverage recorded.
+
+== See also
+
+* xref:retrieval-flow.adoc[Retrieval & flow specification] — the mechanics under test
+* xref:step-up-and-logout.adoc[Step-up & logout specification]
+* xref:token-handling.adoc[Token-handling specification]
+* xref:../../commons/specification/transport.adoc#adversarial_dispatchers[Commons transport spec] — the dispatcher artifact reused here
+* xref:../../oidc/06-implement/README.adoc[Plan 06 — Implement the Client] — executes this test specification
+* xref:../references.adoc[References] — OWASP WSTG (OAuth weaknesses), cui-http-testing

--- a/doc/client/specification/token-handling.adoc
+++ b/doc/client/specification/token-handling.adoc
@@ -116,11 +116,14 @@ claims, `sub` mismatches, and reused rotated refresh tokens
 (xref:../../commons/specification/transport.adoc#adversarial_dispatchers[commons transport
 spec], `COMMONS-7`); the client tests assert the validation pipeline rejects tampered tokens,
 the userinfo `sub` binding is enforced, rotation triggers family revocation on reuse, and the
-sender-constraint survives a refresh (xref:../requirements.adoc#CLIENT-22[CLIENT-22]).
+sender-constraint survives a refresh (xref:../requirements.adoc#CLIENT-22[CLIENT-22]). The full
+unit + integration coverage and the `CLIENT-N` → threat → test traceability are specified in
+xref:test-strategy.adoc[Test strategy].
 
 == See also
 
 * xref:retrieval-flow.adoc[Retrieval & flow specification]
 * xref:step-up-and-logout.adoc[Step-up & logout specification]
+* xref:test-strategy.adoc[Test-strategy specification]
 * xref:../../validation/requirements.adoc[Validation Requirements] — the inherited token-trust pipeline
 * xref:../../commons/specification/error-model.adoc[Commons error-model specification]

--- a/doc/oidc/04-client-spec/README.adoc
+++ b/doc/oidc/04-client-spec/README.adoc
@@ -116,6 +116,7 @@ doc/client/
     retrieval-flow.adoc        # auth-code+PKCE, grants, client auth, state/nonce, mix-up, PAR
     step-up-and-logout.adoc    # RFC 9470 step-up; RP-initiated logout
     token-handling.adoc        # token lifecycle delta (references the validation module)
+    test-strategy.adoc         # two-layer test model + CLIENT-N→threat→test traceability (feeds Plan 06)
 ----
 
 (Discovery/JWKS/userinfo transport specs live under `doc/commons/`, not here.)

--- a/doc/oidc/06-implement/README.adoc
+++ b/doc/oidc/06-implement/README.adoc
@@ -7,7 +7,7 @@
 [cols="1,3"]
 |===
 | Status     | *Ready to execute — next plan.* Dependencies satisfied (Plans 03–05, all done — see the xref:../README.adoc[status roll-up]); execution begins with Increment 1 (client config + discovery). Not yet started.
-| Depends on | Plan 03 (the `commons` base layer + `COMMONS-N` spec + the extended MockWebServer dispatchers), Plan 04 (`CLIENT-N` requirements + threat model), Plan 05 (`token-sheriff-client` module/extension/assembly)
+| Depends on | Plan 03 (the `commons` base layer + `COMMONS-N` spec + the extended MockWebServer dispatchers), Plan 04 (`CLIENT-N` requirements + threat model + xref:../../client/specification/test-strategy.adoc[test strategy]), Plan 05 (`token-sheriff-client` module/extension/assembly)
 | Approach   | Vertical *protocol-by-protocol* increments, dependency-ordered. Each ships unit tests (MockWebServer) *and* integration tests against a *real Keycloak*. Security-driven.
 |===
 
@@ -23,6 +23,17 @@ Implement one *protocol/flow at a time* as a vertical slice — production code 
 
 == Testing model: MockWebServer (unit) + real Keycloak (integration)
 
+[NOTE]
+====
+The *authoritative test specification* for this plan is
+xref:../../client/specification/test-strategy.adoc[Client — Test strategy] (under the
+capability doc set). It owns the two-layer model, the dispatcher / attack-database adversarial
+coverage, the *happy / corner-edge / attack* integration case classes, and the full
+`CLIENT-N` → threat → unit → integration *traceability matrix*. This plan *executes* that
+specification increment by increment; the summary below is the execution view — the spec is
+the contract.
+====
+
 Two distinct layers — do not conflate them:
 
 * *Unit tests* — in `token-sheriff-client` `src/test`, using *MockWebServer* to simulate the OP (discovery/JWKS/token/userinfo/…), driven by the dispatcher artifact *extended in xref:../03-commons/README.adoc[Plan 03]* (`TokenDispatcher`, `UserInfoDispatcher`, … alongside the existing `WellKnownDispatcher`/`JwksResolveDispatcher`). Vital, but *unit*: this is where the *adversarial* coverage lives — malicious metadata, SSRF, wrong `iss`, code injection, PKCE downgrade, tampered/replayed tokens — because only a controllable mock can emit those. Use the CUI MockWebServer standards (`@ModuleDispatcher`, HTTPS/TLS, generator-driven *attack-database*).
@@ -31,6 +42,9 @@ Two distinct layers — do not conflate them:
 The user-facing rule: *MockWebServer proves the mechanics and the attacks; Keycloak proves it really works.* Both are required per increment.
 
 == Per-increment definition of done
+
+_The test-side rows below trace to the per-increment definition of done in
+xref:../../client/specification/test-strategy.adoc[Test strategy]._
 
 * Production code in `token-sheriff-client`, reusing the `commons` transport and the validation pipeline.
 * *Unit tests* (MockWebServer): protocol mechanics + every adversarial case the increment's threats demand.
@@ -94,7 +108,7 @@ Increments 1–2 prove the whole retrieve→validate loop; 5 is the BFF core; 11
 
 == Verification
 
-* [ ] Every `CLIENT-N` requirement is implemented and traced to code + tests
+* [ ] Every `CLIENT-N` requirement is implemented and traced to code + tests per the xref:../../client/specification/test-strategy.adoc#_traceability[test-strategy traceability matrix]
 * [ ] Every threat in Plan 04's model has an adversarial *unit* test (MockWebServer) that fails closed
 * [ ] Every protocol has a *real-Keycloak integration* test proving interoperability
 * [ ] Each increment merged independently with its tests; build green at every step

--- a/doc/resources/diagrams/client-test-layers.svg
+++ b/doc/resources/diagrams/client-test-layers.svg
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- theme-handling: A (theme-neutral) -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 476"
+     role="img" aria-labelledby="title desc"
+     font-family="ui-sans-serif, -apple-system, system-ui, 'Segoe UI', sans-serif">
+  <title id="title">Client engine two-layer test strategy</title>
+  <desc  id="desc">The token-sheriff-client engine (the CLIENT-N subject under test) is exercised from two sides. On the left, a unit layer built on CUI MockWebServer drives the engine against a controllable mock OpenID Provider through the adversarial dispatchers and attack databases, verifying both the request the engine sends and its rejection of malicious responses. On the right, an integration layer runs the Quarkus-packaged engine against real OpenID Providers — Keycloak always-on, Dex and Zitadel profile-gated — through Failsafe IT tests split into happy, corner/edge and attack case classes. MockWebServer proves the mechanics and the attacks; Keycloak proves it really works.</desc>
+
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5"
+            markerWidth="9" markerHeight="9" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" class="arrow-fill"/>
+    </marker>
+    <style>
+      .col-header { font-size: 15px; font-weight: 600; fill: #6e7681; text-anchor: middle; }
+      .node-sub   { font-size: 11px; fill: #6e7681; text-anchor: middle; font-style: italic; }
+      .item-bold  { font-size: 12px; font-weight: 700; fill: #6e7681;
+                    font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; }
+      .item       { font-size: 11px; fill: #6e7681;
+                    font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; }
+      .item-c     { font-size: 12px; fill: #6e7681; text-anchor: middle;
+                    font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; }
+      .box        { stroke: #6e7681; stroke-width: 1.2; fill: none; }
+      .box-mid    { stroke: #6e7681; stroke-width: 1.6; fill: none; }
+      .sep        { stroke: #6e7681; stroke-width: 0.6; stroke-dasharray: 3 3; fill: none; }
+      .arrow      { stroke: #6e7681; stroke-width: 1.5; fill: none; }
+      .arrow-fill { fill: #6e7681; }
+      .edge-lbl   { font-size: 11px; fill: #6e7681; text-anchor: middle; font-style: italic; }
+      .caption    { font-size: 12px; fill: #6e7681; text-anchor: middle; font-style: italic; }
+    </style>
+  </defs>
+
+  <!-- ===== Column headers ===== -->
+  <text x="150" y="30" class="col-header">Unit layer</text>
+  <text x="150" y="46" class="node-sub">CUI MockWebServer · mock OP</text>
+
+  <text x="450" y="30" class="col-header">Subject under test</text>
+  <text x="450" y="46" class="node-sub">token-sheriff-client</text>
+
+  <text x="750" y="30" class="col-header">Integration layer</text>
+  <text x="750" y="46" class="node-sub">Quarkus packaging · real OP</text>
+
+  <!-- ===== Left column box: unit ===== -->
+  <rect class="box" x="20" y="62" width="260" height="360" rx="6" ry="6"/>
+
+  <text x="36" y="94"  class="item-bold">Dispatchers (adversarial)</text>
+  <text x="50" y="114" class="item">Token · UserInfo · EndSession</text>
+  <text x="50" y="132" class="item">Par · WellKnown · Jwks</text>
+
+  <text x="36" y="166" class="item-bold">Attack databases</text>
+  <text x="50" y="186" class="item">OWASP · CVE · ModSecurity CRS</text>
+
+  <text x="36" y="220" class="item-bold">Request verification</text>
+  <text x="50" y="240" class="item">PKCE S256 · exact redirect_uri</text>
+  <text x="50" y="258" class="item">client-auth · DPoP proof sent</text>
+
+  <text x="36" y="292" class="item-bold">Thread-safety &amp; logging</text>
+  <text x="50" y="312" class="item">concurrent flows · LogAsserts</text>
+
+  <text x="150" y="398" class="caption">mechanics + attacks — fail-closed</text>
+
+  <!-- ===== Middle column box: engine ===== -->
+  <rect class="box-mid" x="320" y="62" width="260" height="360" rx="6" ry="6"/>
+
+  <text x="450" y="100" class="node-sub">pure-Java engine · CLIENT-21</text>
+  <line class="sep" x1="360" y1="120" x2="540" y2="120"/>
+
+  <text x="450" y="156" class="item-c">CLIENT-1..11,14</text>
+  <text x="450" y="174" class="node-sub">retrieval &amp; flow</text>
+
+  <text x="450" y="212" class="item-c">CLIENT-12..13</text>
+  <text x="450" y="230" class="node-sub">step-up &amp; logout</text>
+
+  <text x="450" y="268" class="item-c">CLIENT-15..20</text>
+  <text x="450" y="286" class="node-sub">token lifecycle</text>
+
+  <line class="sep" x1="360" y1="316" x2="540" y2="316"/>
+  <text x="450" y="398" class="caption">one protocol increment at a time</text>
+
+  <!-- ===== Right column box: integration ===== -->
+  <rect class="box" x="620" y="62" width="260" height="360" rx="6" ry="6"/>
+
+  <text x="636" y="94"  class="item-bold">Quarkus packaging</text>
+  <text x="650" y="114" class="item">*IT (Failsafe) · RestAssured</text>
+
+  <text x="636" y="148" class="item-bold">Real OPs (Docker Compose)</text>
+  <text x="650" y="168" class="item">Keycloak · Dex · Zitadel</text>
+
+  <text x="636" y="202" class="item-bold">Case classes</text>
+  <text x="650" y="222" class="item">happy · corner/edge · attack</text>
+
+  <text x="636" y="256" class="item-bold">Reused harness</text>
+  <text x="650" y="276" class="item">BaseIntegrationTest · TestRealm</text>
+
+  <text x="750" y="398" class="caption">proves interoperability</text>
+
+  <!-- ===== Convergent arrows: both layers drive the engine ===== -->
+  <line class="arrow" x1="282" y1="250" x2="318" y2="250" marker-end="url(#arrow)"/>
+  <text x="300" y="242" class="edge-lbl">mock OP</text>
+
+  <line class="arrow" x1="618" y1="250" x2="582" y2="250" marker-end="url(#arrow)"/>
+  <text x="600" y="242" class="edge-lbl">real OP</text>
+
+  <!-- Footer caption -->
+  <text x="450" y="458" class="caption">MockWebServer proves the mechanics and the attacks; Keycloak proves it really works — both required per protocol increment.</text>
+</svg>


### PR DESCRIPTION
## What

Adds the missing **test-strategy specification** to the `client` capability doc set and backtracks the implementation plan to it.

### New: `doc/client/specification/test-strategy.adoc`
The authoritative test specification for the confidential-client engine:

- **Two-layer model** — a **unit layer** (CUI MockWebServer: the reused `generators` test-jar dispatchers in adversarial mode, `de.cuioss.http.security.database` attack databases, and `RecordedRequest` request-verification), and an **integration layer** running the **Quarkus-packaged** engine against **real Keycloak** (Dex / Zitadel profile-gated) on the existing in-repo docker-compose harness.
- **Integration case classes** split exactly as requested: **happy** · **corner/edge** · **attack/adversarial**, reusing `BaseIntegrationTest` / `TestRealm` / `TestProviders` / `Capability`.
- A full **`CLIENT-N` → threat → unit → integration traceability matrix** (realizes `CLIENT-22`) and a per-increment test definition of done.

### New: `doc/resources/diagrams/client-test-layers.svg`
Theme-neutral SVG (verified rendered on both GitHub light `#ffffff` and dark `#0d1117`) showing the two layers converging on the engine.

### Wiring
- Client `README` document map + start-here, `references`, `requirements` (`CLIENT-22`), all three sibling specs, and `architecture` now point to the test strategy.
- **Plan 06** now names the test-strategy spec as the *authoritative* contract it executes (testing model, per-increment DoD, and the verification traceability item all backtrack to it); **Plan 04**'s doc-set tree lists the new file.

## Notes
- Docs-only change; no production or test code touched. The test-jar dependency wiring and the tests themselves remain Plan 06 execution work.
- All touched `.adoc` render clean under `asciidoctor --safe-mode=safe`; both embedded diagrams resolve.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new client test strategy guide outlining a two-layer testing approach and requirement-to-test traceability.
  * Updated client specifications and reference pages to link to the new strategy for retrieval, token handling, and step-up/logout coverage.
  * Expanded the client README and implementation plan references to surface the test model, coverage expectations, and verification checklist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->