### PR TITLE
chore(config): correct automatic-review step key prefix to plan-marshall:

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -85,7 +85,7 @@
         "default:push": {},
         "default:create-pr": {},
         "default:ci-verify": {},
-        "default:automatic-review": {
+        "plan-marshall:automatic-review": {
           "review_bot_buffer_seconds": 180,
           "re_review_on_loopback": false,
           "re_review_on_branch_cleanup": true,


### PR DESCRIPTION
One-line marshal.json fix: the review-step key rename that rode PR #560 used `default:automatic-review`, but the step is owned by the plan-marshall bundle skill — the `default:` namespace has no automatic-review standards doc, so the key would fail to resolve at the next plan's manifest compose (the same finalize hard-block nifi-extensions hit, captured there as lesson 2026-07-12-15-001). Canonical form verified against the plan-marshall meta repo and nifi-extensions: `plan-marshall:automatic-review`. Knob values unchanged.