### PR TITLE
chore(steward): reconcile marshal.json via upgrade

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -69,25 +69,31 @@
       "max_iterations": 3,
       "finalize_without_asking": true,
       "loop_back_without_asking": false,
-      "qgate": "auto",
       "checks_wait_timeout_seconds": 600,
       "steps": {
         "default:finalize-step-sync-baseline": {
-          "auto_rebase_threshold": "no_overlap_only"
+          "auto_rebase_threshold": "no_overlap_only",
+          "lane": "minimal"
         },
-        "default:pre-push-quality-gate": {},
+        "default:pre-push-quality-gate": {
+          "lane": "minimal"
+        },
         "default:pre-submission-self-review": {
-          "self_review": "auto",
-          "drop_review_on_scope_gate": false
+          "drop_review_on_scope_gate": false,
+          "lane": "auto"
         },
         "default:finalize-step-simplify": {
-          "simplify": "auto"
+          "lane": "auto"
         },
         "default:finalize-step-security-audit": {
-          "security_audit": "auto"
+          "lane": "full"
         },
-        "default:push": {},
-        "default:create-pr": {},
+        "default:push": {
+          "lane": "minimal"
+        },
+        "default:create-pr": {
+          "lane": "minimal"
+        },
         "plan-marshall:automatic-review": {
           "review_bot_buffer_seconds": 180,
           "re_review_on_loopback": false,
@@ -95,16 +101,29 @@
           "re_review_await_timeout_seconds": 600,
           "re_review_on_timeout": "ask",
           "review_rate_window_await": false,
-          "review_rate_window_timeout_seconds": 3600
+          "review_rate_window_timeout_seconds": 3600,
+          "enabled_bots": "coderabbit,sourcery,gemini",
+          "review_completion_poll_timeout_seconds": 600,
+          "lane": "ask"
         },
-        "default:ci-verify": {},
-        "default:architecture-refresh": {},
+        "default:ci-verify": {
+          "lane": "minimal"
+        },
+        "default:architecture-refresh": {
+          "lane": "minimal"
+        },
         "default:sonar-roundtrip": {
           "touched_file_cleanup": "new_code_only",
           "do_transition": false,
-          "ce_wait_timeout_seconds": 600
+          "ce_wait_timeout_seconds": 600,
+          "lane": "ask"
         },
-        "default:lessons-capture": {},
+        "default:lessons-capture": {
+          "lane": "minimal"
+        },
+        "default:adr-propose": {
+          "lane": "off"
+        },
         "default:branch-cleanup": {
           "pr_merge_strategy": "squash",
           "final_merge_without_asking": false,
@@ -114,14 +133,22 @@
           "merge_hold_budget_seconds": 3600,
           "use_merge_queue": true,
           "admin_merge_on_stuck_state": false,
-          "pre_merge_comment_barrier": "fail_into_loopback"
+          "pre_merge_comment_barrier": "fail_into_loopback",
+          "lane": "minimal"
         },
         "default:finalize-step-preference-emitter": {
-          "preference_min_recurrence": 2
+          "preference_min_recurrence": 2,
+          "lane": "minimal"
         },
-        "default:record-metrics": {},
-        "default:finalize-step-print-phase-breakdown": {},
-        "default:archive-plan": {}
+        "default:record-metrics": {
+          "lane": "minimal"
+        },
+        "default:finalize-step-print-phase-breakdown": {
+          "lane": "minimal"
+        },
+        "default:archive-plan": {
+          "lane": "minimal"
+        }
       },
       "effort": {
         "default": "level-3",
@@ -252,7 +279,7 @@
       "lessons_superseded_days": 0,
       "temp_on_maintenance": true
     },
-    "provisioned_version": "0.1.1101",
-    "config_seed_fingerprint": "d30886a0"
+    "provisioned_version": "0.1.1114",
+    "config_seed_fingerprint": "37df1a33"
   }
 }


### PR DESCRIPTION
## Summary

Post-plugin-update reconciliation of `.plan/marshal.json` produced by
`/marshall-steward upgrade` (plan-marshall `0.1.1114`).

- `sync-defaults` migrated 4 keys and materialized 15 finalize steps
- `steps-sort` restored canonical frontmatter order
- build-map drift check: in sync (no re-seed)

Only `.plan/marshal.json` changed (48 insertions, 21 deletions). This is
steward-maintained configuration.

## Review

Labelled `skip-bot-review` — deterministic config reconcile, no code change.
Note the label fully suppresses only CodeRabbit; Sourcery/Gemini are not
label-suppressible in this repo.

## Test plan

- Executor preflight reports `marshal_status: fresh`, all versions `0.1.1114`
- No production code touched
