### PR TITLE
chore: refresh plan architecture snapshots and CLAUDE.md tool-usage note

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -6,6 +6,7 @@
       "thoroughness": "inherit",
       "scope": "inherit"
     },
+    "finding_raw_input_max_bytes": 65536,
     "phase-1-init": {
       "branch_strategy": "feature",
       "use_worktree": true,
@@ -14,7 +15,12 @@
       "deep_lane": "auto",
       "escalation": "auto",
       "auto_route_recipe": true,
-      "auto_route_recipe_threshold": 0.6
+      "auto_route_recipe_threshold": 0.6,
+      "lane_selection": "ask",
+      "lane_prune_thresholds": {
+        "confidence_complete": 95,
+        "linear_change_max_deliverables": 1
+      }
     },
     "phase-2-refine": {
       "confidence_threshold": 95,
@@ -25,11 +31,12 @@
     },
     "phase-3-outline": {
       "plan_without_asking": false,
-      "qgate": "auto",
+      "q_gate_validation": "once",
       "effort": "level-4"
     },
     "phase-4-plan": {
       "execute_without_asking": true,
+      "q_gate_validation": "once",
       "effort": "level-3"
     },
     "phase-5-execute": {
@@ -40,15 +47,18 @@
         "default:verify:module-tests"
       ],
       "cost_size_token_table": {
+        "XS": "5K",
         "S": "25K",
         "M": "60K",
         "L": "130K",
-        "XL": "260K"
+        "XL": "260K",
+        "XXL": "520K"
       },
       "per_envelope_budget_tokens": "400K",
       "verification_steps": {
         "default:verify:quality-gate": {},
-        "default:verify:module-tests": {}
+        "default:verify:module-tests": {},
+        "default:verify:coverage": {}
       },
       "effort": {
         "default": "level-4",
@@ -58,17 +68,10 @@
     "phase-6-finalize": {
       "max_iterations": 3,
       "finalize_without_asking": true,
-      "loop_back_without_asking": true,
+      "loop_back_without_asking": false,
       "qgate": "auto",
       "checks_wait_timeout_seconds": 600,
       "steps": {
-        "default:finalize-step-sync-baseline": {
-          "auto_rebase_threshold": "no_overlap_only"
-        },
-        "default:pre-push-quality-gate": {},
-        "default:finalize-step-simplify": {
-          "simplify": "auto"
-        },
         "default:push": {},
         "default:create-pr": {},
         "default:ci-verify": {},
@@ -77,19 +80,20 @@
           "re_review_on_loopback": false,
           "re_review_on_branch_cleanup": true,
           "re_review_await_timeout_seconds": 600,
-          "re_review_on_timeout": "ask"
+          "re_review_on_timeout": "ask",
+          "review_rate_window_await": false,
+          "review_rate_window_timeout_seconds": 3600
         },
-        "default:sonar-roundtrip": {
-          "touched_file_cleanup": "new_code_only",
-          "do_transition": false,
-          "ce_wait_timeout_seconds": 600
-        },
+        "default:sonar-roundtrip": {},
         "default:lessons-capture": {},
         "default:branch-cleanup": {
           "pr_merge_strategy": "squash",
           "final_merge_without_asking": false,
           "auto_rebase_threshold": "no_overlap_only",
           "merge_queue_wait_budget_seconds": 1800,
+          "merge_hold_window": "full_window_release_at_waits",
+          "merge_hold_budget_seconds": 3600,
+          "use_merge_queue": false,
           "admin_merge_on_stuck_state": false
         },
         "default:record-metrics": {},
@@ -107,47 +111,6 @@
       "max_slots": 5,
       "max_retries": 10,
       "upper_limit_seconds": 600
-    },
-    "map": {
-      "java": [
-        {
-          "glob": "*/src/main/*.java",
-          "role": "production",
-          "build_class": "compile"
-        },
-        {
-          "glob": "*/src/test/*.java",
-          "role": "test",
-          "build_class": "module-tests"
-        },
-        {
-          "glob": "pom.xml",
-          "role": "config",
-          "build_class": "verify"
-        }
-      ],
-      "javascript": [
-        {
-          "glob": "*.js",
-          "role": "production",
-          "build_class": "compile"
-        },
-        {
-          "glob": "*.spec.js",
-          "role": "test",
-          "build_class": "module-tests"
-        },
-        {
-          "glob": "*.test.js",
-          "role": "test",
-          "build_class": "module-tests"
-        },
-        {
-          "glob": "package.json",
-          "role": "config",
-          "build_class": "verify"
-        }
-      ]
     }
   },
   "project": {
@@ -185,6 +148,21 @@
       "defaults": [],
       "optionals": []
     },
+    "general-dev": {
+      "bundle": "plan-marshall"
+    },
+    "documentation": {
+      "bundle": "pm-documents",
+      "workflow_skill_extensions": {
+        "triage": "pm-documents:ext-triage-docs"
+      }
+    },
+    "javascript": {
+      "bundle": "pm-dev-frontend",
+      "workflow_skill_extensions": {
+        "triage": "pm-dev-frontend:ext-triage-js"
+      }
+    },
     "java": {
       "bundle": "pm-dev-java",
       "workflow_skill_extensions": {
@@ -193,21 +171,6 @@
     },
     "java-cui": {
       "bundle": "pm-dev-java-cui"
-    },
-    "javascript": {
-      "bundle": "pm-dev-frontend",
-      "workflow_skill_extensions": {
-        "triage": "pm-dev-frontend:ext-triage-js"
-      }
-    },
-    "documentation": {
-      "bundle": "pm-documents",
-      "workflow_skill_extensions": {
-        "triage": "pm-documents:ext-triage-docs"
-      }
-    },
-    "general-dev": {
-      "bundle": "plan-marshall"
     },
     "active_profiles": [
       "implementation",
@@ -221,6 +184,8 @@
       "archived_plans_days": 5,
       "lessons_superseded_days": 0,
       "temp_on_maintenance": true
-    }
+    },
+    "provisioned_version": "0.1.1075",
+    "config_seed_fingerprint": "9f5161c2"
   }
 }

