### PR TITLE
chore(client): clean up all client Sonar findings

### DIFF
--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/lifecycle/InMemoryTokenStore.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/lifecycle/InMemoryTokenStore.java
@@ -19,7 +19,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 /**
  * The default in-memory {@link TokenStore} — a thread-safe, single-instance store keyed by session id.
@@ -54,7 +54,7 @@ public class InMemoryTokenStore implements TokenStore {
     }
 
     @Override
-    public Optional<StoredToken> update(String sessionId, Function<StoredToken, StoredToken> updater) {
+    public Optional<StoredToken> update(String sessionId, UnaryOperator<StoredToken> updater) {
         Objects.requireNonNull(updater, "updater must not be null");
         // computeIfPresent performs the read-modify-write atomically per key, so a concurrent remove
         // (logout) cannot interleave between the read and the write and resurrect a revoked session.

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/lifecycle/TokenStore.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/lifecycle/TokenStore.java
@@ -16,7 +16,7 @@
 package de.cuioss.sheriff.token.client.lifecycle;
 
 import java.util.Optional;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 /**
  * Service-provider interface for the server-side token store ({@code CLIENT-19}, design fork 2).
@@ -79,5 +79,5 @@ public interface TokenStore {
      *                  must not be {@code null} and must not return {@code null}
      * @return the updated (stored) bundle, or {@link Optional#empty()} when no bundle was held
      */
