### PR TITLE
chore: update marshal.json via steward and add code-review docs

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -94,7 +94,11 @@
           "review_rate_window_await": false,
           "review_rate_window_timeout_seconds": 3600
         },
-        "default:sonar-roundtrip": {},
+        "default:sonar-roundtrip": {
+          "touched_file_cleanup": "new_code_only",
+          "do_transition": false,
+          "ce_wait_timeout_seconds": 600
+        },
         "default:lessons-capture": {},
         "default:branch-cleanup": {
           "pr_merge_strategy": "squash",
@@ -103,11 +107,16 @@
           "merge_queue_wait_budget_seconds": 1800,
           "merge_hold_window": "full_window_release_at_waits",
           "merge_hold_budget_seconds": 3600,
-          "use_merge_queue": false,
+          "use_merge_queue": true,
           "admin_merge_on_stuck_state": false
         },
         "default:record-metrics": {},
-        "default:archive-plan": {}
+        "default:archive-plan": {},
+        "default:architecture-refresh": {},
+        "default:finalize-step-preference-emitter": {
+          "preference_min_recurrence": 2
+        },
+        "default:finalize-step-print-phase-breakdown": {}
       },
       "effort": {
         "default": "level-3",
@@ -121,6 +130,47 @@
       "max_slots": 5,
       "max_retries": 10,
       "upper_limit_seconds": 600
+    },
+    "map": {
+      "java": [
+        {
+          "glob": "*/src/main/*.java",
+          "role": "production",
+          "build_class": "compile"
+        },
+        {
+          "glob": "*/src/test/*.java",
+          "role": "test",
+          "build_class": "module-tests"
+        },
+        {
+          "glob": "pom.xml",
+          "role": "config",
+          "build_class": "verify"
+        }
+      ],
+      "javascript": [
+        {
+          "glob": "*.js",
+          "role": "production",
+          "build_class": "compile"
+        },
+        {
+          "glob": "*.spec.js",
+          "role": "test",
+          "build_class": "module-tests"
+        },
+        {
+          "glob": "*.test.js",
+          "role": "test",
+          "build_class": "module-tests"
+        },
+        {
+          "glob": "package.json",
+          "role": "config",
+          "build_class": "verify"
+        }
+      ]
     }
   },
   "project": {
@@ -195,7 +245,7 @@
       "lessons_superseded_days": 0,
       "temp_on_maintenance": true
     },
-    "provisioned_version": "0.1.1075",
-    "config_seed_fingerprint": "9f5161c2"
+    "provisioned_version": "0.1.1082",
+    "config_seed_fingerprint": "0acf5eb5"
   }
 }

--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -107,7 +107,7 @@
           "merge_queue_wait_budget_seconds": 1800,
           "merge_hold_window": "full_window_release_at_waits",
           "merge_hold_budget_seconds": 3600,
-          "use_merge_queue": true,
+          "use_merge_queue": false,
           "admin_merge_on_stuck_state": false
         },
         "default:record-metrics": {},