--- a/.plan/project-architecture/_project.json
+++ b/.plan/project-architecture/_project.json
@@ -1,6 +1,6 @@
 {
-  "description": "Token-Sheriff is a security-focused Java/Quarkus framework for validating OAuth2/OIDC JWT tokens in multi-issuer environments. It provides a standalone core validation library (parsing, JWKS key loading, claim mapping, JWE decryption, DPoP), a Quarkus extension (runtime + build-time deployment) with Dev-UI tooling, plus benchmarking and end-to-end test harnesses.",
-  "description_reasoning": "source: README.md introduction and parent pom description; corroborated by module descriptions",
+  "description": "Token-Sheriff is a comprehensive library for offline JWT token validation in multi-issuer environments, with a strong focus on security. It ships a core validation library plus Quarkus runtime/deployment extensions, a client, benchmarking suites, and E2E test harnesses.",
+  "description_reasoning": "source: README.md 'What is it?' and 'Motivation' sections",
   "extensions_used": [
     "plan-marshall",
     "pm-documents"
@@ -14,6 +14,9 @@
     "e-2-e-playwright-maven": {},
     "e-2-e-playwright-npm": {},
     "token-sheriff-bom": {},
+    "token-sheriff-client": {},
+    "token-sheriff-client-quarkus": {},
+    "token-sheriff-client-quarkus-deployment": {},
     "token-sheriff-parent": {},
     "token-sheriff-quarkus-integration-tests": {},
     "token-sheriff-quarkus-parent": {},

--- a/.plan/project-architecture/benchmark-core/enriched.json
+++ b/.plan/project-architecture/benchmark-core/enriched.json
@@ -5,23 +5,26 @@
     "token-sheriff-validation",
     "benchmarking-common"
   ],
-  "key_dependencies": [],
-  "key_dependencies_reasoning": "Benchmarks the core library using shared benchmarking-common infrastructure",
+  "key_dependencies": [
+    "org.openjdk.jmh:jmh-core",
+    "io.jsonwebtoken:jjwt-api"
+  ],
+  "key_dependencies_reasoning": "Benchmarks token-sheriff-validation via JMH using benchmarking-common infrastructure",
   "key_packages": {
     "de.cuioss.sheriff.token.validation.benchmark": {
-      "description": "Benchmark runners and the mock token repository driving JMH/JFR/concurrency-sweep runs."
+      "description": "Top-level JMH benchmark classes and base state for validation benchmarks."
     },
-    "de.cuioss.sheriff.token.validation.benchmark.jfr.benchmarks": {
-      "description": "JFR-instrumented benchmark variants for profiling validation under different loads."
+    "de.cuioss.sheriff.token.validation.benchmark.jfr": {
+      "description": "JFR-instrumented benchmark variants for flight-recorder profiling."
     },
     "de.cuioss.sheriff.token.validation.benchmark.standard": {
-      "description": "Standard JMH benchmarks for core validation and error-load throughput."
+      "description": "Standard end-to-end token validation benchmark scenarios."
     }
   },
   "purpose": "benchmark",
-  "purpose_reasoning": "JMH benchmark classes (jar) targeting the core library",
-  "responsibility": "JMH micro-benchmarks measuring the core token-validation library in isolation. Defines benchmark runners (standard, concurrency-sweep, JFR-profiled), delegates for core/error/mixed validation loads, and a mock token repository to exercise TokenValidator without network.",
-  "responsibility_reasoning": "source: pom description 'Benchmarking module for OAuth/JWT token validation', packages benchmark/standard/jfr/delegates and runners; benchmark profiles",
+  "purpose_reasoning": "jar with JMH deps and benchmark profiles, contains the library JMH benchmarks",
+  "responsibility": "JMH micro-benchmarks for the token-sheriff-validation library. Measures in-process token validation throughput and latency across standard and delegate scenarios, with JFR-instrumented benchmark variants.",
+  "responsibility_reasoning": "pom.xml description + packages (benchmark, benchmark.standard, benchmark.delegates, benchmark.jfr) and JMH deps",
   "skills_by_profile": {
     "implementation": {
       "defaults": [
@@ -85,8 +88,17 @@
         },
         "pm-dev-java-cui:cui-logging"
       ]
+    },
+    "security": {
+      "defaults": [
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "CUI HTTP request-sanitization security surface",
+          "skill": "pm-dev-java-cui:cui-http"
+        }
+      ]
     }
   },
-  "skills_by_profile_reasoning": "",
+  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals",
   "tips": []
 }

--- a/.plan/project-architecture/benchmark-integration-wrk/enriched.json
+++ b/.plan/project-architecture/benchmark-integration-wrk/enriched.json
@@ -5,16 +5,16 @@
     "benchmarking-common"
   ],
   "key_dependencies": [],
-  "key_dependencies_reasoning": "Reuses benchmarking-common converters/reporting for wrk result processing",
+  "key_dependencies_reasoning": "Reuses benchmarking-common report/metrics infrastructure to publish WRK results",
   "key_packages": {
     "de.cuioss.sheriff.token.wrk.benchmark": {
-      "description": "WrkResultPostProcessor converting raw wrk output into the shared benchmark data/report model."
+      "description": "Java harness coordinating WRK HTTP benchmark runs and result collection."
     }
   },
   "purpose": "benchmark",
-  "purpose_reasoning": "HTTP load benchmarks (jar) using external wrk against running endpoints",
-  "responsibility": "WRK-based HTTP integration benchmarks driving the deployed Quarkus validation endpoints. Bundles wrk Lua/shell scripts (ablation, JFR, concurrency, health) plus a WrkResultPostProcessor that parses raw wrk output into the common benchmark report model.",
-  "responsibility_reasoning": "source: pom description 'WRK-based HTTP benchmarks for OAuth/JWT validation endpoints', WrkResultPostProcessor + wrk-scripts resources",
+  "purpose_reasoning": "jar with benchmark profiles driving WRK HTTP benchmarks against running endpoints",
+  "responsibility": "WRK-based HTTP load benchmarks for the deployed OAuth/JWT validation endpoints, with integration-test infrastructure and shell benchmark/ablation scripts orchestrating token fetch and endpoint stress runs.",
+  "responsibility_reasoning": "pom.xml description + wrk-scripts resources + single de.cuioss.sheriff.token.wrk.benchmark package",
   "skills_by_profile": {
     "implementation": {
       "defaults": [
@@ -78,8 +78,17 @@
         },
         "pm-dev-java-cui:cui-logging"
       ]
+    },
+    "security": {
+      "defaults": [
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "CUI HTTP request-sanitization security surface",
+          "skill": "pm-dev-java-cui:cui-http"
+        }
+      ]
     }
   },
-  "skills_by_profile_reasoning": "",
+  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals",
   "tips": []
 }

--- a/.plan/project-architecture/benchmarking-common/enriched.json
+++ b/.plan/project-architecture/benchmarking-common/enriched.json
@@ -2,26 +2,29 @@
   "best_practices": [],
   "insights": [],
   "internal_dependencies": [],
-  "key_dependencies": [],
-  "key_dependencies_reasoning": "",
+  "key_dependencies": [
+    "org.openjdk.jmh:jmh-core",
+    "de.cuioss:cui-java-tools"
+  ],
+  "key_dependencies_reasoning": "Built on the JMH harness with cui-java-tools utilities for the shared runner/report infrastructure",
   "key_packages": {
-    "de.cuioss.benchmarking.common.converter": {
-      "description": "Converters normalizing JMH and WRK raw output into the common BenchmarkData model."
+    "de.cuioss.benchmarking.common.jfr": {
+      "description": "Java Flight Recorder integration for profiling benchmark executions."
     },
     "de.cuioss.benchmarking.common.metrics": {
-      "description": "Metrics collection/transformation pipeline incl. Prometheus client and JSON exporters."
+      "description": "Metrics collection and aggregation across benchmark runs."
     },
     "de.cuioss.benchmarking.common.report": {
-      "description": "Report, badge and GitHub-Pages generation from benchmark results with historical trend data."
+      "description": "Report generation turning benchmark results into published output artifacts."
     },
-    "de.cuioss.benchmarking.common.repository": {
-      "description": "Keycloak-backed token repositories/providers supplying real tokens for benchmark load."
+    "de.cuioss.benchmarking.common.runner": {
+      "description": "Benchmark execution runner orchestrating JMH runs and artifact generation."
     }
   },
   "purpose": "library",
-  "purpose_reasoning": "packaging=jar of reusable benchmark infrastructure consumed by benchmark-core and benchmark-integration-wrk",
-  "responsibility": "Shared benchmarking infrastructure used by all benchmark modules. Provides JMH/WRK result converters, a metrics pipeline (Prometheus client, transformers, JFR instrumentation), Keycloak token repositories/providers for load generation, and HTML/badge report + GitHub-Pages generation.",
-  "responsibility_reasoning": "source: pom description 'Common benchmarking infrastructure with JMH integration', packages config/converter/metrics/jfr/report/repository",
+  "purpose_reasoning": "jar packaging, reusable benchmarking infrastructure consumed by benchmark-core and benchmark-integration-wrk",
+  "responsibility": "Shared benchmarking infrastructure with JMH integration. Provides the benchmark runner, metrics collection and converters, JFR support, and report/output generation used to produce artifacts during benchmark execution.",
+  "responsibility_reasoning": "pom.xml description + packages (runner, metrics, converter, jfr, report, output)",
   "skills_by_profile": {
     "implementation": {
       "defaults": [
@@ -85,8 +88,17 @@
         },
         "pm-dev-java-cui:cui-logging"
       ]
+    },
+    "security": {
+      "defaults": [
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "CUI HTTP request-sanitization security surface",
+          "skill": "pm-dev-java-cui:cui-http"
+        }
+      ]
     }
   },