-    Optional<StoredToken> update(String sessionId, Function<StoredToken, StoredToken> updater);
+    Optional<StoredToken> update(String sessionId, UnaryOperator<StoredToken> updater);
 }

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/logout/EndSessionFlow.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/logout/EndSessionFlow.java
@@ -78,8 +78,8 @@ public class EndSessionFlow {
     public String buildLogoutRedirect(String endSessionEndpoint, String idTokenHint,
             String postLogoutRedirectUri, String state) {
         requireNonBlank(endSessionEndpoint, "endSessionEndpoint");
-        requireNonBlank(idTokenHint, "id_token_hint");
-        requireNonBlank(state, "state");
+        requireNonBlank(idTokenHint, PARAM_ID_TOKEN_HINT);
+        requireNonBlank(state, PARAM_STATE);
         String validatedRedirect = redirectValidator.validate(postLogoutRedirectUri);
 
         Map<String, String> params = new HashMap<>(Map.of(

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/auth/ClientAuthenticationSelectorTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/auth/ClientAuthenticationSelectorTest.java
@@ -104,8 +104,9 @@ class ClientAuthenticationSelectorTest {
     void shouldFailClosedWhenNoConfiguredMethodAdvertised() {
         ClientAuthentication privateKeyJwt = auth(ClientAuthMethod.PRIVATE_KEY_JWT);
         var metadata = metadataAdvertising(List.of("client_secret_post"));
+        var configured = List.of(privateKeyJwt);
 
-        assertThrows(IllegalStateException.class, () -> selector.select(List.of(privateKeyJwt), metadata),
+        assertThrows(IllegalStateException.class, () -> selector.select(configured, metadata),
                 "selection must fail closed rather than pick an unadvertised method");
     }
 
@@ -123,7 +124,8 @@ class ClientAuthenticationSelectorTest {
     void shouldRejectNullArguments() {
         ClientAuthentication basic = auth(ClientAuthMethod.CLIENT_SECRET_BASIC);
         var metadata = metadataAdvertising(List.of("client_secret_basic"));
+        var configured = List.of(basic);
         assertThrows(NullPointerException.class, () -> selector.select(null, metadata));
-        assertThrows(NullPointerException.class, () -> selector.select(List.of(basic), null));
+        assertThrows(NullPointerException.class, () -> selector.select(configured, null));
     }
 }

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/auth/WeakAuthRefusedTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/auth/WeakAuthRefusedTest.java
@@ -93,8 +93,9 @@ class WeakAuthRefusedTest {
     void shouldFailClosedRatherThanUseUnadvertisedSecret() {
         ClientAuthentication basic = auth(ClientAuthMethod.CLIENT_SECRET_BASIC);
         var metadata = advertising(List.of("tls_client_auth"));
+        var configured = List.of(basic);
 
-        assertThrows(IllegalStateException.class, () -> selector.select(List.of(basic), metadata),
+        assertThrows(IllegalStateException.class, () -> selector.select(configured, metadata),
                 "a configured secret that the AS does not advertise must not be silently used");
     }
 

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/config/ClientConfigurationTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/config/ClientConfigurationTest.java
@@ -85,13 +85,16 @@ class ClientConfigurationTest {
     @DisplayName("Should reject a null issuer, client id or auth method")
     void shouldRejectNullRequiredFields() {
         var clientId = Generators.nonBlankStrings().next();
+        var missingIssuer = ClientConfiguration.builder()
+                .clientId(clientId).authMethod(ClientAuthMethod.CLIENT_SECRET_BASIC);
+        var missingClientId = ClientConfiguration.builder()
+                .issuer(issuer()).authMethod(ClientAuthMethod.CLIENT_SECRET_BASIC);
+        var missingAuthMethod = ClientConfiguration.builder()
+                .issuer(issuer()).clientId(clientId);
         assertAll(
-                () -> assertThrows(NullPointerException.class, () -> ClientConfiguration.builder()
-                        .clientId(clientId).authMethod(ClientAuthMethod.CLIENT_SECRET_BASIC).build()),
-                () -> assertThrows(NullPointerException.class, () -> ClientConfiguration.builder()
-                        .issuer(issuer()).authMethod(ClientAuthMethod.CLIENT_SECRET_BASIC).build()),
-                () -> assertThrows(NullPointerException.class, () -> ClientConfiguration.builder()
-                        .issuer(issuer()).clientId(clientId).build()));
+                () -> assertThrows(NullPointerException.class, missingIssuer::build),
+                () -> assertThrows(NullPointerException.class, missingClientId::build),
+                () -> assertThrows(NullPointerException.class, missingAuthMethod::build));
     }
 
     @Test
@@ -104,7 +107,8 @@ class ClientConfigurationTest {
                 .scope("openid")
                 .build();
 
-        assertThrows(UnsupportedOperationException.class, () -> config.getScopes().add("extra"));
+        var scopes = config.getScopes();
+        assertThrows(UnsupportedOperationException.class, () -> scopes.add("extra"));
     }
 
     @Test

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/discovery/DiscoveryAdversarialTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/discovery/DiscoveryAdversarialTest.java
@@ -66,8 +66,9 @@ class DiscoveryAdversarialTest {
     @DisplayName("Should reject a non-TLS issuer when cleartext is not permitted")
     void shouldRejectNonTlsIssuer() {
         var config = configFor("http://internal.example.com", false);
+        var resolver = new DiscoveryResolver(config);
 
-        assertThrows(TransportException.class, () -> new DiscoveryResolver(config).resolve());
+        assertThrows(TransportException.class, resolver::resolve);
         LogAsserts.assertLogMessagePresentContaining(TestLogLevel.WARN, "Rejecting non-TLS issuer");
     }
 
@@ -76,8 +77,9 @@ class DiscoveryAdversarialTest {
     void shouldRejectServerError(URIBuilder uriBuilder) {
         moduleDispatcher.returnError();
         var config = configFor(uriBuilder.buildAsString(), true);
+        var resolver = new DiscoveryResolver(config);
 
-        assertThrows(TransportException.class, () -> new DiscoveryResolver(config).resolve());
+        assertThrows(TransportException.class, resolver::resolve);
     }
 
     @Test
@@ -85,8 +87,9 @@ class DiscoveryAdversarialTest {
     void shouldRejectInvalidJson(URIBuilder uriBuilder) {
         moduleDispatcher.returnInvalidJson();
         var config = configFor(uriBuilder.buildAsString(), true);
+        var resolver = new DiscoveryResolver(config);
 
-        assertThrows(TransportException.class, () -> new DiscoveryResolver(config).resolve());
+        assertThrows(TransportException.class, resolver::resolve);
     }
 
     @Test
@@ -94,8 +97,9 @@ class DiscoveryAdversarialTest {
     void shouldRejectIssuerMismatch(URIBuilder uriBuilder) {
         moduleDispatcher.returnInvalidIssuer();
         var config = configFor(uriBuilder.buildAsString(), true);
+        var resolver = new DiscoveryResolver(config);
 
-        assertThrows(TransportException.class, () -> new DiscoveryResolver(config).resolve());
+        assertThrows(TransportException.class, resolver::resolve);
         LogAsserts.assertLogMessagePresentContaining(TestLogLevel.WARN, "does not match configured issuer");
     }
 }

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/dpop/SenderConstraintTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/dpop/SenderConstraintTest.java
@@ -109,10 +109,11 @@ class SenderConstraintTest {
     @Test
     @DisplayName("Should reject null generator, null headers, and blank/null binding confirmation")
     void shouldRejectInvalidInputs() {
+        var constraint = SenderConstraint.dpop(new DpopProofGenerator(keyPair, "RS256"));
         assertAll("input guards",
                 () -> assertThrows(NullPointerException.class, () -> SenderConstraint.dpop(null)),
                 () -> assertThrows(NullPointerException.class,
-                        () -> SenderConstraint.dpop(new DpopProofGenerator(keyPair, "RS256")).apply(HTM, HTU, null)),
+                        () -> constraint.apply(HTM, HTU, null)),
                 () -> assertThrows(NullPointerException.class, () -> ConstraintBinding.mtls(null)),
                 () -> assertThrows(IllegalArgumentException.class, () -> ConstraintBinding.dpop("  ")));
     }

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/ParClientTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/ParClientTest.java
@@ -67,7 +67,7 @@ class ParClientTest {
     }
 
     private static Map<String, String> authorizationParameters() {
-        Map<String, String> params = new HashMap<>(Map.of(
+        return new HashMap<>(Map.of(
                 "response_type", "code",
                 "redirect_uri", "https://rp.example.com/callback",
                 "scope", "openid",
@@ -75,7 +75,6 @@ class ParClientTest {
                 "nonce", Generators.nonBlankStrings().next(),
                 "code_challenge", Generators.nonBlankStrings().next(),
                 "code_challenge_method", "S256"));
-        return params;
     }
 
     private static String parEndpoint(URIBuilder uriBuilder) {

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/RefreshFlowTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/RefreshFlowTest.java
@@ -171,9 +171,10 @@ class RefreshFlowTest {
     void shouldRejectInvalidArguments(URIBuilder uriBuilder) {
         var flow = flow(config());
         var metadata = metadata(uriBuilder);
+        var refreshToken = Generators.letterStrings(20, 40).next();
         assertAll("argument validation",
                 () -> assertThrows(NullPointerException.class,
-                        () -> flow.refresh(null, Generators.letterStrings(20, 40).next())),
+                        () -> flow.refresh(null, refreshToken)),
                 () -> assertThrows(NullPointerException.class, () -> flow.refresh(metadata, null)),
                 () -> assertThrows(IllegalArgumentException.class, () -> flow.refresh(metadata, "   ")));
     }

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/hardening/FetchPathAttackDatabaseTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/hardening/FetchPathAttackDatabaseTest.java
@@ -89,9 +89,11 @@ class FetchPathAttackDatabaseTest {
         var config = config();
         var client = new TokenEndpointClient(config);
         String tokenEndpoint = uriBuilder.addPathSegment("token").buildAsString();
+        Map<String, String> formParameters = Map.of("grant_type", "client_credentials");
+        Map<String, String> requestHeaders = Map.of();
 
         assertThrows(TransportException.class,
-                () -> client.requestToken(tokenEndpoint, Map.of("grant_type", "client_credentials"), Map.of()),
+                () -> client.requestToken(tokenEndpoint, formParameters, requestHeaders),
                 "an adversarial token response body must never yield a trusted token");
     }
 

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/lifecycle/TokenStoreTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/lifecycle/TokenStoreTest.java
@@ -161,12 +161,15 @@ class TokenStoreTest {
     @DisplayName("Should reject a null token, blank session id, and negative refresh lead")
     void shouldRejectInvalidInputs() {
         var store = new InMemoryTokenStore();
+        var sessionId = Generators.letterStrings(10, 20).next();
+        var token = bearerToken();
+        var negativeLead = Duration.ofSeconds(-1);
 
         assertAll("input guards",
                 () -> assertThrows(NullPointerException.class,
-                        () -> store.store(Generators.letterStrings(10, 20).next(), null)),
-                () -> assertThrows(IllegalArgumentException.class, () -> store.store("  ", bearerToken())),
+                        () -> store.store(sessionId, null)),
+                () -> assertThrows(IllegalArgumentException.class, () -> store.store("  ", token)),
                 () -> assertThrows(IllegalArgumentException.class,
-                        () -> new RefreshScheduler(Duration.ofSeconds(-1))));
+                        () -> new RefreshScheduler(negativeLead)));
     }
 }

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/token/RotationReuseDetectionTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/token/RotationReuseDetectionTest.java
@@ -75,12 +75,13 @@ class RotationReuseDetectionTest {
 
         assertThrows(IllegalStateException.class, () -> family.rotate(initial, attackerNext),
                 "replaying the superseded token must fail closed");
+        String furtherSuccessor = Generators.letterStrings(20, 40).next();
         assertAll("post-reuse state",
                 () -> assertTrue(family.isRevoked(), "reuse must revoke the family"),
                 () -> assertThrows(IllegalStateException.class, family::currentToken,
                         "a revoked family must not expose a current token"),
                 () -> assertThrows(IllegalStateException.class,
-                        () -> family.rotate(next, Generators.letterStrings(20, 40).next()),
+                        () -> family.rotate(next, furtherSuccessor),
                         "a revoked family must reject all further rotations"));
         LogAsserts.assertLogMessagePresentContaining(TestLogLevel.WARN, "Refresh token reuse detected");
     }
@@ -111,14 +112,16 @@ class RotationReuseDetectionTest {
     @Test
     @DisplayName("Should reject null or blank tokens")
     void shouldRejectInvalidTokens() {
+        var familyForNullRotation = new RefreshTokenFamily(Generators.letterStrings(20, 40).next());
+        var successor = Generators.letterStrings(20, 40).next();
+        var familyForBlankSuccessor = new RefreshTokenFamily(Generators.letterStrings(20, 40).next());
+        var presented = Generators.letterStrings(20, 40).next();
         assertAll("token validation",
                 () -> assertThrows(NullPointerException.class, () -> new RefreshTokenFamily(null)),
                 () -> assertThrows(IllegalArgumentException.class, () -> new RefreshTokenFamily("  ")),
                 () -> assertThrows(NullPointerException.class,
-                        () -> new RefreshTokenFamily(Generators.letterStrings(20, 40).next())
-                                .rotate(null, Generators.letterStrings(20, 40).next())),
+                        () -> familyForNullRotation.rotate(null, successor)),
                 () -> assertThrows(IllegalArgumentException.class,
-                        () -> new RefreshTokenFamily(Generators.letterStrings(20, 40).next())
-                                .rotate(Generators.letterStrings(20, 40).next(), "  ")));
+                        () -> familyForBlankSuccessor.rotate(presented, "  ")));
     }
 }

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/token/SubBindingValidatorTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/token/SubBindingValidatorTest.java
@@ -68,29 +68,32 @@ class SubBindingValidatorTest {
         @DisplayName("Should reject a userinfo response that carries no sub")
         void shouldRejectAbsentSub() {
             var userInfo = userInfoWithSub(null);
+            var subject = Generators.nonBlankStrings().next();
 
             assertThrows(IllegalStateException.class,
-                    () -> validator.validate(Generators.nonBlankStrings().next(), userInfo));
+                    () -> validator.validate(subject, userInfo));
         }
 
         @Test
         @DisplayName("Should reject a sub that differs only in trailing length")
         void shouldRejectLengthMismatch() {
             String subject = Generators.letterStrings(8, 16).next();
+            var mismatchedUserInfo = userInfoWithSub(subject + "x");
 
             assertThrows(IllegalStateException.class,
-                    () -> validator.validate(subject, userInfoWithSub(subject + "x")));
+                    () -> validator.validate(subject, mismatchedUserInfo));
         }
 
         @Test
         @DisplayName("Should reject null arguments")
         void shouldRejectNullArguments() {
             var userInfo = userInfoWithSub(Generators.nonBlankStrings().next());
+            var subject = Generators.nonBlankStrings().next();
 
             assertAll("null-guards",
                     () -> assertThrows(NullPointerException.class, () -> validator.validate(null, userInfo)),
                     () -> assertThrows(NullPointerException.class,
-                            () -> validator.validate(Generators.nonBlankStrings().next(), null)));
+                            () -> validator.validate(subject, null)));
         }
     }
 }


### PR DESCRIPTION
## Summary

Cleans up all 27 open SonarQube findings introduced by the OIDC client PR (#550). **All fixed — no source suppressions.**

| Rule | Sev | Count | Fix |
|---|---|---|---|
| S1192 | Critical | 2 | `EndSessionFlow` uses `PARAM_ID_TOKEN_HINT` / `PARAM_STATE` constants instead of duplicating the literals |
| S4276 | Minor | 2 | `TokenStore.update()` + `InMemoryTokenStore` impl take `UnaryOperator<StoredToken>` instead of `Function<StoredToken,StoredToken>` |
| S1488 | Minor | 1 | Inline the return in `ParClientTest` |
| S5778 | Major | 22 | Hoist non-throwing setup out of `assertThrows` lambdas so each lambda holds only the single call under test |

Each `assertThrows` refactor asserts the **same exception on the same call** — only the setup was moved out of the lambda. No behavior change.

## Verification

`./mvnw verify -Ppre-commit -pl token-sheriff-client` — **BUILD SUCCESS**, 471 tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Changes**
  * Updated token store updates to use a more precise updater type while preserving atomic update behavior.

* **Bug Fixes**
  * Standardized logout parameter validation without changing redirect behavior.

* **Tests**
  * Improved test readability and consistency for validation, authentication, discovery, token handling, and security scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->