--- a/doc/code-review-validation.md
+++ b/doc/code-review-validation.md
@@ -1,0 +1,252 @@
+# Code Review — `token-sheriff-validation` (commons base + validation trust core)
+
+**Scope reviewed:** the entire `token-sheriff-validation` Maven module — both the **commons**
+base layer (`de.cuioss.sheriff.token.commons.*`: transport, error, events, metrics) and the
+**validation** trust core (`…validation.*`: pipeline, domain/claims, jwks/keys, jwe, dpop, cache,
+json parsing, security, util). ~17,400 LOC production, ~34,500 LOC test, ~118 main files.
+
+**Reviewed against:** the module's own requirements and specs — `doc/validation/**`
+(VALIDATION-1..12, ~51 IDs; architecture; threat-model; security-reference; the MP-JWT,
+multi-IdP and token-decryption specs) and `doc/commons/**` (COMMONS-1..15; transport, error-model
+and observability specs) — and the RFCs those make normative (RFC 7515/7516/7517/7518/7519/7638/
+8725/9068/9449, NIST SP 800-131A, OIDC Core).
+
+**Method:** six independent deep reviews (commons transport/error/events/metrics; the crypto core
+JWKS/keys/algorithm-policy/JWE; the pipeline claims/domain/multi-issuer; parsing-hardening/DPoP/
+cache/util; a full VALIDATION+COMMONS conformance sweep; and test completeness), each reading the
+real code, followed by first-hand verification of every critical/high finding against source.
+
+**Relationship to the client review:** this is the module the `token-sheriff-client` engine
+(reviewed in [`doc/code-review.md`](code-review.md)) depends on and inherits its token-trust and
+transport posture from. One finding here (C1, SSRF) is the other half of that review's H9 and is
+**cross-cutting** — see the callout under C1.
+
+---
+
+## Executive summary
+
+**This is the inverse of the client-module result.** Where the client review found strong
+components left unwired, here the **trust core is genuinely well-built _and_ wired**: the
+conformance sweep found **no orphaned/dead-code defenses** — DPoP, JWE decryption, key-rotation
+grace period, custom validation rules, and the metrics monitor are all invoked from a real
+`TokenValidator` path. The cryptographic heart is **fail-closed with no discovered fail-open
+path**: `alg=none` and HMAC are rejected in depth (no RS256↔HS256 key-confusion route exists), the
+signature is verified before any claim is trusted, `alg` is bound to the key type, multi-issuer
+routing is correctly key-bound (choosing `iss` only selects the *correct* verifying key set),
+mandatory `exp`/`iat`/`sub` are enforced with correct clock-skew signs, the token cache never
+returns a result that outlives `exp`, and JWE does verify-then-decrypt with a constant-time MAC, a
+256 KB decompression cap, and CEK zeroing. Test hygiene is clean (no `Thread.sleep`, no unseeded
+randomness, no real network) and much of the public entry point *is* exercised adversarially.
+
+**The real defects cluster in two places:**
+
+1. **The commons transport layer under-delivers its own hardening requirements.** SSRF defense
+   (COMMONS-3) is **entirely absent**; cleartext HTTP is **allowed by default** (COMMONS-2 MUST);
+   response bodies are **buffered unbounded** before the size check, and the JWKS path has no size
+   bound at all (COMMONS-4). These are the highest-severity items and they degrade the whole
+   system's transport posture — including the client engine that delegates SSRF here.
+2. **Test honesty regresses at ~6 load-bearing security points** — the same *isolated-green-while-
+   the-wired-path-never-reaches-the-attack* blind spot the client review named, in a narrower but
+   still serious form. The flagship one: the psychic-signature (CVE-2022-21449) test passes for an
+   unrelated reason, so that defense is effectively untested — while the threat-model coverage
+   table reports Spoofing/Tampering/EoP/DPoP at 100%.
+
+Plus a scattering of correctness/hardening items (weak-RSA acceptance, a DPoP replay window, a
+DPoP header-casing bypass, custom-rule bypass on cache hit) and several **documentation-accuracy**
+defects where the docs and code disagree in *both* directions.
+
+### Severity tally
+
+- **Critical: 1** — SSRF defense entirely absent (COMMONS-3), and it is the delegation target the client module relies on.
+- **High: 4** — cleartext HTTP by default; unbounded response buffering (+ JWKS unbounded); psychic-signature defense untested; systemic isolated-vs-wired test blind spot across ~6 defenses.
+- **Medium: ~8** — weak-RSA keys accepted; discovery cached forever + permanent negative cache; DPoP replay window; DPoP header-casing bearer bypass; custom rules skipped on cache hit; dishonest/missing tests (HMAC-confusion, decompression-bomb, concurrency); issuer not a pre-fetch gate; inconsistent transport timeouts.
+- **Low/info: many** — DPoP parser-bound divergence, JSON depth unbounded (+ false javadoc), replay-cache flood eviction, thumbprint JSON escaping, `azp→aud` fallback, COMMONS-11 unimplemented, and three doc-vs-code accuracy defects.
+
+**Recommendation:** the trust core is release-grade. The **commons transport hardening (C1/H1/H2)
+is not** — for a security-first library those are the gating items, and C1 in particular means
+"SSRF is handled by commons" is currently false everywhere it is claimed. The test-honesty items
+(H3/H4) should be fixed before the threat-model coverage table is trusted, because they currently
+certify defenses that aren't on the executed path.
+
+---
+
+## Critical
+
+### C1 — SSRF defense on IdP-advertised URLs is entirely absent (COMMONS-3 unmet)
+*COMMONS-3, T-SSRF / T-DISCOVERY · `commons/transport/HttpJwksLoaderConfig.java:209-226`, `WellKnownConfig.java:237-253`, consumed at `jwks/http/HttpJwksLoader.java:204`*
+
+COMMONS-3 requires that any URL from an IdP-controlled source (`jwks_uri`, discovery endpoints,
+and every advertised endpoint) be constrained before fetch: HTTPS-only, host allow-list/egress
+policy, and internal/link-local/loopback ranges blocked. **None of this exists.** A repo-wide
+sweep confirms no `InetAddress`/`isLoopback`/`isSiteLocal`/`isLinkLocal`/`169.254`/allow-list guard
+anywhere in the module — "SSRF" appears only in javadoc, and `TransportException`'s javadoc
+advertises an "SSRF-blocked" branch that no code path ever raises. DNS-rebinding (re-checking the
+resolved address post-DNS) is not considered at all. An attacker who tampers with or spoofs
+discovery metadata can advertise `jwks_uri: http://169.254.169.254/latest/meta-data/…` (or any
+internal address) and the server will fetch it — exactly the motivating CVE-2026-1180 that the
+requirements exclusion table cites.
+
+> **Cross-cutting with the client review (H9).** [`doc/code-review.md`](code-review.md) found the
+> client engine issues its own HTTP and *delegates SSRF to commons (COMMONS-3)*. This finding shows
+> the delegation target is empty. Net effect across both modules: **no layer in the system
+> implements SSRF defense on IdP-advertised URLs** — not the client, not commons. The two reviews
+> together turn "each layer assumes the other does it" into a confirmed system-wide gap.
+
+**Fix:** add an egress guard in commons applied to every advertised URL before fetch — reject
+resolved loopback/link-local/site-local/ULA/metadata addresses, enforce an optional host
+allow-list, and re-check the address after DNS resolution. Then the client's delegation becomes
+true rather than aspirational.
+
+---
+
+## High
+
+### H1 — Cleartext HTTP permitted by default (COMMONS-2 MUST violated)
+*COMMONS-2 / VALIDATION-8.3, T-TLS · `commons/transport/HttpJwksLoaderConfig.java:285`, `WellKnownConfig.java:110`*
+
+COMMONS-2 states "Plain HTTP endpoints MUST be rejected." Both commons config builders hardcode
+`allowInsecureHttp = true` as the default — and the javadoc documents it as "`true` (default) to
+allow cleartext HTTP." Commons thereby **overrides cui-http's own secure-by-default** (`false`),
+so plaintext discovery/JWKS is accepted with only a WARN; rejection is opt-in. Any operator who
+forgets `allowInsecureHttp(false)` is exposed to a MITM/downgrade on JWKS resolution → key
+substitution (T-TLS). The TLS-floor half of COMMONS-2 (TLS 1.2+, hostname verification) *is*
+satisfied by cui-http; only the reject-plaintext half is inverted. **Fix:** default
+`allowInsecureHttp` to `false` in both builders; require explicit opt-in for cleartext.
+
+### H2 — Response-size limit applied only after full buffering; JWKS path has no size bound
+*COMMONS-4, T-DOS / VALIDATION-8.1 · `commons/transport/WellKnownConfigurationConverter.java:80-87,132`, `JwksHttpContentConverter.java:59-82`*
+
+The discovery converter checks `maxContentSize` *after* `BodyHandlers.ofString()` has already
+buffered the entire body into memory; the JWKS converter has **no overall size check at all**
+(DSL-JSON's `limitStringBuffer=4KB` bounds only individual strings, not document size or key
+count). A hostile or degraded IdP returning a multi-gigabyte (or slow-drip within the read
+timeout) body exhausts heap before any check fires — the size gate as written defends nothing on
+the discovery path and is absent on the JWKS path. The threat model delegates response-DoS here
+and claims "no unbounded buffering." **Fix:** enforce a byte ceiling during streaming (bounded
+`BodySubscriber` / `Content-Length` pre-check + capped read) before materializing the body, and
+apply the same ceiling to JWKS. (The DPoP proof path has an analogous but hardcoded 8 KB cap — see
+HARD-2.)
+
+### H3 — Psychic-signature (CVE-2022-21449) defense is untested; the test passes for an unrelated reason
+*VALIDATION-12.1, threat S1/T4 · `security/PsychicSignatureAttackTest.java:57,65-92`; `pipeline/validator/TokenSignatureValidator.java:139-151`*
+
+`PsychicSignatureAttackTest` mints ES256/384/512 tokens with all-zero signatures, but builds the
+issuer with `InMemoryJWKSFactory.createDefaultJwks()` — an **RSA** key under the default `kid`
+that the token keeps. `TokenSignatureValidator.validateSignature` rejects at
+`isAlgorithmCompatible("ES256","RS256")` (line 139, `UNSUPPORTED_ALGORITHM`) **before**
+`verifySignature` (line 151), and the test asserts exactly `UNSUPPORTED_ALGORITHM`. The all-zero
+ECDSA signature never reaches the verifier — **if the JDK were vulnerable, this test would still
+pass.** Production has no explicit `r ≠ 0 / s ≠ 0 / r,s < n` check (verified: no such guard in
+`TokenSignatureValidator`), so the CVE-2022-21449 defense relies entirely on the JDK version and
+nothing exercises it. **Fix:** configure a matching EC JWKS under the same `kid` so the zero
+signature reaches the verifier and assert `SIGNATURE_VALIDATION_FAILED`; consider an explicit
+component-range check so the defense is in code, not just the platform.
+
+### H4 — Systemic: ~6 security defenses are green in isolation while the wired path never reaches the attack
+*VALIDATION-12.1; threat-model coverage table (claims Spoofing/Tampering/EoP/DPoP = 100%)*
+
+The isolated-vs-wired blind spot the client review named recurs here — narrower (the defenses are
+*reachable*, unlike the client's unwired ones) but still certifying protection that the executed
+path doesn't demonstrate. Beyond H3, the pattern holds at these load-bearing points:
+
+| Defense | What the "attack" test actually does | Where the real defense is (only) proven |
+|---|---|---|
+| **HMAC/RSA algorithm confusion** (VTEST-2) | `shouldRejectAlgorithmConfusionAttack` swaps `kid` and asserts `KEY_NOT_FOUND`; the tampering util rewrites `alg=HS256` but keeps the RS256 signature bytes — no HMAC is ever computed over the RSA public key | header allow-list, isolated (`TokenHeaderValidatorTest`) |
+| **JWE decompression bomb** (VTEST-3) | no test feeds a `zip:"DEF"` payload that inflates past the 256 KB bound | production bound exists (`JweDecryptor.java:337`) but is never exercised |
+| **Cross-issuer key substitution** (VTEST-6) | wired coverage only for `NO_ISSUER_CONFIG` / missing-kid | "same kid, different key material → `SIGNATURE_VALIDATION_FAILED`" only on `TokenSignatureValidator` directly |
+| **JWE alg allow-list** (VTEST-7) | RSA1_5/unsupported-`enc` rejection only against `JweDecryptor`; wired `TokenValidator` JWE tests assert only wrong-key/no-config | isolated only |
+| **DPoP sender-binding** (VTEST-8) | wired test covers replay (DP1) genuinely, but DP2 `cnf.jkt` mismatch, DP3 stale-iat, DP4 HS256 are isolated-only | `DpopProofValidatorTest` only |
+| **jku/x5u & embedded-JWK** (VTEST-9) | wired tests tamper the header (breaking the signature), so `assertThrows` is satisfied by incidental `SIGNATURE_VALIDATION_FAILED`, not the named defense; counter assertions are `>= 0` (always true) | embedded-JWK honest in isolation (`TokenHeaderValidatorTest`) |
+
+Same required fix as the client module: a **wired negative-path tier** that drives the real
+`TokenValidator` entry point with the specific crafted attack and asserts the *specific* rejection
+event — and a rule that the threat-model coverage table may not mark a threat 100% without one.
+The table currently overstates coverage for exactly these rows.
+
+---
+
+## Medium
+
+- **M1 — RSA keys shorter than 2048 bits are accepted** (*VALIDATION-1.3 MUST-NOT, NIST SP 800-131A · `jwks/key/JwkKeyHandler.java:76`, `jwks/parser/KeyProcessor.java:146`, DPoP `DpopProofValidator.java:404`*). No modulus bit-length check exists anywhere (verified: no `bitLength`/`2048` guard in the module). A JWKS endpoint serving a 512/1024-bit RSA key is accepted and RS256/PS256 tokens signed with a factorable modulus validate. The requirement is explicit ("RSA … keys shorter than 2048 bits … shall NOT be supported"). Fix: reject `modulus.bitLength() < 2048` in `parseRsaKey` and on the DPoP embedded-JWK path.
+- **M2 — Discovery cached forever; a transient first-load failure pins the resolver permanently** (*COMMONS-8 · `commons/transport/HttpWellKnownResolver.java:91-103`*). `cachedResult.updateAndGet(cur -> cur == null ? load : cur)` stores the *first* `HttpResult` — including a failed one — permanently; after a transient network failure at first load every later call returns the cached failure with no re-fetch, and on success there is no TTL/ETag revalidation, so discovery never refreshes (contradicting COMMONS-8 "bounded lifetime"). Fix: don't cache failures (short negative-TTL + recovery); add a bounded success TTL.
+- **M3 — DPoP replay window from TTL/freshness decoupling** (*VALIDATION-8.7, RFC 9449 §11.1 · `dpop/DpopConfig.java:159-176`, `DpopReplayProtection.java`, `DpopProofValidator.java:313-321`*). `build()` validates `proofMaxAgeSeconds` and `nonceCacheTtlSeconds` independently but never enforces `ttl ≥ proofMaxAge + clockSkew`. With defaults (both 300s) and the freshness check accepting future-dated proofs up to `clockSkew` ahead, a proof's jti entry evicts at `firstSeen+300` while it stays "fresh" until `firstSeen+360` — the same jti can be **replayed in that ~60s window**, and arbitrarily wider if an operator lowers the TTL below the proof max-age. Fix: enforce the invariant in `build()`, or derive the replay TTL from the freshness window.
+- **M4 — DPoP header lookup is case-sensitive `"dpop"`; RFC-canonical `"DPoP"` is silently ignored** (*VALIDATION-8.7 · `dpop/DpopProofValidator.java:72,171`, `domain/context/AccessTokenRequest.java`*). `DPOP_HEADER_NAME = "dpop"` with a case-sensitive `httpHeaders().get(...)`, and `AccessTokenRequest.httpHeaders` carries no key-casing contract. An integrator supplying the RFC-canonical `"DPoP"` key gets the proof silently ignored; with `dpop.required=false` (default) the sender-constrained token then passes in **bearer mode** — a latent downgrade bypass saved only by the edge happening to lowercase headers (untested at this boundary). Fix: look up case-insensitively, or specify and enforce a normalized header-map contract on `AccessTokenRequest`.
+- **M5 — Custom `TokenValidationRule`s are bypassed on access-token cache hits** (*VALIDATION-6.1 · `pipeline/AccessTokenValidationPipeline.java:165-171` vs `261-264`*). On a cache hit only DPoP re-runs, then the cached content is returned; configured custom rules run only on the cache-miss path before cache store. A rule that depends on external mutable state (a revocation/blocklist, a time window, a feature flag) is bypassed for the whole cache TTL after the token is first cached. Pure content-deterministic rules are unaffected. Fix: re-run custom rules on the cache-hit branch (as DPoP already is), or document a content-deterministic contract + per-rule "run-on-cache-hit" flag.
+- **M6 — Dishonest/blind tests beyond H4** (*VALIDATION-10.1 / 12 · see refs*). `IssuerConfigCacheConcurrencyTest.java:92-94` catches and ignores the exact `UnsupportedOperationException` (the mutable→immutable-map race) it exists to detect, asserting only `totalOperations > 0` — a regressed race on 49/50 threads still passes. JWE decompression-bomb and real HMAC-confusion (H4) are missing outright. The 4 KB string-length limit is only tested just-*under* the bound, never over (`NonValidatingJwtParserTest.java:358-375`; `DSLJsonSecurityTest` sets `maxStringLength(1000)` then never feeds a >1000 string). Fix: assert the race exception is *absent*; add over-limit and bomb tests.
+- **M7 — Advertised issuer is not a gate before advertised URLs are fetched** (*COMMONS-5 · `jwks/http/HttpJwksLoader.java:204,405-423`*). The issuer-mismatch path only logs a WARN + counter and returns the configured issuer — *after* the attacker-advertised `jwks_uri` was already fetched at line 204. COMMONS-5 requires validating the advertised `issuer` before advertised URLs are trusted. Defense-in-depth exists (the JWT `iss` is later matched against the configured issuer at validation time, so rogue-IdP tokens still fail), but the SSRF-relevant fetch (C1) is not gated. Fix: constrain advertised URLs independently (C1) and make issuer-mismatch a hard discovery failure.
+- **M8 — Inconsistent transport timeout defaults** (*COMMONS-4 · `WellKnownConfig.java:53-58` vs `HttpJwksLoaderConfig`*). Discovery sets explicit low timeouts (connect 2s/read 3s); the direct-JWKS path sets none and silently inherits cui-http's 10s/10s, giving JWKS fetches materially laxer DoS bounds with no stated rationale. Fix: set explicit, documented, consistent timeouts on the JWKS handler.
+
+---
+
+## Low / informational
+
+- **L1 (HARD-2)** — DPoP proof parsing bounds the whole proof at a hardcoded `MAX_DPOP_PROOF_SIZE = 8192` and does **not** apply `ParserConfig.getMaxPayloadSize()`/`getMaxTokenSize()`, unlike the main path (`NonValidatingJwtParser.decodeBase64UrlPart`). An operator who tightens the parser bounds doesn't get them on DPoP proofs (per-string `limitStringBuffer` still applies). (`dpop/DpopProofValidator.java:75,212-230`)
+- **L2 (HARD-3 / VTEST-5)** — No JSON nesting-depth or array-size limit exists; DSL-JSON builds the DOM by recursive descent, so a deeply-nested payload within the 8 KB cap can drive a `StackOverflowError` — an uncaught `Error`, not a graceful `TokenValidationException`. And the parser javadoc **advertises `.maxDepth(5)`/`.maxArraySize(10)` builder methods that `ParserConfig` does not expose** (the example would not compile) — a documentation defect masking the missing bound. Fix: add a real depth bound *or* delete the false javadoc and state the size cap is the actual bound. (`NonValidatingJwtParser.java:48-49,94-96`, `ParserConfig.java:161-169`)
+- **L3 (HARD-4)** — Replay-cache flooding: an attacker with any valid DPoP keypair can emit unlimited unique-`jti` proofs; once `seenJti` exceeds `maxSize` (10,000) `evictOldest` can drop legitimate `jti`s still inside their freshness window, making those proofs replayable. Memory stays bounded (good), but replay protection degrades under flood. (`dpop/DpopReplayProtection.java:99-133`)
+- **L4 (HARD-5)** — `JwkThumbprintUtil.buildJson` concatenates member values into canonical JSON without RFC 7638 string escaping; not exploitable for conformant base64url members (and the `cnf.jkt` binding still requires the matching private key), but not spec-correct canonicalization. (`util/JwkThumbprintUtil.java:89-99`)
+- **L5 (HARD-6 / VSPEC-4)** — `htu` normalization strips query/fragment but not scheme/host case, default ports, or path dot-segments; because both sides pass through the same function this only causes **false rejects** (fail-closed), never acceptance of a wrong-endpoint proof. Related: when a proof is present but request URI/method are absent, validation **throws** (fail-closed) — correct security-wise, but an integration footgun if the edge doesn't populate them. (`dpop/DpopProofValidator.java:348-402`)
+- **L6 (CRYP-2)** — ECDH-ES ephemeral key: the code checks the EPK shares the private key's curve params but never independently asserts the point lies on the curve, delegating point-validation to the JCA provider. On current SunEC (JDK 17+) this is mitigated; residual risk is provider-dependent (invalid-curve attack). (`jwe/JweDecryptor.java:196-241`)
+- **L7 (CRYP-3)** — RSA-OAEP with SHA-1 (MGF1-SHA-1) is enabled by default (Keycloak default; not Bleichenbacher-exploitable, no practical SHA-1-in-OAEP break) — informational; prefer RSA-OAEP-256 where interop allows. (`jwe/JweAlgorithmPreferences.java:74-76`)
+- **L8 (CRYP-4)** — Duplicate `kid` in a JWKS is last-one-wins with no warning; impact limited (the shadowing key still comes from the same trusted document and the signature must still verify). (`jwks/key/JWKSKeyLoader.java:384-396`)
+- **L9 (CRYP-5)** — A successful JWKS fetch that parses to zero usable keys still swaps the new (empty, ERROR-status) loader into `currentKeys` and retires the good one — `updateKeys` never checks the new loader's status before swapping. Availability degradation (valid tokens fail until the grace period covers), not a bypass. (`jwks/http/HttpJwksLoader.java:266-303`)
+- **L10 (PIPE-2/3)** — Ungated `azp → expectedAudience` fallback: an access token missing `aud` is accepted if its `azp` is in `expectedAudience` (conflates client-id with audience; no disable flag), and `client_id` substitutes for a missing `azp` per RFC 9068 with no opt-out. Both realistically constrained (IdP-set values), low confused-deputy risk. (`pipeline/validator/AudienceValidator.java:86-120`, `AuthorizedPartyValidator.java:88-102`)
+- **L11 (PIPE-4/5/6)** — No "iat not unreasonably in the future" guard (only `exp`/`nbf` bound validity); mandatory-claim check is presence-only (`containsKey`), so an empty-string `sub`/`iss` counts as present (low impact — bounded by other validators); no duplicate-JSON-key rejection (RFC 8725 §2.4 hardening; not exploitable since the signature covers exact bytes).
+- **L12 (COMMONS-11)** — Inbound IdP error normalization (`error`/`error_description` → typed model) is unimplemented; `TransportException` javadoc lists "SSRF blocked"/"TLS rejected" branches no code constructs. Forward-looking (the client-facing endpoints are contracts-only today), but currently unmet and the javadoc over-claims. (`commons/error/`, `commons/transport/`)
+- **L13 (VTEST-11/12)** — Concurrency guarantees asserted weakly: JWKS refresh single-flight is never asserted as request-count==1 under concurrent load; the `maxRetiredKeySets` bound is config-checked but not behaviorally enforced; `TokenValidatorConcurrencyTest` asserts "passes if no exception." Cache-expiry test uses a real 2s wall-clock wait despite an injectable clock. Determinism is otherwise clean.
+
+### Documentation-accuracy defects (both directions)
+
+Unlike the client module (where docs *overstated* the code), here the docs and code disagree in
+both directions — each is a real accuracy defect for a security-first library whose threat model
+is an audit artifact:
+
+- **DOC-1 — threat model *understates* the code (DPoP htm/htu).** `threat-model.adoc` DP5 states "`htm` and `htu` validation is **not** performed by the library; this is handled at the application/framework level." The code **does** enforce both (`DpopProofValidator.validateHtuHtm`, lines 348-385), strips query/fragment per RFC 9449, and refuses to skip them when a proof is present. An auditor reading the threat model would wrongly conclude a control is absent. Fix: update DP5 to reflect that the library enforces htm/htu.
+- **DOC-2 — parser javadoc *overstates* the code (JSON depth).** `NonValidatingJwtParser` javadoc advertises `.maxDepth(5)`/`.maxArraySize(10)` config that does not exist (L2). Fix: remove or implement.
+- **DOC-3 — security-reference *understates* the code (iat/sub).** `security-reference.adoc` says `iat` is "not actively validated" and `sub` is "mandatory and validated," but `ExpirationValidator` does validate `iat` via `maxTokenAgeSeconds`, and `sub` can be made optional via `claimSubOptional`. Minor; also VALIDATION-2.1 lists `jti` but there is no typed `getJwtId()` accessor. Fix: align the reference with actual behavior.
+- **DOC-4 — threat-model coverage table overstates test coverage.** The 39/41 (95%) "mitigated + test-covered" table marks Spoofing/Tampering/EoP/DPoP at 100%, but H3/H4 show several of those cells are certified by isolated or incidental-pass tests. Fix: don't mark a threat covered without a wired negative-path test (ties to H4).
+
+---
+
+## Verified-good defenses (regression anchors — keep these)
+
+**Crypto core (fail-closed, no fail-open path found):**
+- `alg=none` and HMAC (HS256/384/512) rejected in depth — `SignatureAlgorithmPreferences.REJECTED_ALGORITHMS`, the header allow-list before key lookup, and `JwkAlgorithmPreferences` for JWK parsing. No RS256↔HS256 key-confusion route exists (an RSA public key can never reach an HMAC verifier).
+- Signature verified **before** any claim is trusted; `alg` bound to the key's JWA identifier (RSA family cross-accepts RS*/PS* per RFC 7517 §4.4; EC/EdDSA require exact match); `SignatureTemplateManager` is a second allow-list gate.
+- EC signature encoding handled correctly (IEEE P1363 raw R‖S → ASN.1/DER, correct component sizes), shared identically by the JWT and DPoP paths.
+- Embedded-JWK header rejected (CVE-2018-0114); `kid` mandatory; unknown `kid` does **not** trigger a JWKS fetch (no DoS amplification / negative-cache needed).
+- **JWE**: key-mgmt/content allow-lists enforced before crypto; RSA1_5 rejected even if re-added; AEAD verified before use; AES-CBC-HS is verify-then-decrypt with constant-time `MessageDigest.isEqual` (no padding oracle); Concat-KDF per RFC 7518 §4.6.2; decompression bounded to 256 KB with raw-DEFLATE; CEK/keys zeroized in `finally`; nested JWE forbidden and the inner JWS fully re-validated through the same pipeline.
+- **No unwired defenses** — DPoP, JWE, grace-period rotation, custom rules and the metrics monitor are all invoked from a real `TokenValidator`/`AccessTokenValidationPipeline` path (the conformance sweep confirmed this explicitly; contrast the client module).
+
+**Pipeline / claims:**
+- Multi-issuer routing is key-bound: `iss` selects that issuer's own JwksLoader, so a token cannot be validated against another issuer's keys — choosing `iss` only picks the *correct* verifying key set.
+- `exp` mandatory (missing → reject); clock-skew signs correct (skew extends validity in the right direction only); strict numeric typing on `exp`/`iat`/`nbf` (string/overflow/malformed throw); `iss` exact-match (no prefix/substring); audience enforced when configured and mandatory for ID tokens, with `IssuerConfig.build()` forcing a non-empty `expectedAudience` unless audience validation is explicitly disabled (closes the accidental no-audience fail-open).
+- Access-token and ID-token paths share one `TokenClaimValidator` — no rule drift.
+
+**Cache / DPoP / parsing:**
+- Token cache keyed by SHA-256 of the raw token; `CachedToken.verifyToken` re-compares the raw token on every hit; `isExpired` (with skew) re-checked on every hit — **a cached positive never outlives `exp`**; no negative caching (no poisoning); bounded size + race-safe `putIfAbsent`.
+- DPoP re-validated with the *current* request's proof on every cache hit (no bypass); replay `jti` stored only after signature verification; same algorithm allow-list and crypto path as the main pipeline; `ath`, `iat` two-sided freshness, and RFC 7638 thumbprint ordering correct; htu/htm now fail-closed.
+- Size limits: token/payload 8 KB pre-pipeline; `MAX_KEYS_COUNT=50`; `kid` length ≤100; JWE token size enforced via `TokenStringValidator` (not dead config).
+
+**Commons non-transport & boundary:**
+- `SecurityEventCounter` thread-safe (`ConcurrentHashMap`+`AtomicLong`), keyed by a bounded enum (no cardinality explosion), records no token material/secrets/URLs; `EventCategory` and `MetricIdentifier` carry no Micrometer/validation dependency (COMMONS-13/14/15).
+- Typed exception hierarchy; library throws typed exceptions and never renders problem+json; exception messages safe (URLs only in WARN/DEBUG logs) — COMMONS-9/12 hold within commons.
+- TLS 1.2+ floor pinned on the wire; **redirects not followed** (JDK `Redirect.NEVER`), neutralizing internal-range/downgrade-redirect vectors; retry bounded, jittered, `idempotentOnly=true` (no storms). The **ArchUnit commons→validation boundary is real and enforced** (`architecture/CommonsLayeringTest`).
+
+**Test suite (the strong majority):** signature-tamper, `alg=none`, `iss`/`aud`/`azp`, `kid`
+injection (properly re-signed), size limits, expiry/`nbf`/skew (deterministic injectable clock),
+EC R‖S↔DER, embedded-JWK, JWKS rotation grace period, and DPoP replay are all driven end-to-end
+through the real `TokenValidator` with the correct event asserted. No sleeps, no unseeded
+randomness, no real network.
+
+---
+
+## Suggested remediation order
+
+1. **Implement SSRF defense in commons (C1)** — it is the delegation target the whole system (including the client engine) assumes exists. Egress guard on every advertised URL, with post-DNS re-check. This closes both this review's C1 and the client review's H9.
+2. **Flip cleartext to opt-out and make the size limit real (H1, H2)** — default `allowInsecureHttp=false`; enforce a streaming byte ceiling on discovery *and* JWKS before buffering.
+3. **Fix the test honesty at the load-bearing points (H3, H4)** and add the wired negative-path tier — reach the real attack through `TokenValidator` and assert the specific event; then reconcile the threat-model coverage table (DOC-4) so it stops claiming 100% for incidentally-passing cells.
+4. **Reject weak RSA keys (M1)** — `< 2048` bits, on both the JWKS and DPoP-embedded-JWK paths.
+5. **Close the DPoP gaps (M3, M4)** — enforce `ttl ≥ proofMaxAge + skew`; make the DPoP header lookup case-insensitive (or contract the header map).
+6. **Fix discovery caching (M2)** and the cache-hit custom-rule bypass (M5); align transport timeouts (M8) and gate on advertised issuer (M7).
+7. **Reconcile the documentation (DOC-1..3)** — the threat model and security-reference must match the code in both directions; a stale security document is itself a defect for an audited library.
+8. Sweep the low/info items (parser depth bound + false javadoc, DPoP parser-bound divergence, thumbprint escaping, ECDH point validation, duplicate-kid, empty-key-set retirement, concurrency assertions).

--- a/doc/code-review-validation.md
+++ b/doc/code-review-validation.md
@@ -33,10 +33,13 @@ grace period, custom validation rules, and the metrics monitor are all invoked f
 path**: `alg=none` and HMAC are rejected in depth (no RS256↔HS256 key-confusion route exists), the
 signature is verified before any claim is trusted, `alg` is bound to the key type, multi-issuer
 routing is correctly key-bound (choosing `iss` only selects the *correct* verifying key set),
-mandatory `exp`/`iat`/`sub` are enforced with correct clock-skew signs, the token cache never
+mandatory `exp`/`iat` claims are enforced with correct clock-skew signs (`sub` is likewise
+mandatory unless `claimSubOptional` is enabled — see DOC-3), the token cache never
 returns a result that outlives `exp`, and JWE does verify-then-decrypt with a constant-time MAC, a
 256 KB decompression cap, and CEK zeroing. Test hygiene is clean (no `Thread.sleep`, no unseeded
-randomness, no real network) and much of the public entry point *is* exercised adversarially.
+randomness, no real network — with one exception: a real 2s wall-clock wait in the cache-expiry
+test despite an injectable clock, see L13) and much of the public entry point *is* exercised
+adversarially.
 
 **The real defects cluster in two places:**
 