-  "skills_by_profile_reasoning": "",
+  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals",
   "tips": []
 }

--- a/.plan/project-architecture/benchmarking/enriched.json
+++ b/.plan/project-architecture/benchmarking/enriched.json
@@ -1,14 +1,18 @@
 {
   "best_practices": [],
   "insights": [],
-  "internal_dependencies": [],
+  "internal_dependencies": [
+    "benchmark-core",
+    "benchmark-integration-wrk",
+    "benchmarking-common"
+  ],
   "key_dependencies": [],
-  "key_dependencies_reasoning": "",
+  "key_dependencies_reasoning": "Reactor parent aggregating the three benchmark submodules",
   "key_packages": {},
   "purpose": "parent",
-  "purpose_reasoning": "packaging=pom aggregating benchmark sub-modules",
-  "responsibility": "Parent POM aggregating all benchmarking sub-modules (common infrastructure, JMH micro-benchmarks, WRK integration benchmarks). Coordinates the benchmark build profile and groups performance-measurement tooling.",
-  "responsibility_reasoning": "source: benchmarking/pom.xml packaging=pom, description 'Parent module for all benchmarking related modules'",
+  "purpose_reasoning": "packaging=pom, aggregates the three benchmark submodules",
+  "responsibility": "Aggregator (parent) module for all benchmarking-related modules, including the JMH library benchmarks, WRK integration benchmarks, and shared benchmarking infrastructure.",
+  "responsibility_reasoning": "pom.xml description + build_file list aggregating benchmark-core, benchmark-integration-wrk, benchmarking-common",
   "skills_by_profile": {
     "implementation": {
       "defaults": [
@@ -72,8 +76,17 @@
         },
         "pm-dev-java-cui:cui-logging"
       ]
+    },
+    "security": {
+      "defaults": [
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "CUI HTTP request-sanitization security surface",
+          "skill": "pm-dev-java-cui:cui-http"
+        }
+      ]
     }
   },
-  "skills_by_profile_reasoning": "",
+  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals",
   "tips": []
 }

--- a/.plan/project-architecture/documentation/enriched.json
+++ b/.plan/project-architecture/documentation/enriched.json
@@ -5,11 +5,32 @@
   "key_dependencies": [],
   "key_dependencies_reasoning": "",
   "key_packages": {},
-  "purpose": "documentation",
-  "purpose_reasoning": "documentation build system, only .adoc docs and diagram scripts",
-  "responsibility": "AsciiDoc project documentation tree under doc/, including the OIDC client specification/planning series and PlantUML diagram sources. Holds narrative architecture, specification and migration documents rather than build artifacts.",
-  "responsibility_reasoning": "source: doc/ build_system=documentation, contains README.adoc plus oidc/01-06 spec series and plantuml scripts",
-  "skills_by_profile": {},
-  "skills_by_profile_reasoning": "",
+  "purpose": "library",
+  "purpose_reasoning": "documentation-only module with no build artifact; classified as library per best judgment",
+  "responsibility": "Project-level documentation module holding the AsciiDoc specifications and READMEs for the commons, validation, client and OIDC capability areas, including the multi-plan OIDC restructure/implementation docs.",
+  "responsibility_reasoning": "doc/ tree of README.adoc files (client, commons, oidc/01-06, validation)",
+  "skills_by_profile": {
+    "documentation": {
+      "defaults": [
+        {
+          "description": "AsciiDoc formatting, validation, link verification, and template creation",
+          "skill": "pm-documents:ref-asciidoc"
+        },
+        {
+          "description": "Content quality, tone analysis, organization standards, and review orchestration",
+          "skill": "pm-documents:ref-documentation"
+        },
+        {
+          "description": "Narrative styles for technical documentation \u2014 tone, voice, and arc for the engineering-narrative style",
+          "skill": "pm-documents:ref-narrative-styles"
+        },
+        {
+          "description": "SVG diagram authoring standards \u2014 visual language, theme handling, AsciiDoc embedding, per-diagram-type patterns",
+          "skill": "pm-documents:ref-svg-diagrams"
+        }
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals",
   "tips": []
 }

--- a/.plan/project-architecture/e-2-e-playwright-maven/enriched.json
+++ b/.plan/project-architecture/e-2-e-playwright-maven/enriched.json
@@ -5,12 +5,12 @@
     "e-2-e-playwright-npm"
   ],
   "key_dependencies": [],
-  "key_dependencies_reasoning": "Maven facet delegates to the npm Playwright test sibling",
+  "key_dependencies_reasoning": "Maven wrapper delegates to the npm Playwright sibling sharing the same physical directory",
   "key_packages": {},
   "purpose": "integration-tests",
-  "purpose_reasoning": "Maven wrapper (pom) driving the Playwright E2E npm tests",
-  "responsibility": "Maven build facet (virtual) that hooks the Playwright end-to-end Dev-UI tests into the Maven lifecycle via the e2e-tests profile, orchestrating the npm test run against a started dev environment.",
-  "responsibility_reasoning": "source: pom packaging=pom, description 'End-to-End Playwright tests for Token-Sheriff Dev-UI components', e2e-tests profile, paired npm sibling",
+  "purpose_reasoning": "packaging=pom that runs Playwright E2E tests through the e2e-tests profile",
+  "responsibility": "Maven-side wrapper for the Playwright end-to-end tests of the Token-Sheriff Quarkus Dev-UI. Wires the npm Playwright suite into the Maven reactor via the e2e-tests profile and dev-environment start/stop scripts.",
+  "responsibility_reasoning": "pom.xml description + e2e-tests profile + start/stop-dev-environment scripts wrapping the npm sibling",
   "skills_by_profile": {
     "implementation": {
       "defaults": [
@@ -74,8 +74,17 @@
         },
         "pm-dev-java-cui:cui-logging"
       ]
+    },
+    "security": {
+      "defaults": [
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "CUI HTTP request-sanitization security surface",
+          "skill": "pm-dev-java-cui:cui-http"
+        }
+      ]
     }
   },
-  "skills_by_profile_reasoning": "",
+  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals",
   "tips": []
 }

--- a/.plan/project-architecture/e-2-e-playwright-npm/enriched.json
+++ b/.plan/project-architecture/e-2-e-playwright-npm/enriched.json
@@ -2,13 +2,17 @@
   "best_practices": [],
   "insights": [],
   "internal_dependencies": [],
-  "key_dependencies": [],
-  "key_dependencies_reasoning": "",
+  "key_dependencies": [
+    "@playwright/test",
+    "@axe-core/playwright",
+    "eslint"
+  ],
+  "key_dependencies_reasoning": "Playwright test runner with axe-core accessibility checks and ESLint tooling (all dev dependencies)",
   "key_packages": {},
   "purpose": "integration-tests",
-  "purpose_reasoning": "npm Playwright browser E2E test project, no shipped artifact",
-  "responsibility": "The Playwright end-to-end test suite (virtual npm sibling) validating the Quarkus Dev-UI in a real browser. Provides functional and accessibility (axe-core) tests, Keycloak token fixtures, and a precheck-gated runner against a live dev environment.",
-  "responsibility_reasoning": "source: package.json 'End-to-End Playwright tests for Token-Sheriff Dev-UI', @playwright/test + @axe-core deps, test:functional/test:a11y scripts, fixtures/utils",
+  "purpose_reasoning": "npm Playwright E2E suite driving the running Dev-UI",
+  "responsibility": "Playwright end-to-end test suite for the Token-Sheriff Quarkus Dev-UI. Verifies status/config views, the token debugger and WCAG accessibility against a live dev environment, using Keycloak-issued tokens.",
+  "responsibility_reasoning": "package.json scripts + tests/*.spec.js (status-config, token-debugger, accessibility-wcag) and keycloak-token-service util",
   "skills_by_profile": {
     "implementation": {
       "defaults": [
@@ -61,8 +65,24 @@
           "skill": "plan-marshall:ref-code-quality"
         }
       ]
+    },
+    "security": {
+      "defaults": [
+        {
+          "description": "Core JavaScript development standards covering ES modules, modern patterns, web component patterns, DOM trust boundaries / XSS prevention, and code quality",
+          "skill": "pm-dev-frontend:javascript"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "JavaScript security \u2014 DOM trust boundaries, XSS sinks, sanitization, and Trusted Types",
+          "skill": "pm-dev-frontend:javascript-security"
+        }
+      ]
     }
   },
