### PR TITLE
chore: enable merge-queue support (merge_group triggers + use_merge_queue)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
+  # Required for the GitHub merge queue: without it the queued checks never
+  # report and the queue times out (see cuioss-organization v0.8.0).
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
+  # Required for the GitHub merge queue: without it the queued checks never
+  # report and the queue times out (see cuioss-organization v0.8.0).
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
+  # Required for the GitHub merge queue: without it the queued checks never
+  # report and the queue times out (see cuioss-organization v0.8.0).
+  merge_group:
 
 permissions:
   contents: read

--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -107,7 +107,7 @@
           "merge_queue_wait_budget_seconds": 1800,
           "merge_hold_window": "full_window_release_at_waits",
           "merge_hold_budget_seconds": 3600,
-          "use_merge_queue": false,
+          "use_merge_queue": true,
           "admin_merge_on_stuck_state": false
         },
         "default:record-metrics": {},


### PR DESCRIPTION
## Summary

Completes the merge-queue rollout that was rolled back in #554 (commit b250aef6) after PR 554 hung in the queue.

- Add the `merge_group:` trigger to `maven.yml`, `integration-tests.yml`, and `e2e-tests.yml` — the three workflows producing the required checks (`build / conclusion`, `integration-tests / conclusion`, `e2e-tests / conclusion`) — so they report inside a merge group.
- The reusable workflows handle the event since [cuioss-organization v0.8.0](https://github.com/cuioss/cuioss-organization/pull/172), already pinned on main via #555: docs-only detection and Sonar are skipped in the queue; everything else runs unchanged.
- Re-provision the `merge_queue` ruleset on `main` (done via the steward) and restore `use_merge_queue=true` on the `default:branch-cleanup` finalize step in `marshal.json`.

## Validation

This PR itself merges through the newly enabled queue — the merge-group run uses the merged workflow files, so the triggers take effect for exactly this merge onward.