### PR TITLE
fix(client-quarkus): generate javadoc jar so Maven Central accepts the release

### DIFF
--- a/token-sheriff-quarkus-parent/token-sheriff-client-quarkus/pom.xml
+++ b/token-sheriff-quarkus-parent/token-sheriff-client-quarkus/pom.xml
@@ -18,9 +18,6 @@
 
     <properties>
         <maven.jar.plugin.automatic.module.name>de.cuioss.sheriff.token.client.quarkus</maven.jar.plugin.automatic.module.name>
-        <!-- Wired, empty skeleton (Plan 05): only package-info.java, so Javadoc has no public
-             classes to document and would fail. Re-enable once client runtime code lands (Plan 06). -->
-        <maven.javadoc.skip>true</maven.javadoc.skip>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Problem

The automated 0.9.1 Release workflow failed at the Maven Central publish step. Sonatype rejected the atomic deployment (`336416a9-...`) with:

```
Error: pkg:maven/de.cuioss.sheriff.token/token-sheriff-client-quarkus@0.9.1
Error: Javadocs must be provided but not found in entries
```

## Root cause

`token-sheriff-client-quarkus` is new since 0.9.0 (which is why 0.9.0 published fine). It carried `<maven.javadoc.skip>true</maven.javadoc.skip>` from when it was a wired, empty skeleton (only `package-info.java`). The module now has public runtime classes (`ClientExceptionMapper`, `TokenSheriffClientProducer`, `ClientConfigMapper`, `ClientRuntimeConfig`), so the skip is stale. The module is published to Central (no `deploy.skip`) and its `-deployment` counterpart depends on it, so a missing `-javadoc.jar` fails Central's required-artifact validation.

## Fix

Remove the stale `maven.javadoc.skip`, so the module produces a `-javadoc.jar` like its published sibling `token-sheriff-validation-quarkus`. Verified locally: `javadoc:jar` now builds `token-sheriff-client-quarkus-*-javadoc.jar` (BUILD SUCCESS). This was the only deployed module skipping javadoc.

Once merged, the 0.9.1 release will be re-triggered via `workflow_dispatch`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * Added an automatic Java module name for the Quarkus client package.
  * Updated build configuration so Javadoc generation is no longer explicitly skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->