-  "skills_by_profile_reasoning": "",
+  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals",
   "tips": []
 }

--- a/.plan/project-architecture/token-sheriff-bom/enriched.json
+++ b/.plan/project-architecture/token-sheriff-bom/enriched.json
@@ -6,9 +6,9 @@
   "key_dependencies_reasoning": "",
   "key_packages": {},
   "purpose": "bom",
-  "purpose_reasoning": "Bill of Materials POM under bom/",
-  "responsibility": "Bill of Materials (BOM) POM that publishes a curated, version-aligned set of Token-Sheriff artifact coordinates so downstream consumers can import consistent module versions via dependencyManagement.",
-  "responsibility_reasoning": "source: bom/pom.xml description 'Bill of Materials (BOM) for Token-Sheriff modules', packaging=pom",
+  "purpose_reasoning": "packaging=pom acting as a dependencyManagement BOM",
+  "responsibility": "Bill of Materials (BOM) that centralizes and aligns dependency versions for all Token-Sheriff modules so consumers import a single managed version set.",
+  "responsibility_reasoning": "pom.xml description 'Bill of Materials (BOM) for Token-Sheriff modules'",
   "skills_by_profile": {
     "implementation": {
       "defaults": [
@@ -72,8 +72,17 @@
         },
         "pm-dev-java-cui:cui-logging"
       ]
+    },
+    "security": {
+      "defaults": [
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "CUI HTTP request-sanitization security surface",
+          "skill": "pm-dev-java-cui:cui-http"
+        }
+      ]
     }
   },
-  "skills_by_profile_reasoning": "",
+  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals",
   "tips": []
 }

