### PR TITLE
docs: generalize 'Gemini review' to 'AI Reviewer' in the git workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ All cuioss repositories have branch protection on `main`. Direct pushes to `main
 5. Wait for CI + AI Reviewer(s) (waits until checks complete): `gh pr checks --watch`
 6. **Handle AI Reviewer comments** (whichever bots are configured — e.g. Sourcery, CodeRabbit, Gemini) — fetch with `gh api repos/cuioss/TokenSheriff/pulls/<pr-number>/comments` and for each:
    - If clearly valid and fixable: fix it, commit, push, then reply explaining the fix and resolve the comment
-   - If disagree or out of scope: reply explaining why, then resolve the comment
+   - If you disagree or the comment is out of scope: reply explaining why, then resolve the comment
    - If uncertain (not 100% confident): **ask the user** before acting
    - Every comment MUST get a reply (reason for fix or reason for not fixing) and MUST be resolved
 7. Do **NOT** enable auto-merge unless explicitly instructed. Wait for user approval.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,8 +22,8 @@ All cuioss repositories have branch protection on `main`. Direct pushes to `main
 2. Commit changes: `git add <files> && git commit -m "<message>"`
 3. Push the branch: `git push -u origin <branch-name>`
 4. Create a PR: `gh pr create --repo cuioss/TokenSheriff --head <branch-name> --base main --title "<title>" --body "<body>"`
-5. Wait for CI + Gemini review (waits until checks complete): `gh pr checks --watch`
-6. **Handle Gemini review comments** — fetch with `gh api repos/cuioss/TokenSheriff/pulls/<pr-number>/comments` and for each:
+5. Wait for CI + AI Reviewer(s) (waits until checks complete): `gh pr checks --watch`
+6. **Handle AI Reviewer comments** (whichever bots are configured — e.g. Sourcery, CodeRabbit, Gemini) — fetch with `gh api repos/cuioss/TokenSheriff/pulls/<pr-number>/comments` and for each:
    - If clearly valid and fixable: fix it, commit, push, then reply explaining the fix and resolve the comment
    - If disagree or out of scope: reply explaining why, then resolve the comment
    - If uncertain (not 100% confident): **ask the user** before acting


### PR DESCRIPTION
Generalizes the `CLAUDE.md` Git Workflow wording from **Gemini review** to **AI Reviewer**, since the repo's PRs actually run several review bots (Sourcery, CodeRabbit, Gemini) rather than only Gemini. The comment-handling procedure is unchanged; only the reviewer naming is made generic (with the concrete bots listed as examples).

Docs-only, no code touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Git workflow guidance to apply to CI and AI reviewer comments more broadly.
  * Clarified how to review and respond to automated PR comments, including when to fix, explain, or ask for confirmation.
  * Added a reminder to ensure every comment is addressed and resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->