@@ -45,7 +48,8 @@ randomness, no real network) and much of the public entry point *is* exercised a
    response bodies are **buffered unbounded** before the size check, and the JWKS path has no size
    bound at all (COMMONS-4). These are the highest-severity items and they degrade the whole
    system's transport posture — including the client engine that delegates SSRF here.
-2. **Test honesty regresses at ~6 load-bearing security points** — the same *isolated-green-while-
+2. **Test honesty regresses at seven load-bearing security points** (the psychic-signature
+   defense, H3, plus the six further defenses tabulated in H4) — the same *isolated-green-while-
    the-wired-path-never-reaches-the-attack* blind spot the client review named, in a narrower but
    still serious form. The flagship one: the psychic-signature (CVE-2022-21449) test passes for an
    unrelated reason, so that defense is effectively untested — while the threat-model coverage
@@ -58,7 +62,7 @@ defects where the docs and code disagree in *both* directions.
 ### Severity tally
 
 - **Critical: 1** — SSRF defense entirely absent (COMMONS-3), and it is the delegation target the client module relies on.
-- **High: 4** — cleartext HTTP by default; unbounded response buffering (+ JWKS unbounded); psychic-signature defense untested; systemic isolated-vs-wired test blind spot across ~6 defenses.
+- **High: 4** — cleartext HTTP by default; unbounded response buffering (+ JWKS unbounded); psychic-signature defense untested; systemic isolated-vs-wired test blind spot across six further defenses (seven total including H3).
 - **Medium: ~8** — weak-RSA keys accepted; discovery cached forever + permanent negative cache; DPoP replay window; DPoP header-casing bearer bypass; custom rules skipped on cache hit; dishonest/missing tests (HMAC-confusion, decompression-bomb, concurrency); issuer not a pre-fetch gate; inconsistent transport timeouts.
 - **Low/info: many** — DPoP parser-bound divergence, JSON depth unbounded (+ false javadoc), replay-cache flood eviction, thumbprint JSON escaping, `azp→aud` fallback, COMMONS-11 unimplemented, and three doc-vs-code accuracy defects.
 