--- a/.plan/project-architecture/token-sheriff-client-quarkus-deployment/enriched.json
+++ b/.plan/project-architecture/token-sheriff-client-quarkus-deployment/enriched.json
@@ -1,14 +1,20 @@
 {
   "best_practices": [],
   "insights": [],
-  "internal_dependencies": [],
+  "internal_dependencies": [
+    "token-sheriff-client-quarkus"
+  ],
   "key_dependencies": [],
-  "key_dependencies_reasoning": "",
-  "key_packages": {},
-  "purpose": "parent",
-  "purpose_reasoning": "packaging=pom at repo root aggregating all modules",
-  "responsibility": "Root reactor and parent POM for the Token-Sheriff project. Aggregates all modules (validation core, client, Quarkus extensions, benchmarking, docs and E2E) and centralizes shared build configuration, inheriting from cui-java-parent.",
-  "responsibility_reasoning": "root pom.xml description + build_file[17] aggregating every module; parent cui-java-parent",
+  "key_dependencies_reasoning": "Build-time deployment counterpart of the client runtime extension",
+  "key_packages": {
+    "de.cuioss.sheriff.token.client.quarkus.deployment": {
+      "description": "Build-time processor registering the token-sheriff-client Quarkus feature (skeleton)."
+    }
+  },
+  "purpose": "deployment",
+  "purpose_reasoning": "Quarkus build-time deployment/processor module registering the client feature",
+  "responsibility": "Deployment (build-time) module of the Quarkus extension for the Token-Sheriff OIDC/OAuth client engine. Registers the token-sheriff-client feature during augmentation. Wired, empty skeleton (Plan 05).",
+  "responsibility_reasoning": "pom.xml description; single de.cuioss.sheriff.token.client.quarkus.deployment package with the feature processor",
   "skills_by_profile": {
     "implementation": {
       "defaults": [

--- a/.plan/project-architecture/token-sheriff-client-quarkus/enriched.json
+++ b/.plan/project-architecture/token-sheriff-client-quarkus/enriched.json
@@ -1,14 +1,21 @@
 {
   "best_practices": [],
   "insights": [],
-  "internal_dependencies": [],
+  "internal_dependencies": [
+    "token-sheriff-client",
+    "token-sheriff-validation-quarkus"
+  ],
   "key_dependencies": [],
-  "key_dependencies_reasoning": "",
-  "key_packages": {},
-  "purpose": "parent",
-  "purpose_reasoning": "packaging=pom at repo root aggregating all modules",
-  "responsibility": "Root reactor and parent POM for the Token-Sheriff project. Aggregates all modules (validation core, client, Quarkus extensions, benchmarking, docs and E2E) and centralizes shared build configuration, inheriting from cui-java-parent.",
-  "responsibility_reasoning": "root pom.xml description + build_file[17] aggregating every module; parent cui-java-parent",
+  "key_dependencies_reasoning": "Runtime extension building on the client engine and the validation Quarkus extension",
+  "key_packages": {
+    "de.cuioss.sheriff.token.client.quarkus": {
+      "description": "Quarkus runtime wiring (skeleton) exposing the client engine as CDI beans/config."
+    }
+  },
+  "purpose": "extension",
+  "purpose_reasoning": "Quarkus extension runtime jar for the client engine",
+  "responsibility": "Runtime module of the Quarkus extension for the Token-Sheriff OIDC/OAuth client engine. Builds on the token-sheriff-validation-quarkus extension and the framework-agnostic token-sheriff-client engine. Wired, empty skeleton (Plan 05) with no functional content yet.",
+  "responsibility_reasoning": "pom.xml description; single de.cuioss.sheriff.token.client.quarkus package, status skeleton",
   "skills_by_profile": {
     "implementation": {
       "defaults": [

--- a/.plan/project-architecture/token-sheriff-client/enriched.json
+++ b/.plan/project-architecture/token-sheriff-client/enriched.json
@@ -1,14 +1,22 @@
 {
   "best_practices": [],
   "insights": [],
-  "internal_dependencies": [],
-  "key_dependencies": [],
-  "key_dependencies_reasoning": "",
-  "key_packages": {},
-  "purpose": "parent",
-  "purpose_reasoning": "packaging=pom at repo root aggregating all modules",
-  "responsibility": "Root reactor and parent POM for the Token-Sheriff project. Aggregates all modules (validation core, client, Quarkus extensions, benchmarking, docs and E2E) and centralizes shared build configuration, inheriting from cui-java-parent.",
-  "responsibility_reasoning": "root pom.xml description + build_file[17] aggregating every module; parent cui-java-parent",
+  "internal_dependencies": [
+    "token-sheriff-validation"
+  ],
+  "key_dependencies": [
+    "de.cuioss:cui-java-tools"
+  ],
+  "key_dependencies_reasoning": "Builds on the commons transport base shipped in token-sheriff-validation, with cui-java-tools utilities",
+  "key_packages": {
+    "de.cuioss.sheriff.token.client": {
+      "description": "Client engine package (skeleton) for outbound OIDC/OAuth flows built on the validation transport base."
+    }
+  },
+  "purpose": "library",
+  "purpose_reasoning": "jar packaging, pure-Java framework-agnostic client engine",
+  "responsibility": "Framework-agnostic OIDC/OAuth client engine \u2014 the outbound counterpart to token-sheriff-validation. Intended to add client-side flows (token retrieval, userinfo, revocation, introspection, end-session, PAR) on the commons transport base. Currently a wired, building skeleton with no functional flows yet (Plan 05).",
+  "responsibility_reasoning": "README.adoc + pom.xml description; single de.cuioss.sheriff.token.client package, status=empty skeleton",
   "skills_by_profile": {
     "implementation": {
       "defaults": [

--- a/.plan/project-architecture/token-sheriff-quarkus-integration-tests/enriched.json
+++ b/.plan/project-architecture/token-sheriff-quarkus-integration-tests/enriched.json
@@ -2,19 +2,25 @@
   "best_practices": [],
   "insights": [],
   "internal_dependencies": [
-    "token-sheriff-validation-quarkus"
+    "token-sheriff-validation-quarkus",
+    "token-sheriff-validation-quarkus-deployment-maven"
   ],
-  "key_dependencies": [],
-  "key_dependencies_reasoning": "Integration-tests the Quarkus runtime extension end-to-end",
+  "key_dependencies": [
+    "io.rest-assured:rest-assured"
+  ],
+  "key_dependencies_reasoning": "Exercises the deployed validation extension end-to-end via REST-assured against Keycloak",
   "key_packages": {
+    "de.cuioss.sheriff.token.integration": {
+      "description": "Integration test support/bootstrapping shared across the endpoint and scenario tests."
+    },
     "de.cuioss.sheriff.token.integration.endpoint": {
-      "description": "Test JAX-RS endpoints (real + mock) used as the system-under-test for validation IT suites."
+      "description": "Test REST endpoints that invoke token validation for the integration/native container tests."
     }
   },
   "purpose": "integration-tests",
-  "purpose_reasoning": "jar of Failsafe *IT tests + container infrastructure, no published API",
-  "responsibility": "End-to-end integration tests for the Quarkus extension. Ships a TestApplication with JWT/mock validation endpoints and *IT suites exercising bearer auth, DPoP, JWE, and health against real Keycloak/Zitadel IdPs in Docker, including native-image and HTTPS scenarios.",
-  "responsibility_reasoning": "source: pom description 'Integration tests for the Token-Sheriff Quarkus extension including native container testing with HTTPS', *SpecIT/*IT classes, docker keycloak/zitadel scripts",
+  "purpose_reasoning": "test-focused module with integration-tests profile and container/Keycloak harness",
+  "responsibility": "Integration tests for the Token-Sheriff Quarkus extension. Stands up test endpoints and exercises token validation, bearer-token, health, security and API behavior against a real Keycloak, including native-container testing with HTTPS.",
+  "responsibility_reasoning": "pom.xml description + integration-tests profile + endpoint main package and test packages (token, security, health, bearer, api)",
   "skills_by_profile": {
     "implementation": {
       "defaults": [
@@ -78,8 +84,17 @@
         },
         "pm-dev-java-cui:cui-logging"
       ]
+    },
+    "security": {
+      "defaults": [
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "CUI HTTP request-sanitization security surface",
+          "skill": "pm-dev-java-cui:cui-http"
+        }
+      ]
     }
   },
-  "skills_by_profile_reasoning": "",
+  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals",
   "tips": []
 }

--- a/.plan/project-architecture/token-sheriff-quarkus-parent/enriched.json
+++ b/.plan/project-architecture/token-sheriff-quarkus-parent/enriched.json
@@ -1,14 +1,21 @@
 {
   "best_practices": [],
   "insights": [],
-  "internal_dependencies": [],
+  "internal_dependencies": [
+    "token-sheriff-validation-quarkus",
+    "token-sheriff-validation-quarkus-deployment-maven",
+    "token-sheriff-client-quarkus",
+    "token-sheriff-client-quarkus-deployment",
+    "token-sheriff-quarkus-integration-tests",
+    "e-2-e-playwright-maven"
+  ],
   "key_dependencies": [],
-  "key_dependencies_reasoning": "",
+  "key_dependencies_reasoning": "Reactor parent aggregating the Quarkus runtime/deployment extensions, integration tests and E2E modules",
   "key_packages": {},
   "purpose": "parent",
-  "purpose_reasoning": "packaging=pom aggregating Quarkus runtime/deployment/IT modules",
-  "responsibility": "Parent POM for the Quarkus integration sub-tree. Aggregates the runtime extension, build-time deployment module, integration-tests and Playwright E2E modules, and centralizes Quarkus-specific build configuration and the coverage profile.",
-  "responsibility_reasoning": "source: token-sheriff-quarkus-parent/pom.xml packaging=pom, description references Quarkus integration parent, aggregates 7 build files",
+  "purpose_reasoning": "packaging=pom aggregating all Quarkus-related submodules",
+  "responsibility": "Parent (aggregator) module for the Token-Sheriff Quarkus integration. Groups the validation and client runtime/deployment extensions, integration tests and E2E Playwright modules, and centralizes their shared build configuration (including SecurityEvents-to-Micrometer integration).",
+  "responsibility_reasoning": "pom.xml description + build_file list aggregating validation-quarkus, client-quarkus(+deployment), integration-tests, e-2-e-playwright",
   "skills_by_profile": {
     "implementation": {
       "defaults": [
@@ -72,8 +79,17 @@
         },
         "pm-dev-java-cui:cui-logging"
       ]
+    },
+    "security": {
+      "defaults": [
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "CUI HTTP request-sanitization security surface",
+          "skill": "pm-dev-java-cui:cui-http"
+        }
+      ]
     }
   },
-  "skills_by_profile_reasoning": "",
+  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals",
   "tips": []
 }

--- a/.plan/project-architecture/token-sheriff-validation-quarkus-deployment-maven/enriched.json
+++ b/.plan/project-architecture/token-sheriff-validation-quarkus-deployment-maven/enriched.json
@@ -4,19 +4,17 @@
   "internal_dependencies": [
     "token-sheriff-validation-quarkus"
   ],
-  "key_dependencies": [
-    "io.quarkus:quarkus-core-deployment"
-  ],
-  "key_dependencies_reasoning": "Deployment module augments the runtime extension at build time via Quarkus deployment API",
+  "key_dependencies": [],
+  "key_dependencies_reasoning": "Build-time deployment counterpart of the validation runtime extension",
   "key_packages": {
     "de.cuioss.sheriff.token.quarkus.deployment": {
-      "description": "TokenSheriffProcessor build steps registering beans, native/reflection config and Dev-UI integration."
+      "description": "Build-time processor/build-steps registering the validation extension and its Dev-UI."
     }
   },
   "purpose": "deployment",
-  "purpose_reasoning": "Quarkus build-time deployment processor (jar) paired with the runtime extension",
-  "responsibility": "The Quarkus build-time deployment companion to the runtime extension. Its TokenSheriffProcessor defines the @BuildStep wiring (bean registration, reflection/native config, Dev-UI card and JWT debugger/status pages) that Quarkus executes during augmentation.",
-  "responsibility_reasoning": "source: pom description 'Deployment module for Quarkus integration', TokenSheriffProcessor + dev-ui qwc-* resources",
+  "purpose_reasoning": "Quarkus build-time deployment/processor module with Dev-UI assets",
+  "responsibility": "Build-time deployment module of the Quarkus validation extension. Provides the extension processor/build steps and ships the Dev-UI web components (JWT debugger and status/config views) that surface validation state during development.",
+  "responsibility_reasoning": "pom.xml description + de.cuioss.sheriff.token.quarkus.deployment package + dev-ui qwc-*.js resources",
   "skills_by_profile": {
     "implementation": {
       "defaults": [
@@ -80,8 +78,17 @@
         },
         "pm-dev-java-cui:cui-logging"
       ]
+    },
+    "security": {
+      "defaults": [
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "CUI HTTP request-sanitization security surface",
+          "skill": "pm-dev-java-cui:cui-http"
+        }
+      ]
     }
   },
-  "skills_by_profile_reasoning": "",
+  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals",
   "tips": []
 }

--- a/.plan/project-architecture/token-sheriff-validation-quarkus-deployment-npm/enriched.json
+++ b/.plan/project-architecture/token-sheriff-validation-quarkus-deployment-npm/enriched.json
@@ -1,18 +1,16 @@
 {
   "best_practices": [],
   "insights": [],
-  "internal_dependencies": [],
+  "internal_dependencies": [
+    "token-sheriff-validation-quarkus-deployment-maven"
+  ],
   "key_dependencies": [],
-  "key_dependencies_reasoning": "",
-  "key_packages": {
-    "de.cuioss.sheriff.token.quarkus.deployment": {
-      "description": "Dev-UI JavaScript components (qwc-jwt-debugger, qwc-jwt-status-config) and their build/test tooling."
-    }
-  },
-  "purpose": "extension",
-  "purpose_reasoning": "npm virtual module providing the Dev-UI JS components for the Quarkus deployment extension",
-  "responsibility": "The JavaScript/Dev-UI build facet of the deployment module (virtual npm sibling). Owns the Lit-based Dev-UI web components (JWT debugger, status/config cards) under src/main/resources/dev-ui with their npm lint/test/format/coverage tooling.",
-  "responsibility_reasoning": "source: package.json 'DevUI components for Token-Sheriff Quarkus extension', 26 npm scripts (test/lint/css), qwc-jwt-*.js dev-ui sources",
+  "key_dependencies_reasoning": "JS toolchain sharing the physical deployment module directory, building/testing its Dev-UI web components",
+  "key_packages": {},
+  "purpose": "deployment",
+  "purpose_reasoning": "npm build/test toolchain for the Dev-UI components of the deployment module",
+  "responsibility": "npm/JavaScript side of the validation Quarkus deployment module. Builds, lints, formats and unit-tests (Jest) the Lit-based Dev-UI web components (qwc-jwt-debugger, qwc-jwt-status-config) shipped by the extension.",
+  "responsibility_reasoning": "package.json scripts (test/lint/format/quality) + src/main/resources/dev-ui qwc-*.js and src/test/js component tests",
   "skills_by_profile": {
     "implementation": {
       "defaults": [
@@ -65,8 +63,24 @@
           "skill": "plan-marshall:ref-code-quality"
         }
       ]
+    },
+    "security": {
+      "defaults": [
+        {
+          "description": "Core JavaScript development standards covering ES modules, modern patterns, web component patterns, DOM trust boundaries / XSS prevention, and code quality",
+          "skill": "pm-dev-frontend:javascript"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "JavaScript security \u2014 DOM trust boundaries, XSS sinks, sanitization, and Trusted Types",
+          "skill": "pm-dev-frontend:javascript-security"
+        }
+      ]
     }
   },
-  "skills_by_profile_reasoning": "",
+  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals",
   "tips": []
 }

--- a/.plan/project-architecture/token-sheriff-validation-quarkus/enriched.json
+++ b/.plan/project-architecture/token-sheriff-validation-quarkus/enriched.json
@@ -6,27 +6,28 @@
   ],
   "key_dependencies": [
     "io.quarkus:quarkus-arc",
-    "io.quarkus:quarkus-rest"
+    "org.eclipse.microprofile.jwt:microprofile-jwt-auth-api",
+    "io.quarkus:quarkus-smallrye-health"
   ],
-  "key_dependencies_reasoning": "Wraps the core token-sheriff-validation library; built on Quarkus ARC (CDI) and REST",
+  "key_dependencies_reasoning": "Wraps token-sheriff-validation with Quarkus (Arc CDI, config, health, vertx-http) and MicroProfile JWT APIs",
   "key_packages": {
-    "de.cuioss.sheriff.token.quarkus.annotation": {
-      "description": "Injection annotations (@BearerToken, @BearerAuth) and the servlet objects resolver for the CDI security integration."
-    },
     "de.cuioss.sheriff.token.quarkus.config": {
-      "description": "MicroProfile-Config-driven resolvers mapping application properties into core IssuerConfig/ParserConfig/cache/JWE configuration."
+      "description": "MicroProfile/YAML configuration mapping into issuer and validation configuration."
     },
     "de.cuioss.sheriff.token.quarkus.health": {
-      "description": "SmallRye health checks for the token validator and configured JWKS endpoints."
+      "description": "SmallRye health checks reporting issuer/JWKS readiness and liveness."
     },
     "de.cuioss.sheriff.token.quarkus.producer": {
-      "description": "CDI producers turning validated bearer tokens into injectable results (TokenValidatorProducer, BearerTokenProducer)."
+      "description": "CDI producers exposing TokenValidator and related beans to the Quarkus application."
+    },
+    "de.cuioss.sheriff.token.quarkus.servlet": {
+      "description": "Servlet-layer integration for extracting and validating bearer tokens from HTTP requests."
     }
   },
   "purpose": "extension",
-  "purpose_reasoning": "Quarkus runtime extension (jar) with CDI producers, config resolvers and Dev-UI runtime service; paired with deployment module",
-  "responsibility": "The Quarkus runtime extension that wires the core validation library into Quarkus/CDI. Provides CDI producers for TokenValidator and bearer-token injection (@BearerToken/@BearerAuth), MicroProfile-Config-driven issuer/parser/cache/JWE resolvers, health checks, Micrometer metrics, access logging, and Keycloak claim-mapper beans.",
-  "responsibility_reasoning": "source: pom description 'Runtime module for Quarkus integration...providing configuration, producers, and integration from SecurityEvents to Micrometer', packages quarkus.producer/config/health/metrics/annotation",
+  "purpose_reasoning": "Quarkus extension runtime jar wiring the validation library into Quarkus",
+  "responsibility": "Runtime module of the Quarkus extension for OAuth/JWT token validation. Exposes token-sheriff-validation as CDI producers, maps YAML/MicroProfile configuration to issuer configs, integrates SecurityEvents into Micrometer metrics, adds SmallRye health checks, a bearer-token servlet layer, JWE support and error mapping.",
+  "responsibility_reasoning": "pom.xml description + packages (producer, config, metrics, health, servlet, mapper, jwe, error) and Quarkus deps",
   "skills_by_profile": {
     "implementation": {
       "defaults": [
@@ -90,8 +91,17 @@
         },
         "pm-dev-java-cui:cui-logging"
       ]
+    },
+    "security": {
+      "defaults": [
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "CUI HTTP request-sanitization security surface",
+          "skill": "pm-dev-java-cui:cui-http"
+        }
+      ]
     }
   },
