### PR TITLE
fix(client): address CodeRabbit PR #560 review findings

### DIFF
--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/config/ClientConfiguration.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/config/ClientConfiguration.java
@@ -150,13 +150,34 @@ public class ClientConfiguration {
         this.issuer = requireNonBlank(issuer, "issuer");
         validateIssuerUrl(this.issuer);
         this.clientId = requireNonBlank(clientId, "clientId");
-        this.clientSecret = clientSecret;
+        this.clientSecret = validateClientSecret(clientSecret);
         this.authMethod = Objects.requireNonNull(authMethod, "authMethod must not be null");
         this.scopes = validateScopes(scopes);
         this.redirectUri = redirectUri;
         this.allowInsecureHttp = allowInsecureHttp;
-        this.connectTimeoutSeconds = connectTimeoutSeconds;
-        this.readTimeoutSeconds = readTimeoutSeconds;
+        this.connectTimeoutSeconds = requirePositive(connectTimeoutSeconds, "connectTimeoutSeconds");
+        this.readTimeoutSeconds = requirePositive(readTimeoutSeconds, "readTimeoutSeconds");
+    }
+
+    /**
+     * A client secret is optional (it is {@code null} for the key-based methods), but a
+     * <em>provided</em> secret must carry an actual value: a blank/whitespace-only secret is a
+     * misconfiguration that would otherwise be wired through the shared-secret auth strategies and
+     * fail only later at the token endpoint. A blank secret is rejected; an absent ({@code null})
+     * secret is preserved.
+     */
+    private static @Nullable String validateClientSecret(@Nullable String clientSecret) {
+        if (clientSecret != null && clientSecret.isBlank()) {
+            throw new IllegalArgumentException("clientSecret must not be blank when provided");
+        }
+        return clientSecret;
+    }
+
+    private static int requirePositive(int value, String field) {
+        if (value <= 0) {
+            throw new IllegalArgumentException(field + " must be positive, but was: " + value);
+        }
+        return value;
     }
 
     private static String requireNonBlank(String value, String field) {

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/AuthorizationRequestBuilder.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/AuthorizationRequestBuilder.java
@@ -66,6 +66,7 @@ public class AuthorizationRequestBuilder {
     private static final String PARAM_RESPONSE_MODE = "response_mode";
     private static final String RESPONSE_MODE_FORM_POST = "form_post";
     private static final String SCHEME_HTTPS = "https";
+    private static final String SCHEME_HTTP = "http";
 
     /**
      * Builds the authorization request URL for the given flow context.
@@ -128,10 +129,17 @@ public class AuthorizationRequestBuilder {
             throw new ClientProtocolException(
                     "authorization endpoint is not a valid URL: " + authorizationEndpoint, e);
         }
-        if (!SCHEME_HTTPS.equalsIgnoreCase(scheme) && !configuration.isAllowInsecureHttp()) {
-            throw new ClientProtocolException(
-                    "authorization endpoint is not a TLS (https) URL; refusing to start the authorization_code"
-                            + " flow over an insecure channel");
+        if (SCHEME_HTTPS.equalsIgnoreCase(scheme)) {
+            return;
         }
+        // Only literal cleartext http is tolerated, and only when explicitly allowed for a local test
+        // setup. Any other scheme (ftp/file/javascript/…) and an absent/blank scheme are rejected, so a
+        // non-http(s) authorization endpoint can never be issued.
+        if (configuration.isAllowInsecureHttp() && SCHEME_HTTP.equalsIgnoreCase(scheme)) {
+            return;
+        }
+        throw new ClientProtocolException(
+                "authorization endpoint is not a TLS (https) URL; refusing to start the authorization_code"
+                        + " flow over an insecure channel");
     }
 }

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/StepUpChallengeParser.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/StepUpChallengeParser.java
@@ -101,7 +101,8 @@ public class StepUpChallengeParser {
             String key = pair.substring(0, eq).strip().toLowerCase(Locale.ROOT);
             String value = unquote(pair.substring(eq + 1).strip());
             if (params.putIfAbsent(key, value) != null) {
-                LOGGER.debug("Ignoring step-up challenge with duplicate auth-param '%s'", key);
+                LOGGER.debug("Ignoring step-up challenge with duplicate auth-param '%s'",
+                        LogSanitizer.sanitize(key));
                 return Optional.empty();
             }
         }

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/StepUpHandler.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/StepUpHandler.java
@@ -81,7 +81,7 @@ public class StepUpHandler {
      * @param challenge     the parsed step-up challenge; must not be {@code null}
      * @return the elevated authorization request (URL + fresh flow context)
      * @throws IllegalArgumentException if the client declares no redirect URI
-     * @throws IllegalStateException    if the AS advertises no authorization endpoint or no PKCE
+     * @throws ClientProtocolException  if the AS advertises no authorization endpoint or no PKCE
      *                                  {@code S256}
      */
     public StepUpRequest initiate(ClientConfiguration configuration, ProviderMetadata metadata,

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/StepUpHandler.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/StepUpHandler.java
@@ -106,8 +106,9 @@ public class StepUpHandler {
      *                  {@code null}
      * @param idToken   the validated ID token returned by the elevated exchange; must not be
      *                  {@code null}
-     * @throws IllegalStateException if the {@code acr} is not among the required values or the
-     *                               authentication is older than {@code max_age}
+     * @throws de.cuioss.sheriff.token.commons.error.ClientProtocolException if the {@code acr} is not
+     *                               among the required values or the authentication is older than
+     *                               {@code max_age}
      */
     public void verifyResult(StepUpChallenge challenge, IdTokenContent idToken) {
         resultVerifier.verify(challenge, idToken);

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/config/ClientConfigurationTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/config/ClientConfigurationTest.java
@@ -82,6 +82,77 @@ class ClientConfigurationTest {
     }
 
     @Test
+    @DisplayName("Should reject a blank client secret while still permitting an absent (null) one — blank != absent")
+    void shouldRejectBlankSecretButPermitAbsentSecret() {
+        var blankSecret = ClientConfiguration.builder()
+                .issuer(issuer()).clientId(Generators.nonBlankStrings().next())
+                .clientSecret("   ").authMethod(ClientAuthMethod.CLIENT_SECRET_BASIC);
+        var emptySecret = ClientConfiguration.builder()
+                .issuer(issuer()).clientId(Generators.nonBlankStrings().next())
+                .clientSecret("").authMethod(ClientAuthMethod.CLIENT_SECRET_POST);
+        // A key-based method carries no shared secret: an absent (null) secret must remain valid.
+        var absentSecret = ClientConfiguration.builder()
+                .issuer(issuer()).clientId(Generators.nonBlankStrings().next())
+                .authMethod(ClientAuthMethod.PRIVATE_KEY_JWT).build();
+
+        assertAll("blank-secret rejection, null-secret acceptance",
+                () -> assertThrows(IllegalArgumentException.class, blankSecret::build,
+                        "a whitespace-only client secret is a misconfiguration and must be rejected at construction"),
+                () -> assertThrows(IllegalArgumentException.class, emptySecret::build,
+                        "an empty client secret must be rejected at construction"),
+                () -> assertNull(absentSecret.getClientSecret(),
+                        "an absent (null) secret stays valid for a key-based auth method"));
+    }
+
+    @Test
+    @DisplayName("Should reject a non-positive connect or read timeout at construction")
+    void shouldRejectNonPositiveTimeouts() {
+        var zeroConnect = ClientConfiguration.builder()
+                .issuer(issuer()).clientId(Generators.nonBlankStrings().next())
+                .authMethod(ClientAuthMethod.CLIENT_SECRET_BASIC).connectTimeoutSeconds(0);
+        var negativeConnect = ClientConfiguration.builder()
+                .issuer(issuer()).clientId(Generators.nonBlankStrings().next())
+                .authMethod(ClientAuthMethod.CLIENT_SECRET_BASIC).connectTimeoutSeconds(-1);
+        var zeroRead = ClientConfiguration.builder()
+                .issuer(issuer()).clientId(Generators.nonBlankStrings().next())
+                .authMethod(ClientAuthMethod.CLIENT_SECRET_BASIC).readTimeoutSeconds(0);
+        var negativeRead = ClientConfiguration.builder()
+                .issuer(issuer()).clientId(Generators.nonBlankStrings().next())
+                .authMethod(ClientAuthMethod.CLIENT_SECRET_BASIC).readTimeoutSeconds(-5);
+
+        assertAll("timeout guards",
+                () -> assertThrows(IllegalArgumentException.class, zeroConnect::build,
+                        "a zero connect timeout is invalid"),
+                () -> assertThrows(IllegalArgumentException.class, negativeConnect::build,
+                        "a negative connect timeout is invalid"),
+                () -> assertThrows(IllegalArgumentException.class, zeroRead::build,
+                        "a zero read timeout is invalid"),
+                () -> assertThrows(IllegalArgumentException.class, negativeRead::build,
+                        "a negative read timeout is invalid"));
+    }
+
+    @Test
+    @DisplayName("Should build with explicit positive timeouts and a valid secret, and default the timeouts otherwise")
+    void shouldBuildWithValidTimeoutsAndSecret() {
+        var explicit = ClientConfiguration.builder()
+                .issuer(issuer()).clientId(Generators.nonBlankStrings().next())
+                .clientSecret(Generators.nonBlankStrings().next())
+                .authMethod(ClientAuthMethod.CLIENT_SECRET_BASIC)
+                .connectTimeoutSeconds(7).readTimeoutSeconds(11).build();
+        var defaulted = ClientConfiguration.builder()
+                .issuer(issuer()).clientId(Generators.nonBlankStrings().next())
+                .authMethod(ClientAuthMethod.CLIENT_SECRET_BASIC).build();
+
+        assertAll("valid timeout configuration",
+                () -> assertEquals(7, explicit.getConnectTimeoutSeconds()),
+                () -> assertEquals(11, explicit.getReadTimeoutSeconds()),
+                () -> assertEquals(ClientConfiguration.DEFAULT_CONNECT_TIMEOUT_SECONDS,
+                        defaulted.getConnectTimeoutSeconds()),
+                () -> assertEquals(ClientConfiguration.DEFAULT_READ_TIMEOUT_SECONDS,
+                        defaulted.getReadTimeoutSeconds()));
+    }
+
+    @Test
     @DisplayName("Should reject a null issuer, client id or auth method")
     void shouldRejectNullRequiredFields() {
         var clientId = Generators.nonBlankStrings().next();

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/AuthorizationRequestBuilderTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/AuthorizationRequestBuilderTest.java
@@ -214,4 +214,87 @@ class AuthorizationRequestBuilderTest {
                             () -> builder.build(configuration, metadata, null)));
         }
     }
+
+    @Nested
+    @DisplayName("Endpoint-scheme enforcement (L5)")
+    class SchemeEnforcement {
+
+        private static final String HTTP_ENDPOINT = "http://issuer.example.com/authorize";
+
+        private static ClientConfiguration config(boolean allowInsecureHttp) {
+            return ClientConfiguration.builder()
+                    .issuer("https://issuer.example.com")
+                    .clientId(Generators.nonBlankStrings().next())
+                    .clientSecret(Generators.nonBlankStrings().next())
+                    .authMethod(ClientAuthMethod.CLIENT_SECRET_BASIC)
+                    .scope("openid")
+                    .redirectUri(REDIRECT_URI)
+                    .allowInsecureHttp(allowInsecureHttp)
+                    .build();
+        }
+
+        @Test
+        @DisplayName("Should always accept an https endpoint, whether or not insecure http is allowed")
+        void shouldAcceptHttpsRegardlessOfInsecureFlag() {
+            var context = FlowContext.create(REDIRECT_URI);
+
+            assertAll("https always allowed",
+                    () -> assertTrue(builder.build(config(false), metadataWithS256(AUTH_ENDPOINT), context)
+                            .startsWith(AUTH_ENDPOINT + "?"), "https accepted when insecure http is not allowed"),
+                    () -> assertTrue(builder.build(config(true), metadataWithS256(AUTH_ENDPOINT), context)
+                            .startsWith(AUTH_ENDPOINT + "?"), "https accepted when insecure http is allowed"));
+        }
+
+        @Test
+        @DisplayName("Should accept a cleartext http endpoint only when insecure http is explicitly allowed")
+        void shouldAcceptHttpOnlyWhenAllowed() {
+            var context = FlowContext.create(REDIRECT_URI);
+
+            String url = builder.build(config(true), metadataWithS256(HTTP_ENDPOINT), context);
+
+            assertTrue(url.startsWith(HTTP_ENDPOINT + "?"),
+                    "a cleartext http endpoint is permitted for a local test setup when allowInsecureHttp is set");
+        }
+
+        @Test
+        @DisplayName("Should reject a cleartext http endpoint when insecure http is not allowed")
+        void shouldRejectHttpWhenNotAllowed() {
+            var configuration = config(false);
+            var metadata = metadataWithS256(HTTP_ENDPOINT);
+            var context = FlowContext.create(REDIRECT_URI);
+
+            assertThrows(ClientProtocolException.class,
+                    () -> builder.build(configuration, metadata, context),
+                    "a non-TLS endpoint must be refused unless insecure http is explicitly allowed");
+        }
+
+        @Test
+        @DisplayName("Should reject a non-http(s) scheme even when insecure http is allowed")
+        void shouldRejectForeignSchemeEvenWhenInsecureAllowed() {
+            var configuration = config(true);
+            var context = FlowContext.create(REDIRECT_URI);
+            var ftp = metadataWithS256("ftp://issuer.example.com/authorize");
+            var file = metadataWithS256("file:///etc/passwd");
+
+            assertAll("only literal http is tolerated under allowInsecureHttp",
+                    () -> assertThrows(ClientProtocolException.class,
+                            () -> builder.build(configuration, ftp, context),
+                            "an ftp endpoint is never a valid authorization endpoint"),
+                    () -> assertThrows(ClientProtocolException.class,
+                            () -> builder.build(configuration, file, context),
+                            "a file endpoint is never a valid authorization endpoint"));
+        }
+
+        @Test
+        @DisplayName("Should reject an endpoint with no scheme (relative URL) even when insecure http is allowed")
+        void shouldRejectSchemelessEndpoint() {
+            var configuration = config(true);
+            var metadata = metadataWithS256("/authorize");
+            var context = FlowContext.create(REDIRECT_URI);
+
+            assertThrows(ClientProtocolException.class,
+                    () -> builder.build(configuration, metadata, context),
+                    "a schemeless (relative) authorization endpoint must be rejected");
+        }
+    }
 }

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/ClientCredentialsFlowTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/ClientCredentialsFlowTest.java
@@ -133,11 +133,14 @@ class ClientCredentialsFlowTest {
         KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
         generator.initialize(2048);
         KeyPair keyPair = generator.generateKeyPair();
+        // URIBuilder is mutable, so metadata(uriBuilder) must be resolved once: a second call would
+        // append another "/token" segment and point the request at the wrong path.
+        ProviderMetadata metadata = metadata(uriBuilder);
         var privateKeyJwt = new PrivateKeyJwtAuth(config.getClientId(),
-                metadata(uriBuilder).getTokenEndpoint().orElseThrow(), keyPair.getPrivate(),
+                metadata.getTokenEndpoint().orElseThrow(), keyPair.getPrivate(),
                 Generators.letterStrings(3, 8).next(), "RS256");
 
-        AccessTokenContent content = flow(config, privateKeyJwt).obtainToken(metadata(uriBuilder));
+        AccessTokenContent content = flow(config, privateKeyJwt).obtainToken(metadata);
 
         assertNotNull(content, "key-based client_credentials acquisition must return a validated token");
         RecordedRequest request = server.takeRequest();

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/StepUpChallengeAttackDatabaseTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/StepUpChallengeAttackDatabaseTest.java
@@ -26,6 +26,7 @@ import de.cuioss.test.generator.Generators;
 import de.cuioss.test.generator.junit.EnableGeneratorController;
 import de.cuioss.test.juli.junit5.EnableTestLogger;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
@@ -99,6 +100,20 @@ class StepUpChallengeAttackDatabaseTest {
                 "the attack payload must be encoded into exactly one acr_values parameter, never injecting a second");
         assertTrue(url.startsWith(AUTH_ENDPOINT + "?"),
                 "the payload must not break the authorization endpoint prefix");
+    }
+
+    @Test
+    @DisplayName("Should reject and log a challenge carrying a duplicate auth-param, sanitizing the key (RFC 9110 §11.2)")
+    void shouldRejectDuplicateAuthParamFailClosed() {
+        // A duplicate auth-param is malformed per RFC 9110 §11.2; the parser fails closed rather than
+        // taking a last-wins value an attacker could inject, and the offending key is log-sanitized.
+        String duplicated = "Bearer error=\"insufficient_user_authentication\", "
+                + "acr_values=\"gold\", acr_values=\"silver\"";
+
+        Optional<StepUpChallenge> challenge = parser.parse(duplicated);
+
+        assertTrue(challenge.isEmpty(),
+                "a challenge with a duplicate auth-param must be rejected fail-closed");
     }
 
     private void assertForgedHeaderRejected(String attackHeader) {

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/WiredFlowNegativePathIT.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/WiredFlowNegativePathIT.java
@@ -126,7 +126,7 @@ class WiredFlowNegativePathIT extends WiredFlowTestSupport {
         var metadata = metadataWithTokenEndpoint(uriBuilder);
         var clientAuth = clientAuth(config);
 
-        assertRefusedBeforeTokenEndpoint(IllegalStateException.class,
+        assertRefusedBeforeTokenEndpoint(ClientProtocolException.class,
                 () -> flow.exchange(metadata, context, forgedCallback, clientAuth));
     }
 
@@ -142,7 +142,7 @@ class WiredFlowNegativePathIT extends WiredFlowTestSupport {
         var metadata = metadataWithTokenEndpoint(uriBuilder);
         var clientAuth = clientAuth(config);
 
-        assertRefusedBeforeTokenEndpoint(IllegalStateException.class,
+        assertRefusedBeforeTokenEndpoint(ClientProtocolException.class,
                 () -> flow.exchange(metadata, context, mixedUpCallback, clientAuth));
     }
 
@@ -159,7 +159,7 @@ class WiredFlowNegativePathIT extends WiredFlowTestSupport {
         var flow = authorizationCodeFlow(config);
         var clientAuth = clientAuth(config);
 
-        assertRefusedBeforeTokenEndpoint(IllegalStateException.class,
+        assertRefusedBeforeTokenEndpoint(ClientProtocolException.class,
                 () -> flow.exchange(metadata, context, callbackWithoutIss, clientAuth));
     }
 

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/lifecycle/TokenStoreTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/lifecycle/TokenStoreTest.java
@@ -144,15 +144,20 @@ class TokenStoreTest {
         Instant now = Instant.now();
         String freshSession = Generators.letterStrings(10, 20).next();
         String expiringSession = Generators.letterStrings(10, 20).next();
+        String unknownExpirySession = Generators.letterStrings(10, 20).next();
         manager.store(freshSession, new StoredToken(Generators.letterStrings(20, 40).next(), null, null, null,
                 now.plusSeconds(300)));
         manager.store(expiringSession, new StoredToken(Generators.letterStrings(20, 40).next(), null, null, null,
                 now.plusSeconds(10)));
+        manager.store(unknownExpirySession, new StoredToken(Generators.letterStrings(20, 40).next(), null, null, null,
+                null));
 
         assertAll("refresh scheduling",
                 () -> assertFalse(manager.needsRefresh(freshSession, now), "a token far from expiry is not refreshed"),
                 () -> assertTrue(manager.needsRefresh(expiringSession, now),
                         "a token inside the refresh window is refreshed"),
+                () -> assertTrue(manager.needsRefresh(unknownExpirySession, now),
+                        "a token with unknown (null) expiry is treated as refresh-eligible"),
                 () -> assertFalse(manager.needsRefresh(Generators.letterStrings(10, 20).next(), now),
                         "an absent session never needs refresh"));
     }


### PR DESCRIPTION
Follow-up to #560 addressing the 9 CodeRabbit review comments that were posted on that PR but not resolved before it merged.

## Major — broken S0 wired-flow test assertions (merged undetected)
`WiredFlowNegativePathIT` (the S0 wired-flow / negative-path tier) asserted `IllegalStateException` for the state-mismatch, mix-up, and missing-`iss` cases, but `CallbackHandler.handle()` and `IssValidator.validate()` now throw `ClientProtocolException` (the M5 typed-exception change). Because `token-sheriff-client` has **no failsafe binding**, these `*IT` tests don't run in CI, so the stale assertions merged without failing. Fixed all three; force-ran `WiredFlowNegativePathIT` (7/7 pass).

## Minor
- **ClientConfiguration** — validate `connectTimeoutSeconds` / `readTimeoutSeconds` are positive at construction (they previously bypassed validation and failed obscurely later).
- **AuthorizationRequestBuilder** — `enforceEndpointScheme` permitted any non-https scheme (`ftp`/`file`/`javascript`) and a null scheme when `allowInsecureHttp=true`. Now: `https` always; literal `http` only when `allowInsecureHttp`; everything else (incl. null/blank) rejected.
- **StepUpChallengeParser** — sanitize the attacker-controlled duplicate auth-param **key** before logging (CWE-117; the value was already sanitized).
- **StepUpHandler** — `@throws` javadoc corrected to `ClientProtocolException`.
- **ClientConfiguration** — reject a blank/whitespace `clientSecret` at construction (preserving `null` = absent for `private_key_jwt`/mTLS).
- **ClientCredentialsFlowTest** — mutable `URIBuilder` was reused, appending a second `/token`; resolve `ProviderMetadata` once and reuse.
- **TokenStoreTest** — add a null-expiry assertion (`expiresAt == null` ⇒ refresh-eligible) so that `RefreshScheduler` branch can't regress.

## Verification
- `install -pl token-sheriff-client -am -DskipTests` → green
- `test -pl token-sheriff-client` → 564 tests, 0 failures
- `WiredFlowNegativePathIT` (forced via `-Dtest`) → 7/7
- `install` + `test -pl token-sheriff-client-quarkus` → 14 tests, 0 failures


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for client secrets and connection timeouts, providing clearer errors for invalid configuration.
  * Strengthened endpoint security checks to accept only valid HTTP or HTTPS schemes.
  * Standardized protocol errors for invalid authorization responses and challenge verification failures.
  * Improved handling of unknown token expiry values by triggering proactive refresh.
  * Sanitized duplicate parameter names in diagnostic logging.
* **Documentation**
  * Corrected documented error behavior for failed step-up challenge verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->