### PR TITLE
chore(steward): sync marshal.json with current config defaults

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -76,6 +76,10 @@
           "auto_rebase_threshold": "no_overlap_only"
         },
         "default:pre-push-quality-gate": {},
+        "default:pre-submission-self-review": {
+          "self_review": "auto",
+          "drop_review_on_scope_gate": false
+        },
         "default:finalize-step-simplify": {
           "simplify": "auto"
         },
@@ -84,7 +88,6 @@
         },
         "default:push": {},
         "default:create-pr": {},
-        "default:ci-verify": {},
         "plan-marshall:automatic-review": {
           "review_bot_buffer_seconds": 180,
           "re_review_on_loopback": false,
@@ -94,6 +97,8 @@
           "review_rate_window_await": false,
           "review_rate_window_timeout_seconds": 3600
         },
+        "default:ci-verify": {},
+        "default:architecture-refresh": {},
         "default:sonar-roundtrip": {
           "touched_file_cleanup": "new_code_only",
           "do_transition": false,
@@ -108,19 +113,15 @@
           "merge_hold_window": "full_window_release_at_waits",
           "merge_hold_budget_seconds": 3600,
           "use_merge_queue": true,
-          "admin_merge_on_stuck_state": false
+          "admin_merge_on_stuck_state": false,
+          "pre_merge_comment_barrier": "fail_into_loopback"
         },
-        "default:record-metrics": {},
-        "default:archive-plan": {},
-        "default:architecture-refresh": {},
         "default:finalize-step-preference-emitter": {
           "preference_min_recurrence": 2
         },
+        "default:record-metrics": {},
         "default:finalize-step-print-phase-breakdown": {},
-        "default:pre-submission-self-review": {
-          "self_review": "auto",
-          "drop_review_on_scope_gate": false
-        }
+        "default:archive-plan": {}
       },
       "effort": {
         "default": "level-3",
@@ -183,7 +184,9 @@
       "feature/",
       "fix/",
       "chore/"
-    ]
+    ],
+    "pr_strategy": "compact",
+    "pr_compact_max_changed_files": 150
   },
   "providers": [
     {
@@ -249,7 +252,7 @@
       "lessons_superseded_days": 0,
       "temp_on_maintenance": true
     },
-    "provisioned_version": "0.1.1090",
-    "config_seed_fingerprint": "dde4bc0c"
+    "provisioned_version": "0.1.1101",
+    "config_seed_fingerprint": "d30886a0"
   }
 }


### PR DESCRIPTION
## Summary

Steward-maintained sync of `.plan/marshal.json` produced by the `/marshall-steward`
menu-mode Re-Run Remediation Pass. No production code or behaviour changes.

The remediation pass reconciled the project's `marshal.json` against the current
plan-marshall config defaults (installed version `0.1.1101`):

- Normalized top-level key order (`normalize-keys`).
- Back-filled missing default keys via `sync-defaults`:
  - `project.pr_strategy`
  - `project.pr_compact_max_changed_files`
  - `plan.phase-6-finalize.steps.default:branch-cleanup.pre_merge_comment_barrier`
- Re-sorted `phase-6-finalize.steps` into canonical frontmatter order (`steps-sort`).

The executor was regenerated in-place during the pass (per-tree derived state);
`marshal_status` is now `fresh` (`0.1.1090` → `0.1.1101`).

## Review

Labelled `skip-bot-review` — this is a deterministic config reconcile, not a code
change. Note the label fully suppresses only CodeRabbit; Sourcery/Gemini are not
label-suppressible in this repo.