-  "skills_by_profile_reasoning": "",
+  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals",
   "tips": []
 }

--- a/.plan/project-architecture/token-sheriff-validation/enriched.json
+++ b/.plan/project-architecture/token-sheriff-validation/enriched.json
@@ -3,28 +3,30 @@
   "insights": [],
   "internal_dependencies": [],
   "key_dependencies": [
+    "de.cuioss:cui-java-tools",
     "de.cuioss:cui-http",
-    "de.cuioss:cui-java-tools"
+    "io.jsonwebtoken:jjwt-api",
+    "jakarta.json:jakarta.json-api"
   ],
-  "key_dependencies_reasoning": "cui-http provides the resilient HTTP/ETag client used by HttpJwksLoader; cui-java-tools provides core utilities and logging",
+  "key_dependencies_reasoning": "Uses cui-java-tools and cui-http as the transport/utility base, JJWT for JWT primitives and Jakarta JSON (Parsson/dsl-json) for parsing; pure Java with no framework runtime deps.",
   "key_packages": {
     "de.cuioss.sheriff.token.validation": {
-      "description": "Public API surface: TokenValidator entry point, IssuerConfig, ParserConfig, TokenType and issuer-config caching."
+      "description": "Public entry point: TokenValidator plus IssuerConfig/IssuerConfigCache, TokenType and the JWT validation LogMessages."
     },
-    "de.cuioss.sheriff.token.validation.domain.claim.mapper": {
-      "description": "Claim value mappers, including Keycloak-specific roles/groups and scope/collection mappers."
+    "de.cuioss.sheriff.token.validation.domain.token": {
+      "description": "Immutable token content domain types (access/id/refresh) returned from validation."
     },
     "de.cuioss.sheriff.token.validation.jwks": {
-      "description": "JWKS key loading (HTTP/file/in-memory), parsing and key resolution for signature verification."
+      "description": "JWKS key material loading and the JwksLoader factory used to resolve signing keys per issuer."
     },
     "de.cuioss.sheriff.token.validation.pipeline": {
-      "description": "The staged token-validation pipeline orchestrating signature, claim and expiration checks."
+      "description": "Staged validation pipelines (access/id/refresh) with JWT decoding, signature verification and token building."
     }
   },
   "purpose": "library",
-  "purpose_reasoning": "packaging=jar, framework-agnostic core, depended on by Quarkus and benchmark modules",
-  "responsibility": "The standalone core JWT validation library. Provides the TokenValidator entry point and a full validation pipeline: multi-issuer configuration, JWKS key loading/caching, signature verification, claim extraction and mapping (incl. Keycloak mappers), JWE decryption, DPoP proof validation, and OIDC well-known discovery \u2014 all with no runtime framework dependency.",
-  "responsibility_reasoning": "source: README.adoc 'Comprehensive JWT token validation library', pom description 'Core library for OAuth/JWT token validation in multi-issuer environments', package layout (pipeline, jwks, jwe, dpop, domain.claim.mapper)",
+  "purpose_reasoning": "jar packaging, framework-agnostic pure-Java library consumed by all other modules",
+  "responsibility": "Core library for offline OAuth/JWT token validation in multi-issuer environments. Provides the TokenValidator entry point, issuer configuration, staged validation pipelines for access/id/refresh tokens, JWKS loading, signature verification, JWE decryption, DPoP proof validation, and token caching, using standard JDK cryptographic providers.",
+  "responsibility_reasoning": "pom.xml description + package structure (validation, pipeline, jwks, jwe, dpop, cache, security)",
   "skills_by_profile": {
     "implementation": {
       "defaults": [
@@ -88,8 +90,17 @@
         },
         "pm-dev-java-cui:cui-logging"
       ]
+    },
+    "security": {
+      "defaults": [
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "CUI HTTP request-sanitization security surface",
+          "skill": "pm-dev-java-cui:cui-http"
+        }
+      ]
     }
   },