@@ -142,7 +146,7 @@ nothing exercises it. **Fix:** configure a matching EC JWKS under the same `kid`
 signature reaches the verifier and assert `SIGNATURE_VALIDATION_FAILED`; consider an explicit
 component-range check so the defense is in code, not just the platform.
 
-### H4 — Systemic: ~6 security defenses are green in isolation while the wired path never reaches the attack
+### H4 — Systemic: six further security defenses are green in isolation while the wired path never reaches the attack
 *VALIDATION-12.1; threat-model coverage table (claims Spoofing/Tampering/EoP/DPoP = 100%)*
 
 The isolated-vs-wired blind spot the client review named recurs here — narrower (the defenses are

--- a/doc/code-review.md
+++ b/doc/code-review.md
@@ -8,8 +8,10 @@
 
 **Lenses:** correctness, completeness, consistency; full semantic review against the project's
 own requirements and specifications (`doc/client/**`) and the RFCs those documents make
-normative (RFC 6749/7636/7523/8705/9126/9207/9449/9470, OIDC Core & RP-Initiated Logout,
-RFC 7009). Security-first bar, as requested.
+normative, including RFC 6749/7636/7523/8705/9126/9207/9449/9470, OIDC Core & RP-Initiated
+Logout, RFC 7009, and — where individual findings rely on them — RFC 7638 (JWK thumbprint),
+RFC 8259 (JSON), RFC 9457 (problem details), and RFC 9700 (OAuth security BCP).
+Security-first bar, as requested.
 
 **Method:** five independent deep reviews (spec conformance, auth/flow security, token-lifecycle
 security, cross-cutting consistency, test completeness), each reading the real code, then
@@ -70,7 +72,7 @@ was decided in an archived plan ("design fork 1") and never reflected back into 
 
 - **Systemic (root cause): S0** — the verification strategy tests components in isolation, not the wired flow; it must gain a mandatory wired-flow / negative-path tier before any of CLIENT-8/10/11/12/17 can be marked covered.
 - **Critical: 2** — `form_post` missing (code in URL); `iss` mix-up defense unwired.
-- **High: 8** — step-up verification missing; DPoP unwired + no `ath`/nonce; mTLS non-functional & mis-ranked; refresh-reuse detection orphaned; no single-flight refresh; `client_credentials` capped at shared secret; token `toString()` leaks; architecture "no HTTP" boundary contradicted.
+- **High: 9** — step-up verification missing (H1) and `max_age` parsed-then-discarded (H2); DPoP unwired + no `ath`/nonce (H3); mTLS non-functional & mis-ranked (H4); refresh-reuse detection orphaned (H5); no single-flight refresh (H6); `client_credentials` capped at shared secret (H7); token `toString()` leaks (H8); architecture "no HTTP" boundary contradicted (H9).
 - **Medium: ~14** — token_type unvalidated, no-`state`-return-verification on logout, signed userinfo unsupported, `at_hash` unvalidatable, JDK exceptions instead of typed hierarchy, refresh ID-token/sub consistency skipped, response buffered before size cap, inconsistent sanitization/timeouts/exception-types, and their test counterparts.
 - **Low/info: many** — doc rot, traceability ID errors, `@NullMarked` gap, header-append vs set, config validation gaps.
 
@@ -360,18 +362,18 @@ control.
 ## Verified-good defenses (regression anchors — keep these)
 
 - **PKCE S256** — 32-byte `SecureRandom` verifier → 43-char base64url (valid RFC 7636 length/charset); challenge = `B64URL(SHA-256(ASCII(verifier)))`; `plain` not implementable; builder fails closed when the AS doesn't advertise `S256`.
-- **`state`/`nonce`** — 256-bit `SecureRandom` each; constant-time compare (`MessageDigest.isEqual`) in `CallbackHandler`, `IdTokenValidationBridge`, `IssValidator`, `SubBindingValidator`; callback order error → state → code, all before redemption.
+- **`state`/`nonce`** — 256-bit `SecureRandom` each; constant-time compare (`MessageDigest.isEqual`) in `CallbackHandler`, `IdTokenValidationBridge`, `SubBindingValidator` (and internally in `IssValidator`, though that class is unwired — C2); callback order error → state → code before redemption. The `iss` check is **not** part of the executed pre-redemption sequence until C2 is fixed.
 - **Basic auth** — client id + secret form-urlencoded *before* base64 (RFC 6749 §2.3.1) in both `ClientSecretBasicAuth` and `ClientCredentialsFlow`.
 - **`private_key_jwt`** — fresh `jti` (`UUID.randomUUID`), 60s lifetime, full `aud`/`iss`/`sub`/`iat`/`exp`, RFC 8259-complete JSON escaping, strict allow-list (no `none`/HMAC).
-- **DPoP proof construction** — RFC 7638 lexicographic JWK thumbprint (`e`,`kty`,`n`), correct unsigned big-endian encoding, `typ: dpop+jwt`, RS256/384/512-only, per-call `Signature` instances, bounded fail-closed `jti`-reuse LRU. (Construction is correct; wiring is the gap — see H3.)
+- **DPoP proof construction** — RFC 7638 lexicographic JWK thumbprint (`e`,`kty`,`n`), correct unsigned big-endian encoding, `typ: dpop+jwt`, RS256/384/512-only, per-call `Signature` instances, bounded fail-closed `jti`-reuse LRU. (This anchor covers *only* the verified thumbprint/`jti` mechanics; wiring, the `ath` claim, DPoP-Nonce handling, and `htu` normalization are all gaps — see H3. Wiring the existing generator alone is not sufficient.)
 - **RFC 7009 revocation** — any 2xx = success (unknown token = success per §2.2), optional `token_type_hint`, client auth applied, TLS enforced.
 - **Token store race** — `InMemoryTokenStore.update` uses `computeIfPresent`, `remove` is atomic take-and-clear; a refresh landing after logout is a no-op, not a resurrection — and the contract is documented on the SPI for custom stores.
 - **Post-logout open-redirect** — `PostLogoutRedirectValidator` exact whole-string match against an immutable copied allow-list, no normalization/prefix/wildcard, fail-closed, CWE-117 sanitized.
 - **Validation-pipeline monopoly** — access and ID tokens always pass through the bridges into the multi-issuer pipeline; no local signature/algorithm logic exists in the client (CLIENT-15).
 - **Duplicate callback-parameter rejection** (`CallbackParameters.parse`, post-decode, RFC 9700 §4.7.3); `FormEncoder` is the single UTF-8 form-encoding path; `JsonEscaper` covers all mandatory control-char escapes.
 - **`ClientLogMessages`** — unique identifiers, correct levels, no template interpolates a token/secret; session id SHA-256-masked before the INFO log.
-- **ArchUnit boundaries** — `ClientArchitectureTest` (no CDI/MP/JAX-RS) and `CommonsTransportReuseTest` (no bespoke `HttpClient`) actually enforce the stated architecture.
-- **Weak-auth refusal** — `WeakAuthRefusedTest` + `ClientAuthenticationSelector` genuinely fail closed when the AS advertises none of the configured methods and never downgrade below the strongest advertised method.
+- **ArchUnit boundaries** — `ClientArchitectureTest` (no CDI/MP/JAX-RS) actually enforces the stated layering. `CommonsTransportReuseTest` is narrower than its "no bespoke `HttpClient`" name suggests: the five endpoint clients do construct their own `HttpHandler`/`java.net.http` request paths (H9, L16) — the test constrains transport *construction* idioms, not HTTP orchestration or SSRF ownership, which remain the H9 gap.
+- **Weak-auth refusal** — `WeakAuthRefusedTest` + `ClientAuthenticationSelector` genuinely fail closed when the AS advertises none of the configured methods and never downgrade below the strongest advertised method. *Scope: selector-backed flows only* — `ClientCredentialsFlow` bypasses the selector entirely and remains uncovered until H7 is fixed.
 - **Rotation reuse race** — `RefreshConcurrencyTest` correctly proves exactly-one-winner across 16 threads on the family object (the object works; it's just not wired into the flow — H5).
 
 ---

--- a/doc/code-review.md
+++ b/doc/code-review.md
@@ -1,0 +1,396 @@
+# Code Review — `token-sheriff-client` (PR #550 + #553)
+
+**Scope reviewed:** the new `token-sheriff-client` Maven module introduced by
+[#550 *feat(client): implement OIDC/OAuth confidential client engine*](https://github.com/cuioss/TokenSheriff/pull/550)
+(merge `c2b0dfff`) and its follow-up
+[#553 *chore(client): clean up all client Sonar findings*](https://github.com/cuioss/TokenSheriff/pull/553)
+(merge `59265ade`). ~5,300 LOC production, ~5,700 LOC test, ~40 main files.
+
+**Lenses:** correctness, completeness, consistency; full semantic review against the project's
+own requirements and specifications (`doc/client/**`) and the RFCs those documents make
+normative (RFC 6749/7636/7523/8705/9126/9207/9449/9470, OIDC Core & RP-Initiated Logout,
+RFC 7009). Security-first bar, as requested.
+
+**Method:** five independent deep reviews (spec conformance, auth/flow security, token-lifecycle
+security, cross-cutting consistency, test completeness), each reading the real code, then
+cross-verification of every high/critical finding against the source. Findings below were
+confirmed against the actual code, not inferred from names.
+
+---
+
+## Executive summary
+
+The **per-component cryptographic mechanics are genuinely strong and often exceed the letter of
+the spec**: PKCE S256 (32-byte `SecureRandom`, correct RFC 7636 length/charset, `plain`
+unrepresentable), 256-bit `state`/`nonce`, constant-time comparisons everywhere they matter,
+exact-match redirect validators, an RFC 7638-correct DPoP JWK thumbprint with a fail-closed
+`jti`-reuse LRU, RFC 6749 §2.3.1-correct Basic-auth form-encoding, a `private_key_jwt` assertion
+with fresh `jti` and a strict no-`none`/no-HMAC algorithm allow-list, and an atomic
+`computeIfPresent`/`remove` token store that closes the refresh-after-logout race. The test suite
+is disciplined — AAA structure, no sleeps, seeded generators, latch-gated concurrency, log
+assertions matched to the real message catalog.
+
+**The dominant defect class is *unwired security components*.** Several defenses that the
+requirements and threat model state as unqualified `MUST`s exist as well-written classes that
+**no production code path ever invokes**:
+
+| Advertised defense | Class exists? | Wired into a flow? | Requirement |
+|---|---|---|---|
+| RFC 9207 `iss` mix-up defense | `IssValidator` ✓ | **No** — `AuthorizationCodeFlow.exchange()` never calls it | CLIENT-8 |
+| PAR (push authz params) | `ParClient` ✓ | **No** — zero production callers; no `request_uri` redirect builder | CLIENT-10 |
+| DPoP / sender-constraining | `DpopProofGenerator`, `SenderConstraint` ✓ | **No** — no flow attaches a proof | CLIENT-11 / 18 |
+| Refresh-reuse → family revocation | `RefreshTokenFamily` ✓ | **No** — orphan; shipped refresh path has no reuse detection | CLIENT-17 |
+| `response_mode=form_post` | — | **Not implemented at all** | CLIENT-1 / 14 |
+| Step-up `acr`/`auth_time` verification | — | **Not implemented at all** | CLIENT-12 |
+| mTLS client auth | `MtlsClientAuth` ✓ | **Non-functional** — no `SSLContext` ever plumbed, yet ranked *strongest* | CLIENT-4 / 11 |
+
+Because the threat-model and test-strategy documents describe these as covered ("the `iss`
+response parameter is cross-checked before exchange", "the front-channel redirect carries only
+the `request_uri`"), **the documentation currently overstates what the engine enforces**, and
+several tests certify controls the engine does not run. Some classes carry javadoc markers like
+"deliverable 6" / "increment 3", indicating this was intended as staged work — but the specs
+state the behavior as present-tense MUSTs and no document under `doc/` records the staging.
+
+**This is not a set of isolated missing tests — it is a gap in the test strategy itself.** Each
+orphaned defense is "covered" by a unit test and, in several cases, a real-Keycloak integration
+spec (`MixUpSpecIT`, `ParSpecIT`, `DpopBoundSpecIT`, `StepUpSpecIT`) — but those tests exercise the
+security component *in isolation*, or verify the *authorization server's* capability, and **never
+assert that the engine's own flow orchestrator, called as an application would call it, actually
+runs the check**. The suite passes while the defense is unreachable. Because this blind spot spans
+at least five requirements and the Quarkus edge as well, it is written up as its own root-cause
+finding, **[S0](#s0--systemic-the-verification-strategy-tests-components-not-the-wired-flow-root-cause)**,
+which the individual flow findings reference.
+
+There is also a **material architecture-boundary contradiction**: `architecture.adoc` states "the
+engine issues *no* HTTP of its own … adds no SSRF/TLS logic," but five classes issue their own
+`java.net.http`/cui-http calls with only TLS-scheme enforcement and no commons SSRF control. This
+was decided in an archived plan ("design fork 1") and never reflected back into `doc/client`.
+
+### Severity tally
+
+- **Systemic (root cause): S0** — the verification strategy tests components in isolation, not the wired flow; it must gain a mandatory wired-flow / negative-path tier before any of CLIENT-8/10/11/12/17 can be marked covered.
+- **Critical: 2** — `form_post` missing (code in URL); `iss` mix-up defense unwired.
+- **High: 8** — step-up verification missing; DPoP unwired + no `ath`/nonce; mTLS non-functional & mis-ranked; refresh-reuse detection orphaned; no single-flight refresh; `client_credentials` capped at shared secret; token `toString()` leaks; architecture "no HTTP" boundary contradicted.
+- **Medium: ~14** — token_type unvalidated, no-`state`-return-verification on logout, signed userinfo unsupported, `at_hash` unvalidatable, JDK exceptions instead of typed hierarchy, refresh ID-token/sub consistency skipped, response buffered before size cap, inconsistent sanitization/timeouts/exception-types, and their test counterparts.
+- **Low/info: many** — doc rot, traceability ID errors, `@NullMarked` gap, header-append vs set, config validation gaps.
+
+**Recommendation:** the module is a strong foundation but is **not yet spec-conformant for a
+security-first release**. Either (a) wire and test the four orphaned defenses + implement
+`form_post` and step-up verification before claiming CLIENT-8/10/11/12/17, or (b) if staging is
+intended, downgrade the affected requirements to explicitly-deferred status in `doc/client` and
+correct the threat-model/test-strategy claims so they do not assert coverage that does not exist.
+
+---
+
+## S0 — Systemic: the verification strategy tests components, not the wired flow (root cause)
+
+This is the single most important finding, and it is **not "a test is missing" — it is a hole in
+the test strategy itself.** Every orphaned defense in this review (C2 mix-up, H3 DPoP, H5
+refresh-reuse, plus PAR and step-up) is "covered" on paper — unit tests, and even real-Keycloak
+integration specs, carry its name — yet the engine's executable path never invokes it. The tests
+pass while the defense is unreachable, because **the strategy verifies each security component in
+isolation (or verifies the authorization server's capability) but never asserts that the engine's
+own flow orchestrator, as an application would call it, actually runs the check.** That is a
+category of blind spot, and it currently spans at least five requirements.
+
+Concretely, the verification is structured so that a defense can be fully deleted from the
+executable path without a single test going red:
+
+| Requirement | What the test suite exercises | What it never asserts (the wiring) |
+|---|---|---|
+| **CLIENT-8** mix-up | `MixUpSpecIT` does `new IssValidator()` and calls `validate()` directly against real Keycloak issuers; unit `MixUpDefenseTest` likewise | That `AuthorizationCodeFlow.exchange()` invokes `IssValidator` and refuses to redeem the code on `iss` mismatch (dispatcher call-count == 0) |
+| **CLIENT-10** PAR | `ParSpecIT` **hand-rolls a raw `HttpClient` POST** to Keycloak's PAR endpoint — it does not import `ParClient` | That the engine builds a `request_uri`-only front-channel redirect; `ParClient` has zero production/edge callers |
+| **CLIENT-11** DPoP | `DpopBoundSpecIT` imports only `DpopProofGenerator` (standalone proof); unit `SenderConstraintTest` checks a bare `HashMap` | That any flow attaches a `DPoP` header to a real token/refresh/userinfo request |
+| **CLIENT-12** step-up | `StepUpSpecIT` drives `StepUpHandler.initiate()` (request side only) | That the returned ID token's `acr`/`auth_time` are verified — no verifier exists to test |
+| **CLIENT-17** refresh-reuse | `RefreshConcurrencyTest` proves a correct 16-thread exactly-one-winner race **on the `RefreshTokenFamily` object** | That `RefreshFlow`/`TokenLifecycleManager` route through the family and drive RFC 7009 revocation on reuse |
+
+Three independent facts make this systemic rather than incidental:
+
+1. **The production orchestrators are not driven end-to-end.** Grepping the integration suite,
+   only `StepUpSpecIT` references any flow orchestrator (and only `StepUpHandler`). No IT imports
+   `AuthorizationCodeFlow` or `RefreshFlow` at all — even `FullFlowE2EIT`, the "full flow" test,
+   assembles logout/userinfo pieces by hand rather than driving the code-exchange flow. So the
+   one place the wiring would be observable is never invoked by a test.
+2. **The edge wiring is not verified against the flow either.** The Quarkus CDI producer
+   (`TokenSheriffClientProducer`) produces the transport/lifecycle beans but **no**
+   `AuthorizationCodeFlow`, `RefreshFlow`, `IssValidator`, `ParClient`, `SenderConstraint`, or
+   `RefreshTokenFamily` — and no test asserts the produced bean graph can actually perform a
+   guarded exchange. A "does the wired engine reject a mix-up?" test would have failed to even
+   compile a subject.
+3. **The test-strategy document already claims these as covered** (its traceability matrix asserts
+   CLIENT-8 "rejected before exchange", CLIENT-10 "front-channel redirect carries only the
+   `request_uri`", CLIENT-11 "DPoP proof present on the token request", CLIENT-17 rotation reuse →
+   family revocation). Those rows are backed by isolated-component or server-capability tests, not
+   by flow-level assertions — so the matrix reports green for behavior the engine does not perform.
+
+**Additional strategy-level weaknesses reinforcing the same theme** (detailed in the Low section):
+"tampered token" tests re-sign the token so **signature integrity is never actually exercised**
+(rejection comes only from unknown-issuer lookup); the callback attack-database feeds
+`CallbackParameters.of(Map)`/the constructor and **never the real `parse(rawQuery)`** decode path,
+so encoding-evasion payloads never reach the code under test; every HTTP unit test uses
+`allowInsecureHttp(true)` so the **TLS path is never exercised** despite the strategy mandating
+HTTPS mocks; and the security-critical `internal` package (`LogSanitizer`, `FormEncoder`,
+`JsonEscaper`) has **zero tests**. Each is the same failure mode: the test targets a stand-in for
+the real trust boundary rather than the boundary itself.
+
+**Required strategy change (not just added cases):** the test strategy must add a mandatory
+**"wired-flow / negative-path" tier** whose contract is *drive the engine (and the produced
+Quarkus bean graph) exactly as an application would, then assert the attack is refused before any
+side effect* — e.g. on `iss` mismatch the token endpoint is never called; on PAR the front-channel
+URL contains only `request_uri`; on a DPoP-requested flow a `DPoP` header reaches the recorded
+request; on rotated-token reuse the family path fires RFC 7009 revocation. A defense that has no
+such flow-level negative test must not be marked covered in the traceability matrix. Until that
+tier exists, isolated-component green does not imply the requirement is met — and the matrix
+should say so.
+
+---
+
+## Critical
+
+### C1 — `response_mode=form_post` is never sent; the code/state/iss ride in the URL
+*CLIENT-1, CLIENT-14, T-URL-LEAK · `flow/AuthorizationRequestBuilder.java:86-99`*
+
+The authorization request never emits `response_mode=form_post` (the parameter appears nowhere in
+the module). The AS therefore defaults to `response_mode=query`, so the authorization `code`,
+`state`, and `iss` are returned in the redirect URL query — precisely the exposure
+(browser history, server logs, `Referer`) that the requirement and the exclusion table
+("*Tokens / codes in URL query or fragment* — refused") mandate against. `retrieval-flow.adoc §2`
+states `form_post` "so the response … never rides in a URL"; the code does not implement it.
+**Fix:** emit `response_mode=form_post` on the authorization request; add a test asserting it.
+
+### C2 — RFC 9207 `iss` mix-up defense is dead code
+*CLIENT-8, T-MIXUP · `flow/AuthorizationCodeFlow.java:143-156`, `flow/IssValidator.java`, `discovery/ProviderMetadata.java`*
+
+`IssValidator` is instantiated by **no production code** (verified: only tests reference it).
+`exchange()` runs the `state` check (`callbackHandler.handle`) and then immediately redeems the
+code — the ordered `state → iss → exchange` sequence that `retrieval-flow.adoc §3` requires
+("MUST be rejected before the code is exchanged") is not performed. Compounding it,
+`ProviderMetadata` does not parse `authorization_response_iss_parameter_supported`, so even a
+caller wiring `IssValidator` manually cannot derive its `requireIssuer` flag from discovery —
+and with `requireIssuer=false`, an attacker who simply *omits* `iss` bypasses the check
+(`IssValidator.java:63-69` returns silently). `CallbackParameters.java` openly notes the `iss` is
+captured "so a later mix-up defence (deliverable 6) can check it." With two ASes configured (the
+exact T-MIXUP scenario), the engine redeems a code from the wrong AS.
+
+*Not closed by the integration suite (see S0):* `MixUpSpecIT` instantiates `new IssValidator()`
+and calls `validate()` directly against real Keycloak issuers — it never drives
+`AuthorizationCodeFlow.exchange()`, so a green mix-up IT coexists with the flow never invoking the
+validator. The Quarkus producer also produces no `IssValidator`. **Fix:** wire
+`IssValidator.validate(configuration.getIssuer(), callback, requireIss)` into `exchange()` before
+redemption; parse the discovery flag to force `requireIss` when the AS advertises support; add a
+flow-level test asserting the token endpoint is not called on `iss` mismatch.
+
+---
+
+## High
+
+### H1 — Step-up result verification (`acr`/`auth_time`) is unimplemented
+*CLIENT-12 · `flow/StepUpHandler.java`; no verifier class exists*
+
+`step-up-and-logout.adoc §2.3` requires that after a re-driven authorization the engine "verifies
+the resulting ID token's `acr` satisfies the requirement and `auth_time` satisfies `max_age` …
+A response whose `acr` / `auth_time` does not satisfy the requirement MUST NOT be treated as a
+successful step-up." No production code inspects `acr` or `auth_time` (grep confirms request-side
+`acr_values` only). A step-up the IdP silently ignored (returns a low `acr`) is treated as a
+successful elevation. **Fix:** add a post-exchange verifier asserting `acr` ∈ required set and
+`auth_time` within `max_age`; fail closed otherwise.
+
+### H2 — RFC 9470 `max_age` is parsed then discarded
+*CLIENT-12 · `flow/StepUpHandler.java:75`, `flow/AuthorizationRequestBuilder.java`, `flow/FlowContext.java`*
+
+`StepUpChallengeParser` extracts `max_age` (and accepts `max_age`-only challenges,
+`StepUpChallengeParser.java:68-73`), but `StepUpHandler.initiate` forwards only `acrValues` into
+`FlowContext.create`, and neither `FlowContext` nor `AuthorizationRequestBuilder` models a
+`max_age` request parameter. A `max_age=300` challenge re-drives authorization **without** the
+freshness constraint — or, for a `max_age`-only challenge, re-drives a request identical to the
+original, looping forever without satisfying the resource server. **Fix:** carry `maxAge` in
+`FlowContext` and emit the `max_age` authorization parameter.
+
+### H3 — DPoP is proof-generation-only; no flow presents it, and it is non-conformant for resource requests
+*CLIENT-11, CLIENT-18 · `dpop/SenderConstraint.java:86-91`, `dpop/DpopProofGenerator.java:136-156`, `flow/*`, `token/UserInfoClient.java:94`*
+
+`SenderConstraint.apply` is on **no executable path** — `AuthorizationCodeFlow`, `RefreshFlow`,
+`ClientCredentialsFlow`, and `TokenEndpointClient` build their header maps internally and never
+attach a DPoP proof, so CLIENT-11 ("be able to *request* sender-constrained tokens at the token
+endpoint") is unreachable through the engine's flow API. (`DpopBoundSpecIT` exercises only
+`DpopProofGenerator` standalone, and no flow-level test asserts a `DPoP` header reaches a recorded
+request — see S0.) Further:
+- `generateProof(htm, htu)` emits only `jti`/`htm`/`htu`/`iat` — there is **no `ath` claim**
+  (RFC 9449 §4.3, mandatory for protected-resource proofs), so a userinfo/resource DPoP request
+  can never be conformant; `UserInfoClient` hardcodes `"Bearer "`.
+- There is **no DPoP-Nonce support**: `TokenEndpointClient` throws a generic `TransportException`
+  on any non-2xx and discards the `DPoP-Nonce` header, so a `use_dpop_nonce` challenge (§8) is
+  unrecoverable — any AS that mandates server nonces (e.g. Okta default) permanently fails.
+- `htu` is embedded verbatim, not stripped of query/fragment (RFC 9449 §4.2).
+
+**Constraint-preservation is metadata-only (CLIENT-18):** `TokenLifecycleManager.applyRefresh` /
+`StoredToken.refreshed(...)` copy the old `ConstraintBinding` onto the refreshed token, but the
+refresh request carried no proof — so the store records a `cnf.jkt` binding for a token actually
+issued as a plain bearer, misrepresenting a replayable token as sender-constrained. **Fix:** wire
+`SenderConstraint` into the token/refresh/userinfo request paths; add `ath` and nonce-retry;
+verify the refreshed token's `cnf` rather than copying the binding blindly.
+
+### H4 — mTLS client auth is selectable and ranked *strongest* but cannot work
+*CLIENT-4, CLIENT-11 · `auth/MtlsClientAuth.java:54-57`, `auth/ClientAuthenticationSelector.java`, `flow/TokenEndpointClient.java:89-94` (+ ParClient, RevocationClient, DiscoveryResolver)*
+
+No code path ever passes an `SSLContext` to `HttpHandler.builder()` (verified against cui-http
+2.0.0, which does expose `.sslContext(...)`); `ClientConfiguration` has no key-material field.
+`MtlsClientAuth` only adds `client_id` to the form. Yet `ClientAuthenticationSelector` ranks
+`tls_client_auth` at strength 3 and will **prefer** it over a working `client_secret_basic` when
+both are advertised — selecting a method the transport cannot honor and producing an
+unauthenticated request (or silently leaning on a process-global default SSLContext). **Fix:**
+plumb an `SSLContext`/keystore through configuration into every endpoint client, or make
+`MtlsClientAuth` construction fail fast until the transport supports it.
+
+### H5 — Refresh-token reuse detection is an orphan and revokes nothing at the AS
+*CLIENT-17, T-REFRESH-THEFT · `token/RefreshTokenFamily.java`, `flow/RefreshFlow.java`, `lifecycle/TokenLifecycleManager.java`*
+
+`RefreshTokenFamily.rotate()` is called by **no executable path** (only a javadoc mention in
+`RefreshFlow`, and a unit test — `RefreshConcurrencyTest` — that races the family object in
+isolation, see S0). The shipped path — `RefreshFlow.refresh` → `TokenLifecycleManager.applyRefresh`
+— performs rotation with **no reuse detection at all**. There is no session→family mapping, and
+families are purely in-memory (lost on restart), unlike the pluggable `TokenStore`. Even when
+reuse *is* detected, `RefreshTokenFamily.java:120-130` only sets a local `revoked` flag and
+throws — it never calls `RevocationClient` (RFC 7009) to invalidate the still-live token at the
+AS, nor clears the `TokenStore`. `token-handling.adoc §4` requires revocation "on detected
+misuse." A thief holding the current rotated token keeps minting access tokens indefinitely;
+only the legitimate client is locked out. (`supersededTokens`, `RefreshTokenFamily.java:48`, is
+also a write-only, unbounded set of secret strings — never read, contradicting "minimal
+storage.") **Fix:** wire the family into `RefreshFlow`, persist it alongside the store, and drive
+RFC 7009 revocation + store-clear on detected reuse.
+
+### H6 — No single-flight refresh; ordinary concurrency self-destructs the session
+*CLIENT-22 · `lifecycle/TokenLifecycleManager.java:89-110`, `flow/RefreshFlow.java:94-121`*
+
+Nothing serializes refresh per session: `needsRefresh` is a pure read and `RefreshFlow.refresh`
+is stateless. Two threads that both observe `needsRefresh=true` both redeem the same refresh
+token. Against a rotating AS with revoke-on-reuse (Keycloak), the second redemption trips
+*AS-side* reuse detection and kills the grant; once client-side detection (H5) is wired, the
+losing thread's rotation is classified as reuse and revokes the family — a benign thundering herd
+is indistinguishable from theft. Two refreshes racing through `applyRefresh` can also land
+last-writer-wins with the *older* result, storing a superseded refresh token. **Fix:**
+per-session single-flight (mutex or shared in-flight future) spanning redeem + `applyRefresh`;
+only presentations outside an in-flight rotation count as reuse.
+
+### H7 — `client_credentials` is hard-capped at shared-secret auth
+*CLIENT-4 · `flow/ClientCredentialsFlow.java:109-137`*
+
+The flow reads `configuration.getAuthMethod()` directly and throws
+`IllegalStateException("… not supported … before increment 3")` for `PRIVATE_KEY_JWT` /
+`TLS_CLIENT_AUTH`; it neither accepts a `ClientAuthentication` strategy nor uses
+`ClientAuthenticationSelector` (unlike `RefreshFlow`, `ParClient`, `RevocationClient`). It also
+duplicates `ClientSecretBasicAuth`'s Basic-encoding byte-for-byte (drift risk). Service-to-service
+acquisition therefore cannot use `private_key_jwt`/mTLS even when the AS advertises them — the
+exact "weak client auth where private_key_jwt/mTLS is available" the exclusion table refuses.
+**Fix:** give it a `ClientAuthentication` constructor like every other authenticated caller;
+delete the duplicated encoding.
+
+### H8 — Secret-carrying records leak tokens via default `toString()`
+*Consistency / secure-logging · `lifecycle/StoredToken.java:45`, `token/RotationResult.java:41`, `flow/CallbackParameters.java:44`*
+
+`StoredToken` (raw `accessToken`/`refreshToken`/`idToken`), `RotationResult` (raw
+`refreshToken`), and `CallbackParameters` (`code`/`state`) are records with auto-generated
+`toString()`. Any debug log, assertion failure, or exception that formats one writes live token
+material to logs — directly contradicting the module's own policy, where
+`ClientConfiguration.clientSecret` is `@ToString.Exclude`d precisely so "an incidental toString
+can never leak it," and session ids are SHA-256-masked before logging. **Fix:** explicit masked
+`toString()` on all three records; add a test asserting secrets are absent.
+
+### H9 — Architecture boundary "engine issues no HTTP of its own" is contradicted
+*Architecture/threat-model boundary; SSRF delegation (COMMONS-3) · `discovery/DiscoveryResolver.java`, `flow/TokenEndpointClient.java`, `flow/ParClient.java`, `token/UserInfoClient.java`, `lifecycle/RevocationClient.java`*
+
+`architecture.adoc` ("Boundaries enforced") and the threat model's out-of-scope section state the
+engine "issues *no* HTTP of its own" and delegates SSRF/TLS to commons (COMMONS-3: egress
+allow-list, internal/link-local blocking). In fact five classes construct their own cui-http
+`HttpHandler` + `java.net.http` calls; **no COMMONS-3 SSRF control** is applied to the
+discovery-advertised `token_endpoint`/`userinfo_endpoint`/`revocation_endpoint`/PAR URLs before
+they are fetched — protection is TLS-scheme-only. A hostile/compromised discovery document can
+point credential-bearing back-channel POSTs at internal addresses. The javadoc calls this "design
+fork 1," but **no document under `doc/` records the fork** — the delegation claim that excludes
+SSRF from the client's threat model is, as written, false. **Fix:** either apply an SSRF/egress
+control on advertised URLs in these clients, or amend `doc/client` (architecture + threat model +
+requirements exclusion table) to state the client performs its own hardened HTTP and owns the
+control.
+
+---
+
+## Medium
+
+- **M1 — `token_type` never validated** (*CLIENT-14 · `flow/TokenEndpointClient.java:127-132`, `token/TokenResponse.java`*). `parse()` checks only `access_token` presence; RFC 6749 §5.1 makes `token_type` REQUIRED. A `token_type: DPoP` (or garbage) response is silently consumed as Bearer, and a DPoP-requested flow cannot detect the AS ignored the constraint.
+- **M2 — Post-logout `state` return-verification has no seam** (*CLIENT-13 · `logout/EndSessionFlow.java`*). The engine builds the end-session redirect with a `state` but provides no component to verify the echoed `state` on the post-logout redirect (`CallbackHandler` is auth-code-specific). The mandated logout CSRF check is entirely unimplemented.
+- **M3 — Signed (JWT) userinfo unsupported** (*CLIENT-16 · `token/UserInfoClient.java:117-135`*). Only `Accept: application/json` plain userinfo is handled; against an OP with `userinfo_signed_response_alg` the engine cannot operate, and there is no path to the signature validation the requirement describes.
+- **M4 — `at_hash` unvalidatable** (*CLIENT-16 · `token/IdTokenValidationBridge.java:69`*). `IdTokenRequest.of(idToken)` never receives the access token, and no `at_hash`/`atHash` handling exists in client *or* validation. The ID-token↔access-token binding check the spec commits to cannot be performed.
+- **M5 — Security rejections throw JDK exceptions, not the commons typed hierarchy** (*CLIENT-20, COMMONS-9 · `CallbackHandler`, `IssValidator`, `IdTokenValidationBridge`, `AuthorizationRequestBuilder`, `PostLogoutRedirectValidator`, `RefreshTokenFamily`*). State/nonce/PKCE-downgrade/mix-up/open-redirect rejections are `IllegalStateException`/`IllegalArgumentException`. The Quarkus/RESTEasy edge cannot map these to RFC 9457 via the typed hierarchy, so they surface as generic 500s.
+- **M6 — Refresh skips OIDC §12.2 ID-token/sub consistency** (*`flow/RefreshFlow.java:113-121`, `token/RotationResult.java`, `lifecycle/StoredToken.java`*). An `id_token` returned on refresh is silently discarded; `RotationResult` has no field for it and `StoredToken` carries the pre-refresh ID token forward forever. Neither the refreshed ID token's `iss`/`sub`/`aud` consistency nor the access token's `sub` is checked — an AS bug/mix-up/store cross-wiring returning another user's tokens is accepted under the victim's session.
+- **M7 — Response fully buffered before the size cap** (*`flow/TokenEndpointClient.java`, `token/UserInfoClient.java`, `flow/ParClient.java`, `discovery/DiscoveryResolver.java`*). `BodyHandlers.ofString()` reads the whole body into memory; `maxContentSize` is checked only afterwards, so the limit defends nothing — a hostile AS can OOM the client first. This path uses raw `java.net.http`, not a hardened commons fetcher. Use a bounded/streaming body handler.
+- **M8 — Uneven log/exception sanitization of external input** (*`flow/CallbackHandler.java:57-59`, `flow/StepUpChallengeParser.java:97`, DSL-JSON `e.getMessage()` at parse sites, `auth/ClientAuthenticationSelector.java:71-73`*). `LogSanitizer` is applied to the callback `iss` and discovery issuer, but the browser-controlled callback `error`, the RS `max_age`, AS-controlled parse-error fragments, and advertised auth-method strings flow unsanitized into log/exception messages (CWE-117), inconsistent with the project's own discipline.
+- **M9 — Transport-boundary exception type inconsistent** (*`flow/TokenEndpointClient.java:89` et al. vs `discovery/DiscoveryResolver.java:110-123`*). Discovery converts non-TLS/malformed URLs to `TransportException`, but the token/PAR/revocation/userinfo clients let `HttpHandler.build()` throw a raw `IllegalArgumentException` for an `http://` or malformed endpoint — despite javadoc declaring only `TransportException`. A discovery doc with an `http://` `token_endpoint` bypasses callers' `TransportException` handling.
+- **M10 — Trailing-slash asymmetry breaks spec-compliant issuers** (*`discovery/DiscoveryResolver.java:125-127` vs `182-191`*). The slash is stripped when building the well-known URL, but `validateIssuer` compares against the *original* configured issuer — a configured `https://as.example/realms/x/` always fails against a spec-compliant AS. Fail-closed, so a correctness/usability defect.
+- **M11–M14 (test)** — the medium test gaps that mirror the above: `form_post` / `acr`-`auth_time` / mix-up-at-exchange are claimed in the traceability matrix but have no backing test (**TEST-1/3/4**); "tampered token" tests validly re-sign the token so **signature integrity is never exercised**, rejection comes only from unknown-issuer lookup (**TEST-7**); the callback attack-database feeds `CallbackParameters.of(Map)`/the constructor and never the real `parse(rawQuery)` decode/duplicate-rejection surface, so encoding-evasion payloads never hit the code and the assertions cannot fail for any corpus-specific reason (**TEST-8**); the `ParClientTest` "only `request_uri`" assertion is vacuous against a hard-coded mock constant (**TEST-9**); the token-endpoint size guard, refresh-window clock edges, and the claimed refresh/logout atomicity race are untested (**TEST-12/13/14**).
+
+---
+
+## Low / informational
+
+- **L1** — All 12 HTTP test classes use `.allowInsecureHttp(true)`; the test strategy mandates `@EnableMockWebServer(useHttps = true)` because the engine's outbound HTTP is TLS-only. The TLS path is never exercised at unit level, and non-TLS refusal is tested only for discovery, not for token/userinfo/revocation/PAR. (**TEST-5**)
+- **L2** — Security-critical `internal` package (`LogSanitizer`, `FormEncoder`, `JsonEscaper`) has **zero tests**; a sanitizer/encoder regression would pass the suite. `ClientConfiguration.toString()` secret-exclusion is likewise untested. (**TEST-15/16**)
+- **L3** — Mandated commons test-jar reuse is partial: `TokenDispatcher`, `RevocationDispatcher`, `EndSessionDispatcher`, `AdversarialResponses`, `JwtTokenTamperingUtil`, and `ShouldHandleObjectContracts` are unused; four near-identical token-endpoint dispatchers are hand-rolled and duplicated across flow tests. (**TEST-6**)
+- **L4** — Vacuous/conditional assertions: `StepUpChallengeAttackDatabaseTest` silently `return`s for most corpus entries; `CallbackParametersAttackDatabaseTest` asserts `isPresent()` after `orElseThrow()`; `PostLogoutRedirectAttackDatabaseTest` guards `assertThrows` behind a null/blank check. (**TEST-10/11**)
+- **L5** — `authorization_endpoint` (the user redirect target) gets no scheme/TLS check, unlike every back-channel URL. A tampered discovery doc (dev insecure mode / compromised AS) can point users at `http://` or an arbitrary scheme. Defense-in-depth gap. (`flow/AuthorizationRequestBuilder.java`)
+- **L6** — `ClientAuthenticationSelector.java:84` `Set.copyOf(advertised)` NPEs on a JSON `null` element in `token_endpoint_auth_methods_supported` (AS-controlled → unclassified crash). `ProviderMetadata.supportsS256()` tolerates the same shape.
+- **L7** — No one-time-use semantics for `state`/`FlowContext`; the handler is stateless and can validate a replayed callback repeatedly. Document the discard contract or add a consumed flag. (`flow/CallbackHandler.java`, `flow/FlowContext.java`)
+- **L8** — `CallbackParameters.of(Map)` silently bypasses the duplicate-parameter injection defense that `parse(String)` enforces; an RP feeding `request.getParameterMap()` loses the RFC 9700 §4.7.3 defense with no javadoc warning.
+- **L9** — `private_key_jwt` supports only `RS256/384/512` — no `PS256`/`ES256`, which FAPI 2.0 (cited as a bar-raiser) requires while banning RS256. (`auth/PrivateKeyJwtAuth.java`)
+- **L10** — `StepUpChallengeParser` uses naive `split(",")`/`unquote`: breaks on quoted values containing commas, silently last-wins on duplicate params, ignores escaped quotes. Only reachable via a `WWW-Authenticate` header, but robustness matters.
+- **L11** — `expires_in` is a primitive `long`; absent (`0`) is indistinguishable from a literal `0`, and downstream an unknown expiry (`expiresAt == null`) makes `isExpired`/`needsRefresh` **always false** — a token with unknown lifetime is used forever and never proactively refreshed. Negative/absurd values also pass unvalidated. Prefer nullable lifetime + conservative default window. (`token/TokenResponse.java`, `lifecycle/RefreshScheduler.java`, `lifecycle/StoredToken.java`)
+- **L12** — `@NullMarked` appears nowhere in the client module, while `token-sheriff-validation` carries it; every `@Nullable` here sits in a null-unmarked context, so JSpecify tooling cannot enforce the non-null default.
+- **L13** — Header collisions: caller/auth headers are applied via `HttpRequest.Builder.header()` (append) after `Content-Type` is set; a colliding `Content-Type`/second `Authorization` is duplicated, not replaced. Use `setHeader`. (`flow/TokenEndpointClient.java`, `flow/ParClient.java`, `lifecycle/RevocationClient.java`)
+- **L14** — Config validation gaps: blank `issuer`/`clientId` accepted; `scopes` may contain null/blank (→ literal `"null"` in the `scope` parameter); no issuer URL-shape check at construction — inconsistent with `PostLogoutRedirectValidator`, which validates every entry. (`config/ClientConfiguration.java`)
+- **L15** — Inconsistent timeouts (discovery 2s/3s; other clients 5s/10s), all hardcoded, no configuration knob — a slow IdP can fail discovery while token calls to the same host succeed. (`discovery/DiscoveryResolver.java` vs the endpoint clients)
+- **L16** — New `HttpClient` built per request in every client, never reused/closed — selector/executor thread churn under load. (`flow/TokenEndpointClient.java`, `token/UserInfoClient.java`, `lifecycle/RevocationClient.java`)
+- **L17** — `TokenLifecycleManager.revokeAndClear` logs `LOGOUT_TOKENS_REVOKED` when it has only *cleared the store* — AS revocation isn't guaranteed to have happened. Misleading audit log.
+- **L18** — `LogSanitizer` escapes but never truncates; a megabyte-long attacker-controlled `iss`/`post_logout_redirect_uri` is written to WARN in full (log flooding). Cap output length.
+- **L19 (traceability rot)** — Production javadoc cites wrong `CLIENT-N` IDs, corrupting the stable traceability the requirements declare: `RefreshFlow`/`RefreshTokenFamily` cite `CLIENT-5` (state CSRF) for rotation (`CLIENT-17`); `FlowContext` cites `CLIENT-2` for state/nonce (`CLIENT-5`/`CLIENT-6`); `IdTokenValidationBridge` cites `CLIENT-2`/`CLIENT-15` for nonce (`CLIENT-6`/`CLIENT-16`); `RevocationClient` cites `CLIENT-13` for `CLIENT-17`.
+- **L20 (doc rot)** — Root `package-info.java` still says "no client behaviour lives here yet"; `ClientCredentialsFlow`/`ClientAuthMethod` reference plan-internal "increment 2/3"; `pom.xml` keeps `maven.javadoc.skip=true` "while the engine is under construction" though the public surface now exists.
+- **L21** — `pom.xml` pins `version.archunit=1.3.0` locally while dependabot bumped validation to 1.4.2 (#552) — cross-module test-dependency drift hidden from future bumps.
+- **L22 (info)** — Token material is held as immutable `String` throughout (`StoredToken`, `RefreshTokenFamily`, `TokenResponse`, `ClientConfiguration.clientSecret`); cannot be zeroed on clear/logout. An accepted Java trade-off, but worth stating explicitly in the store's security docs given "protect the at-rest store."
+
+---
+
+## Verified-good defenses (regression anchors — keep these)
+
+- **PKCE S256** — 32-byte `SecureRandom` verifier → 43-char base64url (valid RFC 7636 length/charset); challenge = `B64URL(SHA-256(ASCII(verifier)))`; `plain` not implementable; builder fails closed when the AS doesn't advertise `S256`.
+- **`state`/`nonce`** — 256-bit `SecureRandom` each; constant-time compare (`MessageDigest.isEqual`) in `CallbackHandler`, `IdTokenValidationBridge`, `IssValidator`, `SubBindingValidator`; callback order error → state → code, all before redemption.
+- **Basic auth** — client id + secret form-urlencoded *before* base64 (RFC 6749 §2.3.1) in both `ClientSecretBasicAuth` and `ClientCredentialsFlow`.
+- **`private_key_jwt`** — fresh `jti` (`UUID.randomUUID`), 60s lifetime, full `aud`/`iss`/`sub`/`iat`/`exp`, RFC 8259-complete JSON escaping, strict allow-list (no `none`/HMAC).
+- **DPoP proof construction** — RFC 7638 lexicographic JWK thumbprint (`e`,`kty`,`n`), correct unsigned big-endian encoding, `typ: dpop+jwt`, RS256/384/512-only, per-call `Signature` instances, bounded fail-closed `jti`-reuse LRU. (Construction is correct; wiring is the gap — see H3.)
+- **RFC 7009 revocation** — any 2xx = success (unknown token = success per §2.2), optional `token_type_hint`, client auth applied, TLS enforced.
+- **Token store race** — `InMemoryTokenStore.update` uses `computeIfPresent`, `remove` is atomic take-and-clear; a refresh landing after logout is a no-op, not a resurrection — and the contract is documented on the SPI for custom stores.
+- **Post-logout open-redirect** — `PostLogoutRedirectValidator` exact whole-string match against an immutable copied allow-list, no normalization/prefix/wildcard, fail-closed, CWE-117 sanitized.
+- **Validation-pipeline monopoly** — access and ID tokens always pass through the bridges into the multi-issuer pipeline; no local signature/algorithm logic exists in the client (CLIENT-15).
+- **Duplicate callback-parameter rejection** (`CallbackParameters.parse`, post-decode, RFC 9700 §4.7.3); `FormEncoder` is the single UTF-8 form-encoding path; `JsonEscaper` covers all mandatory control-char escapes.
+- **`ClientLogMessages`** — unique identifiers, correct levels, no template interpolates a token/secret; session id SHA-256-masked before the INFO log.
+- **ArchUnit boundaries** — `ClientArchitectureTest` (no CDI/MP/JAX-RS) and `CommonsTransportReuseTest` (no bespoke `HttpClient`) actually enforce the stated architecture.
+- **Weak-auth refusal** — `WeakAuthRefusedTest` + `ClientAuthenticationSelector` genuinely fail closed when the AS advertises none of the configured methods and never downgrade below the strongest advertised method.
+- **Rotation reuse race** — `RefreshConcurrencyTest` correctly proves exactly-one-winner across 16 threads on the family object (the object works; it's just not wired into the flow — H5).
+
+---
+
+## Suggested remediation order
+
+1. **Fix the test strategy first (S0), because it is why the rest was not caught.** Add the
+   mandatory wired-flow / negative-path tier: drive `AuthorizationCodeFlow`/`RefreshFlow`/the
+   step-up path *and* the produced Quarkus bean graph as an application would, and assert the
+   attack is refused before any side effect (token endpoint not called on `iss` mismatch;
+   front-channel URL carries only `request_uri`; `DPoP` header reaches the recorded request;
+   rotated-token reuse fires RFC 7009 revocation). Forbid marking a requirement "covered" in the
+   traceability matrix without such a test. Adding this tier turns the following items into
+   red tests, which is the point.
+2. **Decide the staging question.** Confirm with the module owner whether CLIENT-8/10/11/12/17 were deliberately staged. If yes, correct `doc/client` (requirements status, threat-model coverage claims, test-strategy traceability) so the docs stop asserting coverage that does not exist — this is itself a security-documentation defect. If no, they are release blockers.
+3. **Wire the four orphaned defenses** into the actual flow paths with the request-verifying tests from step 1: `IssValidator` (C2), `ParClient`/`request_uri` redirect (M-PAR), `SenderConstraint`+`ath`+nonce (H3), `RefreshTokenFamily`→`RevocationClient` + single-flight (H5/H6).
+4. **Implement the two missing behaviors**: `response_mode=form_post` (C1) and step-up `acr`/`auth_time` verification + `max_age` (H1/H2).
+5. **Fix mTLS** (H4) — plumb `SSLContext` or fail fast + stop ranking it strongest.
+6. **Secure-logging pass**: masked `toString()` on the three records (H8); uniform `LogSanitizer` on all external input (M8).
+7. **Reconcile the HTTP/SSRF boundary** (H9) — apply the control or amend the docs.
+8. **Harden the remaining test surfaces**: real signature tampering via `JwtTokenTamperingUtil` (TEST-7), point the callback corpus at `parse()` (TEST-8), add HTTPS-mock coverage (TEST-5), and cover the `internal` package (TEST-15).
+9. Sweep the low/info items (typed exceptions, `token_type`, trailing-slash, `@NullMarked`, doc/traceability rot, config validation).


### PR DESCRIPTION
## Summary

- Enable the GitHub merge queue: `use_merge_queue=true` on the `default:branch-cleanup` finalize step (a `merge_queue` ruleset was provisioned on `main` via the steward)
- Seed `build.map` for the `java` and `javascript` domains (file-to-build-class contract)
- Back-fill newly added finalize-step defaults: `architecture-refresh`, `finalize-step-preference-emitter`, `finalize-step-print-phase-breakdown`, and `sonar-roundtrip` params
- Refresh provisioning stamps to plan-marshall 0.1.1082
- Add `doc/code-review.md` and `doc/code-review-validation.md` from the recent code-review sessions

## Notes

Configuration-only change produced by `/marshall-steward` (menu mode remediation pass + merge-queue provisioning); no production code touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive security review documentation for the client and validation modules.
  * Documented identified security findings, severity levels, verified defenses, and prioritized remediation guidance.
  * Added coverage of cryptographic protections, authentication flows, transport security, caching, parsing, and testing considerations.

* **Configuration**
  * Updated workflow finalization and build-routing configuration to support improved project automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->