### PR TITLE
chore(steward): land steward-maintained artifacts

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -88,10 +88,10 @@
         "default:finalize-step-security-audit": {
           "lane": "full"
         },
-        "default:push": {
+        "default:architecture-refresh": {
           "lane": "minimal"
         },
-        "default:create-pr": {
+        "default:push": {
           "lane": "minimal"
         },
         "plan-marshall:automatic-review": {
@@ -106,10 +106,10 @@
           "review_completion_poll_timeout_seconds": 600,
           "lane": "ask"
         },
-        "default:ci-verify": {
+        "default:create-pr": {
           "lane": "minimal"
         },
-        "default:architecture-refresh": {
+        "default:ci-verify": {
           "lane": "minimal"
         },
         "default:sonar-roundtrip": {
@@ -279,7 +279,7 @@
       "lessons_superseded_days": 0,
       "temp_on_maintenance": true
     },
-    "provisioned_version": "0.1.1114",
+    "provisioned_version": "0.1.1116",
     "config_seed_fingerprint": "37df1a33"
   }
 }


### PR DESCRIPTION
## Summary

Post-plugin-update reconciliation of `.plan/marshal.json` produced by
`/marshall-steward upgrade` (plan-marshall `0.1.1116`).

- Executor regenerated (131 scripts discovered)
- `sync-defaults` reported no changes needed
- `steps-sort` restored canonical `phase-6-finalize.steps` frontmatter order
- build-map drift check: in sync (no re-seed)

Only `.plan/marshal.json` changed (5 insertions, 5 deletions). This is
steward-maintained configuration.

## Review

Labelled `skip-bot-review` — deterministic config reconcile, no code change.
Note the label fully suppresses only CodeRabbit; Sourcery/Gemini are not
label-suppressible in this repo.

## Test plan

- Executor preflight reports `marshal_status: fresh`, all versions `0.1.1116`
- No production code touched