-  "skills_by_profile_reasoning": "",
+  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals",
   "tips": []
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,3 +202,8 @@ Execute comprehensive quality verification and commit workflow for a specific mo
 
 - For ad-hoc file reading, searching, and editing, prefer the dedicated tools (Edit, Read, Write, Glob, Grep) over their shell equivalents (echo, cat, ls, find, grep).
 - This is a default for exploratory work only — it does **not** override the prescribed `grep`/`find`-based steps in the custom commands above (fixOpenRewriteMarkers, verifyCuiLoggingGuidelines, verifyAndCommit) or any other documented verification/cleanup workflow. Run those commands exactly as written.
+
+## Tool Usage
+
+- Use proper tools (Edit, Read, Write) instead of shell commands (echo, cat)
+- Never use Bash for file operations (find, grep, cat, ls) — use Glob, Read, Grep tools instead

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,207 +1,25 @@
 # Claude Code Configuration
 
-All AI development guidelines for this project are located in: **`agents.md`**
+All AI development guidelines for this project live in **`agents.md`** (hardlinked to `AGENTS.md`).
+Refer to that file for dev-environment tips, build commands, testing instructions, code style,
+and framework-specific standards when working on Token-Sheriff.
 
-This file contains:
-- Dev environment tips and build commands
-- Testing instructions and pre-commit validation
-- Code style and logging standards
-- Framework-specific standards (Quarkus, CDI)
-- OpenRewrite marker handling
-- Custom commands
+## Temporary Files
 
-Please refer to `agents.md` for complete guidance when working on this Token-Sheriff project.
-
-- Use `.plan/temp/` for ALL temporary files (covered by `Write(.plan/**)` permission - avoids permission prompts)
+- Use `.plan/temp/` for ALL temporary files (covered by the `Write(.plan/**)` permission — avoids permission prompts).
 
 ## Git Workflow
 
-All cuioss repositories have branch protection on `main`. Direct pushes to `main` are never allowed. Always use this workflow:
+Branch protection on `main` forbids direct pushes. Always:
 
 1. Create a feature branch: `git checkout -b <branch-name>`
-2. Commit changes: `git add <files> && git commit -m "<message>"`
-3. Push the branch: `git push -u origin <branch-name>`
-4. Create a PR: `gh pr create --repo cuioss/TokenSheriff --head <branch-name> --base main --title "<title>" --body "<body>"`
-5. Wait for CI + AI Reviewer(s) (waits until checks complete): `gh pr checks --watch`
-6. **Handle AI Reviewer comments** (whichever bots are configured — e.g. Sourcery, CodeRabbit, Gemini) — fetch with `gh api repos/cuioss/TokenSheriff/pulls/<pr-number>/comments` and for each:
-   - If clearly valid and fixable: fix it, commit, push, then reply explaining the fix and resolve the comment
-   - If you disagree or the comment is out of scope: reply explaining why, then resolve the comment
-   - If uncertain (not 100% confident): **ask the user** before acting
-   - Every comment MUST get a reply (reason for fix or reason for not fixing) and MUST be resolved
-7. Do **NOT** enable auto-merge unless explicitly instructed. Wait for user approval.
-8. Return to main: `git checkout main && git pull`
-
-## Custom Commands
-
-### verifyCuiLoggingGuidelines
-
-Verify that the codebase complies with CUI logging standards by:
-
-1. **Analyze CUI logging standards** from `/Users/oliver/git/cui-llm-rules/standards/logging`
-2. **Scan for logging violations** in the token-sheriff-validation module:
-   - Direct string usage in INFO/WARN/ERROR logging calls
-   - Missing LogRecord definitions for structured messages
-   - Incorrect parameter substitution patterns (should use '%s', not '{}' or '%d')
-   - Wrong exception parameter ordering (exception should come first)
-3. **Check LogRecord compliance**:
-   - All INFO/WARN/ERROR logs must use LogRecord constants
-   - Proper identifier ranges: INFO (001-099), WARN (100-199), ERROR (200-299)
-   - DSL-Style Constants Pattern with static imports
-4. **Validate documentation** in `doc/LogMessages.adoc` matches LogRecord definitions
-5. **Run logging-related tests** to verify LogAsserts work with LogRecord format
-6. **Generate compliance report** with:
-   - Compliance percentage
-   - List of violations found
-   - Recommendations for fixes
-   - Testing verification results
-
-**Usage:** When user says "verifyCuiLoggingGuidelines", execute this comprehensive logging standards audit.
-
-### fixOpenRewriteMarkers <module-path>
-
-Fix all OpenRewrite TODO markers in a module following CUI standards:
-
-**CRITICAL UNDERSTANDING**: Markers like `/*~~(TODO: INFO needs LogRecord)~~>*/` indicate **ACTUAL BUGS**, not just style issues.
-
-**Execution Steps**:
-
-1. **Locate All Markers**:
-   ```bash
-   grep -r "~~(TODO:" <module-path>/src --include="*.java"
-   ```
-   - Count markers: `grep -r "~~(TODO:" <module-path>/src --include="*.java" | wc -l`
-   - Group by type: INFO needs LogRecord, WARN needs LogRecord, placeholder mismatches, etc.
-
-2. **Analyze and Fix Each Marker**:
-
-   **Production Code (src/main/java)**:
-   - **Placeholder Mismatches**: Fix bugs like `LOGGER.info("value: %s", x, y)` (2 params, 1 placeholder)
-     - Add missing `%s` placeholders or remove extra parameters
-   - **Wrong Format Specifiers**: Change `%.2f`, `{:.2f}`, `{}`, `%d` → **ALWAYS use `%s`**
-   - **Missing LogRecords**: Create LogRecord constants for INFO/WARN/ERROR messages
-   - **Generic Exceptions**: Replace `Exception` with specific types (IOException, IllegalStateException)
-   - **RuntimeException**: Replace with specific exception types (TokenValidationException, etc.)
-
-   **Test Code (src/test/java)**:
-   - **Diagnostic Logging** (performance tests, concurrency tests):
-     - Add class-level suppression comment:
-       ```java
-       // cui-rewrite:disable CuiLogRecordPatternRecipe
-       // This is a test/utility class that outputs diagnostic information for analysis
-       ```
-     - **NEVER create LogRecords for test diagnostic output**
-   - **Placeholder Mismatches**: Fix bugs even in tests (change to %s)
-   - **RuntimeException Throws**: Replace with AssertionError for test failures
-   - **Generic Exception Catches**: Replace with specific types + InterruptedException/BrokenBarrierException
-
-3. **Remove Markers After Fixing**:
-
-   **macOS (BSD sed)**:
-   ```bash
-   find <module-path>/src -name "*.java" -exec sed -i '' 's|/\*~~(TODO: INFO needs LogRecord)~~>\*/||g; s|/\*~~(TODO: WARN needs LogRecord)~~>\*/||g; s|/\*~~(TODO: ERROR needs LogRecord)~~>\*/||g' {} +
-   ```
-
-   **Linux (GNU sed)**:
-   ```bash
-   find <module-path>/src -name "*.java" -exec sed -i 's|/\*~~(TODO: INFO needs LogRecord)~~>\*/||g; s|/\*~~(TODO: WARN needs LogRecord)~~>\*/||g; s|/\*~~(TODO: ERROR needs LogRecord)~~>\*/||g' {} +
-   ```
-
-   - Verify removal: `grep -r "~~(TODO:" <module-path>/src --include="*.java" | wc -l` (should be 0)
-
-4. **Verify Fixes**:
-   ```bash
-   cd <module-path> && ../mvnw -Ppre-commit clean verify
-   ```
-   - All tests must pass
-   - No compilation errors
-   - Markers may reappear if bugs not truly fixed
-   - If markers reappear, repeat steps 2-4
-
-5. **Final Validation**:
-   - Run full test suite: `cd <module-path> && ../mvnw clean install`
-   - Confirm zero markers: `grep -r "~~(TODO:" <module-path>/src --include="*.java"`
-   - Verify test count matches previous successful run (no tests accidentally broken)
-
-**Common Bugs to Watch For**:
-- `LOGGER.info("value %s", x, y)` → Missing placeholder for `y`
-- `LOGGER.info("avg %.2f ms", avg)` → Use `%s` not `%.2f`
-- `LOGGER.info("result {}", value)` → Use `%s` not `{}`
-- `catch (Exception e)` → Use specific exception types
-- `catch (RuntimeException e)` → Use IllegalArgumentException | IllegalStateException | TokenValidationException
-- Test logging creating LogRecords → Use suppression comment instead
-
-**Critical Rules**:
-- ❌ **NEVER remove markers without fixing bugs**
-- ❌ **NEVER create LogRecords for test diagnostic logging**
-- ✅ **ALWAYS use `%s` for ALL string substitutions** (never `%.2f`, `{}`, `%d`)
-- ✅ **ALWAYS fix placeholder/parameter count mismatches**
-- ✅ **ALWAYS use specific exception types** (never Exception/RuntimeException)
-
-**Usage:** When user says "fixOpenRewriteMarkers token-sheriff-validation", execute this complete marker fixing workflow.
-
-### verifyAndCommit <module-name>
-
-Execute comprehensive quality verification and commit workflow for a specific module:
-
-1. **Quality Verification Build** (pre-commit profile):
-   ```bash
-   ./mvnw -Ppre-commit clean verify -pl <module-name>
-   ```
-   - Runs code quality checks (checkstyle, spotbugs, PMD)
-   - Performs static analysis
-   - Validates code formatting and style compliance
-   - **NO SHORTCUTS** - Fix ALL errors and warnings before proceeding
-
-2. **Final Verification Build** (full integration):
-   ```bash
-   ./mvnw clean install -pl <module-name>
-   ```
-   - Runs complete build with all tests
-   - Validates full integration and functionality
-   - Ensures no regressions introduced
-   - This will take nearly 8 Minutes. Always wait for it to complete. !0 minutes on the outside
-   - **NO SHORTCUTS** - Fix ALL test failures and build errors
-
-3. **Error Resolution Loop**:
-   - If ANY errors or warnings occur in either build, STOP and fix them
-   - Re-run the failed build command until it passes completely
-   - DO NOT proceed to next step until current step is 100% clean
-   - Apply fixes systematically and verify each fix
-
-4. **Artifact Cleanup Verification**:
-   ```bash
-   find <module-name>/src/main/java -name "*.class" -type f
-   find <module-name>/src/test/java -name "*.class" -type f
-   find <module-name>/src -name "*.jar" -type f
-   find <module-name>/src -name "*.war" -type f
-   find <module-name>/src -name "target" -type d
-   ```
-   - Verify NO class files exist in source directories
-   - Verify NO jar/war files exist in source directories
-   - Verify NO target directories exist in source directories
-   - Ensure NO build artifacts contaminate source code
-   - Clean up any artifacts found before proceeding
-   - **FAIL BUILD** if any artifacts are found in src/ directories
-
-5. **Git Commit**:
-   - Only proceed to commit when ALL steps pass completely
-   - Create descriptive commit message explaining the changes
-   - Include Co-Authored-By: Claude footer
-
-**Usage:** When user says "verifyAndCommit token-sheriff-validation", execute this complete verification and commit workflow for the token-sheriff-validation module.
-
-**Critical Rules:**
-- **NEVER skip error fixes** - Every warning and error must be resolved
-- **NEVER use shortcuts** - Run complete verification cycles
-- **NEVER commit with failing builds** - Only commit when everything passes
-- **NEVER commit with source artifacts** - Source directories must be clean of .class files
-- **ALWAYS fix issues systematically** - Address root causes, not symptoms
-
-
-## Tool Usage
-
-- For ad-hoc file reading, searching, and editing, prefer the dedicated tools (Edit, Read, Write, Glob, Grep) over their shell equivalents (echo, cat, ls, find, grep).
-- This is a default for exploratory work only — it does **not** override the prescribed `grep`/`find`-based steps in the custom commands above (fixOpenRewriteMarkers, verifyCuiLoggingGuidelines, verifyAndCommit) or any other documented verification/cleanup workflow. Run those commands exactly as written.
+2. Commit: `git add <files> && git commit -m "<message>"`
+3. Push: `git push -u origin <branch-name>`
+4. Open a PR against `main` via `gh pr create --repo cuioss/TokenSheriff`
+5. Wait for CI + AI reviewer(s): `gh pr checks --watch`
+6. Address every AI-reviewer comment — reply with the reason for fixing or not fixing, and resolve it. If uncertain, ask the user first.
+7. Do **not** enable auto-merge unless explicitly instructed.
+8. After merge, return to `main`: `git checkout main && git pull`
 
 ## Tool Usage
 


### PR DESCRIPTION
## Summary

- Regenerate `.plan/project-architecture` enriched snapshots, reconciling stale index deletions and adding the new `token-sheriff-client`, `token-sheriff-client-quarkus`, and `token-sheriff-client-quarkus-deployment` module snapshots.
- Add a Tool Usage note to `CLAUDE.md` (prefer Edit/Read/Write over shell file operations).

## Notes

Labelled `skip-bot-review` to skip automated AI reviews — this is a routine tooling/metadata refresh with no production code changes.