### PR TITLE
fix(client,validation): remediate open findings from delta report

### DIFF
--- a/token-sheriff-client/pom.xml
+++ b/token-sheriff-client/pom.xml
@@ -21,6 +21,11 @@
         <version.lombok>1.18.46</version.lombok>
         <version.dsl.json>2.0.2</version.dsl.json>
         <version.archunit>1.4.2</version.archunit>
+        <!-- Explicit Failsafe version: token-sheriff-client inherits no maven-failsafe-plugin
+             pluginManagement from cui-java-parent or token-sheriff-parent, so the IT tier
+             binding below must pin its own version. Kept aligned with the effective Surefire
+             version so the *Test unit tier and *IT integration tier run the same generation. -->
+        <version.maven.failsafe>3.5.6</version.maven.failsafe>
     </properties>
 
     <dependencyManagement>
@@ -176,6 +181,22 @@
                     </annotationProcessorPaths>
                     <release>21</release>
                 </configuration>
+            </plugin>
+            <!-- Bind Failsafe so the wired-flow integration tier (WiredFlowNegativePathIT, which uses
+                 MockWebServer — no external infra) actually runs under `mvn verify`. The *IT class was
+                 previously compiled but never executed because no Failsafe binding existed here. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>${version.maven.failsafe}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/auth/package-info.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/auth/package-info.java
@@ -27,4 +27,7 @@
  *
  * @since 1.0
  */
+@NullMarked
 package de.cuioss.sheriff.token.client.auth;
+
+import org.jspecify.annotations.NullMarked;

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/config/package-info.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/config/package-info.java
@@ -25,4 +25,7 @@
  *
  * @since 1.0
  */
+@NullMarked
 package de.cuioss.sheriff.token.client.config;
+
+import org.jspecify.annotations.NullMarked;

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/discovery/package-info.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/discovery/package-info.java
@@ -25,4 +25,7 @@
  *
  * @since 1.0
  */
+@NullMarked
 package de.cuioss.sheriff.token.client.discovery;
+
+import org.jspecify.annotations.NullMarked;

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/dpop/ConstraintBinding.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/dpop/ConstraintBinding.java
@@ -24,7 +24,7 @@ import java.util.Objects;
  * {@code cnf} (confirmation) claim ties it to a key the client holds — a DPoP proof-key thumbprint
  * ({@code cnf.jkt}, RFC 9449) or the client certificate thumbprint ({@code cnf."x5t#S256"},
  * RFC 8705). This value object carries that binding alongside the stored token so the constraint
- * survives storage and refresh (consumed by the token-lifecycle increment, {@code CLIENT-18}).
+ * survives storage and refresh (consumed by the token lifecycle, {@code CLIENT-18}).
  * <p>
  * The engine only <em>records</em> the binding here; verifying that a presented token actually
  * matches the confirmed key is inherited from the validation pipeline ({@code VALIDATION-8.7}) and

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/dpop/SenderConstraint.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/dpop/SenderConstraint.java
@@ -46,10 +46,10 @@ public final class SenderConstraint {
     /** The RFC 9449 request header carrying the DPoP proof. */
     static final String DPOP_HEADER = "DPoP";
 
-    private final DpopProofGenerator dpopGenerator;
+    private final @Nullable DpopProofGenerator dpopGenerator;
     private final ConstraintBinding binding;
 
-    private SenderConstraint(DpopProofGenerator dpopGenerator, ConstraintBinding binding) {
+    private SenderConstraint(@Nullable DpopProofGenerator dpopGenerator, ConstraintBinding binding) {
         this.dpopGenerator = dpopGenerator;
         this.binding = binding;
     }

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/dpop/SenderConstraint.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/dpop/SenderConstraint.java
@@ -33,8 +33,8 @@ import java.util.Objects;
  *       {@code cnf."x5t#S256"}. No request header is added — the binding is transport-level.</li>
  * </ul>
  * Either way the resulting {@link ConstraintBinding} is recorded ({@link #binding()}) so the
- * sender-constraint can be preserved alongside the stored token (consumed by the token-lifecycle
- * increment, {@code CLIENT-18}).
+ * sender-constraint can be preserved alongside the stored token (consumed by the token lifecycle,
+ * {@code CLIENT-18}).
  *
  * @since 1.0
  * @author Oliver Wolff

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/dpop/package-info.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/dpop/package-info.java
@@ -22,7 +22,7 @@
  * {@link de.cuioss.sheriff.token.client.dpop.SenderConstraint} applies the DPoP proof header (or,
  * for mTLS, relies on the transport-level certificate binding) to the token request and records the
  * resulting {@link de.cuioss.sheriff.token.client.dpop.ConstraintBinding}. The binding is carried
- * alongside the stored token by the token-lifecycle increment so the constraint survives storage and
+ * alongside the stored token by the token lifecycle so the constraint survives storage and
  * refresh ({@code CLIENT-18}). Verifying that a presented token matches its confirmed key is
  * inherited from the validation pipeline ({@code VALIDATION-8.7}) and is not re-implemented here.
  *

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/dpop/package-info.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/dpop/package-info.java
@@ -28,4 +28,7 @@
  *
  * @since 1.0
  */
+@NullMarked
 package de.cuioss.sheriff.token.client.dpop;
+
+import org.jspecify.annotations.NullMarked;

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/AuthorizationCodeFlow.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/AuthorizationCodeFlow.java
@@ -123,6 +123,10 @@ public class AuthorizationCodeFlow {
      * @param senderConstraint            the DPoP/mTLS sender-constraint to attach to the code exchange,
      *                                    or {@code null} for a plain bearer redemption
      */
+    // S107 (too many parameters) is unavoidable here: this is the explicit-collaborators constructor
+    // that exposes every dependency for DI/testing; the two shorter overloads above delegate to it.
+    // Collapsing the parameters into a parameter object would obscure, not reduce, the collaborators.
+    @SuppressWarnings("java:S107")
     public AuthorizationCodeFlow(ClientConfiguration configuration, TokenEndpointClient tokenEndpointClient,
             TokenValidationBridge accessTokenBridge, IdTokenValidationBridge idTokenBridge,
             IssValidator issValidator, AuthorizationRequestBuilder authorizationRequestBuilder,

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/AuthorizationCodeFlow.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/AuthorizationCodeFlow.java
@@ -153,7 +153,11 @@ public class AuthorizationCodeFlow {
      */
     public AuthorizationRedirect authorize(ProviderMetadata metadata) {
         Objects.requireNonNull(metadata, "metadata must not be null");
-        FlowContext context = FlowContext.create(configuration.getRedirectUri());
+        String redirectUri = configuration.getRedirectUri();
+        if (redirectUri == null || redirectUri.isBlank()) {
+            throw new IllegalArgumentException("client declares no redirect URI");
+        }
+        FlowContext context = FlowContext.create(redirectUri);
         String url = authorizationRequestBuilder.build(configuration, metadata, context);
         return new AuthorizationRedirect(url, context);
     }

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/AuthorizationCodeFlow.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/AuthorizationCodeFlow.java
@@ -206,8 +206,9 @@ public class AuthorizationCodeFlow {
         clientAuthentication.decorate(form, headers);
 
         // Route through the constraint-bearing overload so a DPoP/mTLS-requiring AS can bind the
-        // initial code redemption; a null senderConstraint preserves the plain-bearer exchange
-        // (including the one-shot use_dpop_nonce retry the 4-arg overload already implements).
+        // initial code redemption; a null senderConstraint preserves the plain-bearer exchange.
+        // The one-shot use_dpop_nonce retry the 4-arg overload implements applies only when a DPoP
+        // senderConstraint is supplied — it never fires for the null-senderConstraint plain-bearer path.
         TokenResponse tokenResponse = tokenEndpointClient.requestToken(tokenEndpoint, form, headers,
                 senderConstraint);
         AccessTokenContent accessToken = accessTokenBridge.validateAccessToken(tokenResponse.accessToken);

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/AuthorizationCodeFlow.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/AuthorizationCodeFlow.java
@@ -18,12 +18,14 @@ package de.cuioss.sheriff.token.client.flow;
 import de.cuioss.sheriff.token.client.auth.ClientAuthentication;
 import de.cuioss.sheriff.token.client.config.ClientConfiguration;
 import de.cuioss.sheriff.token.client.discovery.ProviderMetadata;
+import de.cuioss.sheriff.token.client.dpop.SenderConstraint;
 import de.cuioss.sheriff.token.client.token.IdTokenValidationBridge;
 import de.cuioss.sheriff.token.client.token.TokenResponse;
 import de.cuioss.sheriff.token.client.token.TokenValidationBridge;
 import de.cuioss.sheriff.token.validation.domain.token.AccessTokenContent;
 import de.cuioss.sheriff.token.validation.domain.token.IdTokenContent;
 import de.cuioss.tools.logging.CuiLogger;
+import org.jspecify.annotations.Nullable;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -67,6 +69,8 @@ public class AuthorizationCodeFlow {
     private final IssValidator issValidator;
     private final AuthorizationRequestBuilder authorizationRequestBuilder;
     private final CallbackHandler callbackHandler;
+    @Nullable
+    private final SenderConstraint senderConstraint;
 
     /**
      * Creates a flow with a default {@link IssValidator}, {@link AuthorizationRequestBuilder}, and
@@ -80,24 +84,30 @@ public class AuthorizationCodeFlow {
     public AuthorizationCodeFlow(ClientConfiguration configuration, TokenEndpointClient tokenEndpointClient,
             TokenValidationBridge accessTokenBridge, IdTokenValidationBridge idTokenBridge) {
         this(configuration, tokenEndpointClient, accessTokenBridge, idTokenBridge, new IssValidator(),
-                new AuthorizationRequestBuilder(), new CallbackHandler());
+                new AuthorizationRequestBuilder(), new CallbackHandler(), null);
     }
 
     /**
      * Creates a flow with an explicit {@link IssValidator} and default {@link AuthorizationRequestBuilder}
      * / {@link CallbackHandler}.
+     * <p>
+     * When {@code senderConstraint} is supplied, the initial code redemption is DPoP/mTLS-bound so the
+     * issued access token is confirmed to the proof key ({@code CLIENT-11}); {@code null} preserves the
+     * plain-bearer redemption.
      *
      * @param configuration       the client configuration; must not be {@code null}
      * @param tokenEndpointClient the token-endpoint transport; must not be {@code null}
      * @param accessTokenBridge   the access-token validation bridge; must not be {@code null}
      * @param idTokenBridge       the ID-token validation bridge; must not be {@code null}
      * @param issValidator        the RFC 9207 issuer mix-up validator; must not be {@code null}
+     * @param senderConstraint    the DPoP/mTLS sender-constraint to attach to the code exchange, or
+     *                            {@code null} for a plain bearer redemption
      */
     public AuthorizationCodeFlow(ClientConfiguration configuration, TokenEndpointClient tokenEndpointClient,
             TokenValidationBridge accessTokenBridge, IdTokenValidationBridge idTokenBridge,
-            IssValidator issValidator) {
+            IssValidator issValidator, @Nullable SenderConstraint senderConstraint) {
         this(configuration, tokenEndpointClient, accessTokenBridge, idTokenBridge, issValidator,
-                new AuthorizationRequestBuilder(), new CallbackHandler());
+                new AuthorizationRequestBuilder(), new CallbackHandler(), senderConstraint);
     }
 
     /**
@@ -110,11 +120,13 @@ public class AuthorizationCodeFlow {
      * @param issValidator                the RFC 9207 issuer mix-up validator; must not be {@code null}
      * @param authorizationRequestBuilder the authorization-request builder; must not be {@code null}
      * @param callbackHandler             the callback handler; must not be {@code null}
+     * @param senderConstraint            the DPoP/mTLS sender-constraint to attach to the code exchange,
+     *                                    or {@code null} for a plain bearer redemption
      */
     public AuthorizationCodeFlow(ClientConfiguration configuration, TokenEndpointClient tokenEndpointClient,
             TokenValidationBridge accessTokenBridge, IdTokenValidationBridge idTokenBridge,
             IssValidator issValidator, AuthorizationRequestBuilder authorizationRequestBuilder,
-            CallbackHandler callbackHandler) {
+            CallbackHandler callbackHandler, @Nullable SenderConstraint senderConstraint) {
         this.configuration = Objects.requireNonNull(configuration, "configuration must not be null");
         this.tokenEndpointClient = Objects.requireNonNull(tokenEndpointClient, "tokenEndpointClient must not be null");
         this.accessTokenBridge = Objects.requireNonNull(accessTokenBridge, "accessTokenBridge must not be null");
@@ -123,6 +135,7 @@ public class AuthorizationCodeFlow {
         this.authorizationRequestBuilder = Objects.requireNonNull(authorizationRequestBuilder,
                 "authorizationRequestBuilder must not be null");
         this.callbackHandler = Objects.requireNonNull(callbackHandler, "callbackHandler must not be null");
+        this.senderConstraint = senderConstraint;
     }
 
     /**
@@ -184,7 +197,11 @@ public class AuthorizationCodeFlow {
         Map<String, String> headers = new HashMap<>();
         clientAuthentication.decorate(form, headers);
 
-        TokenResponse tokenResponse = tokenEndpointClient.requestToken(tokenEndpoint, form, headers);
+        // Route through the constraint-bearing overload so a DPoP/mTLS-requiring AS can bind the
+        // initial code redemption; a null senderConstraint preserves the plain-bearer exchange
+        // (including the one-shot use_dpop_nonce retry the 4-arg overload already implements).
+        TokenResponse tokenResponse = tokenEndpointClient.requestToken(tokenEndpoint, form, headers,
+                senderConstraint);
         AccessTokenContent accessToken = accessTokenBridge.validateAccessToken(tokenResponse.accessToken);
 
         if (tokenResponse.idToken == null || tokenResponse.idToken.isBlank()) {

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/CallbackHandler.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/CallbackHandler.java
@@ -15,8 +15,8 @@
  */
 package de.cuioss.sheriff.token.client.flow;
 
-import de.cuioss.sheriff.token.client.internal.LogSanitizer;
 import de.cuioss.sheriff.token.commons.error.ClientProtocolException;
+import de.cuioss.sheriff.token.commons.error.InboundErrorNormalizer;
 import de.cuioss.tools.logging.CuiLogger;
 
 import java.nio.charset.StandardCharsets;
@@ -57,9 +57,9 @@ public class CallbackHandler {
         Objects.requireNonNull(parameters, "parameters must not be null");
 
         if (parameters.hasError()) {
-            throw new ClientProtocolException(
-                    "authorization server returned an error callback: "
-                            + LogSanitizer.sanitize(parameters.error()));
+            // Route both error and error_description through the shared commons normalizer so the
+            // inbound and outbound error surfaces render one sanitized contract (COMMONS-11).
+            throw InboundErrorNormalizer.normalize(parameters.error(), parameters.errorDescription());
         }
         if (!statesMatch(context.state(), parameters.state())) {
             LOGGER.debug("Rejecting authorization callback: state mismatch");

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/CallbackHandler.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/CallbackHandler.java
@@ -19,6 +19,8 @@ import de.cuioss.sheriff.token.commons.error.ClientProtocolException;
 import de.cuioss.sheriff.token.commons.error.InboundErrorNormalizer;
 import de.cuioss.tools.logging.CuiLogger;
 
+import org.jspecify.annotations.Nullable;
+
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.Objects;
@@ -70,7 +72,7 @@ public class CallbackHandler {
                 .orElseThrow(() -> new ClientProtocolException("authorization callback is missing the authorization code"));
     }
 
-    private static boolean statesMatch(String expected, String actual) {
+    private static boolean statesMatch(String expected, @Nullable String actual) {
         if (actual == null) {
             return false;
         }

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/ParClient.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/ParClient.java
@@ -22,6 +22,7 @@ import de.cuioss.sheriff.token.client.auth.ClientAuthentication;
 import de.cuioss.sheriff.token.client.config.ClientConfiguration;
 import de.cuioss.sheriff.token.client.internal.BackChannelHttp;
 import de.cuioss.sheriff.token.client.internal.FormEncoder;
+import de.cuioss.sheriff.token.client.internal.LogSanitizer;
 import de.cuioss.sheriff.token.commons.error.TransportException;
 import de.cuioss.sheriff.token.commons.transport.ParserConfig;
 import de.cuioss.tools.logging.CuiLogger;
@@ -138,8 +139,11 @@ public class ParClient {
             }
             return parResponse;
         } catch (IOException e) {
-            LOGGER.debug(e, "Failed to parse PAR endpoint response: %s", e.getMessage());
-            throw new TransportException("Failed to parse PAR endpoint response: " + e.getMessage(), e);
+            // The parse-error message can echo an AS-controlled JSON fragment; sanitize it (CWE-117)
+            // before it reaches the log appender or the exception message.
+            String sanitizedError = LogSanitizer.sanitize(e.getMessage());
+            LOGGER.debug(e, "Failed to parse PAR endpoint response: %s", sanitizedError);
+            throw new TransportException("Failed to parse PAR endpoint response: " + sanitizedError, e);
         }
     }
 

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/ParClient.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/ParClient.java
@@ -124,6 +124,10 @@ public class ParClient {
         }
     }
 
+    // java:S2589 — body is non-null by every current caller/handler wiring, but the guard is kept
+    // (consistent with the equivalent parse() entry guards in UserInfoClient / TokenEndpointClient) as
+    // defensive resilience against a future change to the shared bounded body-handler.
+    @SuppressWarnings("java:S2589")
     private ParResponse parse(String body) {
         if (body == null || body.isBlank()) {
             throw new TransportException("Empty PAR endpoint response");

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/ParClient.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/ParClient.java
@@ -146,7 +146,7 @@ public class ParClient {
             // The parse-error message can echo an AS-controlled JSON fragment; sanitize it (CWE-117)
             // before it reaches the log appender or the exception message.
             String sanitizedError = LogSanitizer.sanitize(e.getMessage());
-            LOGGER.debug(e, "Failed to parse PAR endpoint response: %s", sanitizedError);
+            LOGGER.debug("Failed to parse PAR endpoint response: %s", sanitizedError);
             throw new TransportException("Failed to parse PAR endpoint response: " + sanitizedError, e);
         }
     }

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/TokenEndpointClient.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/TokenEndpointClient.java
@@ -218,7 +218,7 @@ public class TokenEndpointClient {
             // The parse-error message can echo an AS-controlled JSON fragment; sanitize it (CWE-117)
             // before it reaches the log appender or the exception message, matching the token_type site.
             String sanitizedError = LogSanitizer.sanitize(e.getMessage());
-            LOGGER.debug(e, "Failed to parse token endpoint response: %s", sanitizedError);
+            LOGGER.debug("Failed to parse token endpoint response: %s", sanitizedError);
             throw new TransportException("Failed to parse token endpoint response: " + sanitizedError, e);
         }
     }

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/TokenEndpointClient.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/TokenEndpointClient.java
@@ -211,8 +211,11 @@ public class TokenEndpointClient {
             }
             return tokenResponse;
         } catch (IOException e) {
-            LOGGER.debug(e, "Failed to parse token endpoint response: %s", e.getMessage());
-            throw new TransportException("Failed to parse token endpoint response: " + e.getMessage(), e);
+            // The parse-error message can echo an AS-controlled JSON fragment; sanitize it (CWE-117)
+            // before it reaches the log appender or the exception message, matching the token_type site.
+            String sanitizedError = LogSanitizer.sanitize(e.getMessage());
+            LOGGER.debug(e, "Failed to parse token endpoint response: %s", sanitizedError);
+            throw new TransportException("Failed to parse token endpoint response: " + sanitizedError, e);
         }
     }
 

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/TokenEndpointClient.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/TokenEndpointClient.java
@@ -189,6 +189,10 @@ public class TokenEndpointClient {
         }
     }
 
+    // java:S2589 — body is non-null by every current caller/handler wiring, but the guard is kept
+    // (consistent with the equivalent parse() entry guards in UserInfoClient / ParClient) as
+    // defensive resilience against a future change to the shared bounded body-handler.
+    @SuppressWarnings("java:S2589")
     private TokenResponse parse(String body) {
         if (body == null || body.isBlank()) {
             throw new TransportException("Empty token endpoint response");

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/package-info.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/package-info.java
@@ -20,8 +20,9 @@
  * {@code HttpHandler} wrapper for the authenticated back-channel token-endpoint {@code POST}
  * (design fork 1). {@link de.cuioss.sheriff.token.client.flow.ClientCredentialsFlow} drives the
  * {@code client_credentials} grant on top of it, validating every retrieved token through the
- * validation pipeline. Later increments add the {@code refresh_token} and
- * {@code authorization_code} + PKCE flows to this package.
+ * validation pipeline. {@link de.cuioss.sheriff.token.client.flow.RefreshFlow} drives the
+ * {@code refresh_token} grant and {@link de.cuioss.sheriff.token.client.flow.AuthorizationCodeFlow}
+ * drives the {@code authorization_code} + PKCE flow on the same back-channel client.
  *
  * @since 1.0
  */

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/package-info.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/package-info.java
@@ -25,4 +25,7 @@
  *
  * @since 1.0
  */
+@NullMarked
 package de.cuioss.sheriff.token.client.flow;
+
+import org.jspecify.annotations.NullMarked;

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/internal/package-info.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/internal/package-info.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Client-engine-internal transport and encoding utilities.
+ * <p>
+ * These types are implementation details of the client engine, not part of its public API:
+ * {@link de.cuioss.sheriff.token.client.internal.BackChannelHttp} centralises the shared back-channel
+ * egress/SSRF and TLS controls; {@link de.cuioss.sheriff.token.client.internal.BoundedContentBodyHandler}
+ * enforces the response payload ceiling during the read;
+ * {@link de.cuioss.sheriff.token.client.internal.FormEncoder} and
+ * {@link de.cuioss.sheriff.token.client.internal.JsonEscaper} handle request/response encoding; and
+ * {@link de.cuioss.sheriff.token.client.internal.LogSanitizer} neutralizes externally-sourced values
+ * before they are logged (CWE-117). {@link de.cuioss.sheriff.token.client.internal.ClientLogMessages}
+ * holds the package's structured {@code LogRecord} definitions.
+ *
+ * @since 1.0
+ */
+@NullMarked
+package de.cuioss.sheriff.token.client.internal;
+
+import org.jspecify.annotations.NullMarked;

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/lifecycle/StoredToken.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/lifecycle/StoredToken.java
@@ -27,7 +27,7 @@ import java.util.Optional;
  * <p>
  * A stored token keeps the retrieved token material off the browser: the access token, the optional
  * refresh token and ID token, the optional sender-constraint {@link ConstraintBinding} (from the
- * DPoP/mTLS increment), and the access-token expiry. Carrying the {@code ConstraintBinding} here is
+ * DPoP/mTLS sender-constraint), and the access-token expiry. Carrying the {@code ConstraintBinding} here is
  * what lets the sender-constraint survive storage and proactive refresh.
  * <p>
  * <strong>Refresh is proof-driven, not metadata-only.</strong> {@link #refreshed} does <em>not</em>

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/logout/package-info.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/logout/package-info.java
@@ -25,4 +25,7 @@
  *
  * @since 1.0
  */
+@NullMarked
 package de.cuioss.sheriff.token.client.logout;
+
+import org.jspecify.annotations.NullMarked;

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/token/UserInfoClient.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/token/UserInfoClient.java
@@ -256,7 +256,7 @@ public class UserInfoClient {
             // The parse-error message can echo an AS-controlled JSON fragment; sanitize it (CWE-117)
             // before it reaches the log appender or the exception message.
             String sanitizedError = LogSanitizer.sanitize(e.getMessage());
-            LOGGER.debug(e, "Failed to parse userinfo endpoint response: %s", sanitizedError);
+            LOGGER.debug("Failed to parse userinfo endpoint response: %s", sanitizedError);
             throw new TransportException("Failed to parse userinfo endpoint response: " + sanitizedError, e);
         }
     }

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/token/UserInfoClient.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/token/UserInfoClient.java
@@ -208,7 +208,12 @@ public class UserInfoClient {
             throw new TransportException("Empty userinfo endpoint response");
         }
         UserInfoResponse userInfo = signedResponseValidator.validate(body);
-        if (userInfo == null || userInfo.sub == null || userInfo.sub.isBlank()) {
+        // java:S2589 — the SignedUserInfoValidator functional interface and UserInfoResponse.sub are
+        // declared non-null under @NullMarked, but a caller-supplied validator implementation can
+        // still violate that contract; kept as a defensive guard against a misbehaving validator.
+        @SuppressWarnings("java:S2589")
+        boolean missingSub = userInfo == null || userInfo.sub == null || userInfo.sub.isBlank();
+        if (missingSub) {
             throw new TransportException("signed userinfo response is missing the 'sub' claim");
         }
         return userInfo;
@@ -229,6 +234,10 @@ public class UserInfoClient {
         }
     }
 
+    // java:S2589 — body is non-null by every current caller/handler wiring, but the guard is kept
+    // (consistent with the equivalent parse() entry guards in ParClient / TokenEndpointClient) as
+    // defensive resilience against a future change to the shared bounded body-handler.
+    @SuppressWarnings("java:S2589")
     private UserInfoResponse parse(String body) {
         if (body == null || body.isBlank()) {
             throw new TransportException("Empty userinfo endpoint response");

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/token/UserInfoClient.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/token/UserInfoClient.java
@@ -21,6 +21,7 @@ import de.cuioss.http.client.handler.HttpStatusFamily;
 import de.cuioss.sheriff.token.client.config.ClientConfiguration;
 import de.cuioss.sheriff.token.client.dpop.SenderConstraint;
 import de.cuioss.sheriff.token.client.internal.BackChannelHttp;
+import de.cuioss.sheriff.token.client.internal.LogSanitizer;
 import de.cuioss.sheriff.token.commons.error.TransportException;
 import de.cuioss.sheriff.token.commons.transport.ParserConfig;
 import de.cuioss.tools.logging.CuiLogger;
@@ -243,8 +244,11 @@ public class UserInfoClient {
             }
             return userInfo;
         } catch (IOException e) {
-            LOGGER.debug(e, "Failed to parse userinfo endpoint response: %s", e.getMessage());
-            throw new TransportException("Failed to parse userinfo endpoint response: " + e.getMessage(), e);
+            // The parse-error message can echo an AS-controlled JSON fragment; sanitize it (CWE-117)
+            // before it reaches the log appender or the exception message.
+            String sanitizedError = LogSanitizer.sanitize(e.getMessage());
+            LOGGER.debug(e, "Failed to parse userinfo endpoint response: %s", sanitizedError);
+            throw new TransportException("Failed to parse userinfo endpoint response: " + sanitizedError, e);
         }
     }
 }

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/token/package-info.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/token/package-info.java
@@ -24,4 +24,7 @@
  *
  * @since 1.0
  */
+@NullMarked
 package de.cuioss.sheriff.token.client.token;
+
+import org.jspecify.annotations.NullMarked;

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/auth/ClientSecretAuthTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/auth/ClientSecretAuthTest.java
@@ -21,15 +21,12 @@ import de.cuioss.sheriff.token.client.flow.TokenEndpointClient;
 import de.cuioss.test.generator.Generators;
 import de.cuioss.test.generator.junit.EnableGeneratorController;
 import de.cuioss.test.juli.junit5.EnableTestLogger;
+import de.cuioss.sheriff.token.validation.test.dispatcher.TokenDispatcher;
 import de.cuioss.test.mockwebserver.EnableMockWebServer;
 import de.cuioss.test.mockwebserver.URIBuilder;
-import de.cuioss.test.mockwebserver.dispatcher.HttpMethodMapper;
-import de.cuioss.test.mockwebserver.dispatcher.ModuleDispatcherElement;
 import lombok.Getter;
-import mockwebserver3.MockResponse;
 import mockwebserver3.MockWebServer;
 import mockwebserver3.RecordedRequest;
-import okhttp3.Headers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -39,8 +36,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -66,7 +61,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ClientSecretAuthTest {
 
     @Getter
-    private final TokenEndpointDispatcher moduleDispatcher = new TokenEndpointDispatcher();
+    private final TokenDispatcher moduleDispatcher = new TokenDispatcher();
 
     @BeforeEach
     void resetDispatcher() {
@@ -84,7 +79,7 @@ class ClientSecretAuthTest {
     }
 
     private static String tokenEndpoint(URIBuilder uriBuilder) {
-        return uriBuilder.addPathSegment("token").buildAsString();
+        return uriBuilder.addPathSegments("oidc", "token").buildAsString();
     }
 
     @Test
@@ -123,7 +118,7 @@ class ClientSecretAuthTest {
     @Test
     @DisplayName("client_secret_basic should send the Basic header on the wire without leaking the secret into the URL")
     void basicShouldSendHeaderOnTheWire(URIBuilder uriBuilder, MockWebServer server) throws Exception {
-        moduleDispatcher.success();
+        moduleDispatcher.returnDefault();
         String clientId = Generators.letterStrings(5, 12).next();
         String clientSecret = Generators.letterStrings(8, 20).next();
         var auth = new ClientSecretBasicAuth(clientId, clientSecret);
@@ -186,7 +181,7 @@ class ClientSecretAuthTest {
     @Test
     @DisplayName("client_secret_post should send credentials in the form body without leaking the secret into the URL")
     void postShouldSendFormCredentialsOnTheWire(URIBuilder uriBuilder, MockWebServer server) throws Exception {
-        moduleDispatcher.success();
+        moduleDispatcher.returnDefault();
         String clientId = Generators.letterStrings(5, 12).next();
         String clientSecret = Generators.letterStrings(8, 20).next();
         var auth = new ClientSecretPostAuth(clientId, clientSecret);
@@ -218,40 +213,5 @@ class ClientSecretAuthTest {
         assertAll("null rejection",
                 () -> assertThrows(NullPointerException.class, () -> new ClientSecretPostAuth(null, secret)),
                 () -> assertThrows(NullPointerException.class, () -> new ClientSecretPostAuth(id, null)));
-    }
-
-    /**
-     * Minimal token-endpoint dispatcher serving a success response so {@link TokenEndpointClient}
-     * completes and the request can be inspected.
-     */
-    static final class TokenEndpointDispatcher implements ModuleDispatcherElement {
-
-        private static final int HTTP_OK = 200;
-
-        private String body = "";
-
-        void reset() {
-            this.body = "";
-        }
-
-        void success() {
-            this.body = "{\"access_token\":\"" + Generators.letterStrings(20, 40).next()
-                    + "\",\"token_type\":\"Bearer\",\"expires_in\":300}";
-        }
-
-        @Override
-        public String getBaseUrl() {
-            return "/token";
-        }
-
-        @Override
-        public Set<HttpMethodMapper> supportedMethods() {
-            return Set.of(HttpMethodMapper.POST);
-        }
-
-        @Override
-        public Optional<MockResponse> handlePost(RecordedRequest request) {
-            return Optional.of(new MockResponse(HTTP_OK, Headers.of("Content-Type", "application/json"), body));
-        }
     }
 }

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/AuthorizationCodeFlowTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/AuthorizationCodeFlowTest.java
@@ -30,19 +30,16 @@ import de.cuioss.sheriff.token.validation.domain.token.AccessTokenContent;
 import de.cuioss.sheriff.token.validation.domain.token.IdTokenContent;
 import de.cuioss.sheriff.token.validation.exception.TokenValidationException;
 import de.cuioss.sheriff.token.validation.test.TestTokenHolder;
+import de.cuioss.sheriff.token.validation.test.dispatcher.TokenDispatcher;
 import de.cuioss.sheriff.token.validation.test.generator.TestTokenGenerators;
 import de.cuioss.test.generator.Generators;
 import de.cuioss.test.generator.junit.EnableGeneratorController;
 import de.cuioss.test.juli.junit5.EnableTestLogger;
 import de.cuioss.test.mockwebserver.EnableMockWebServer;
 import de.cuioss.test.mockwebserver.URIBuilder;
-import de.cuioss.test.mockwebserver.dispatcher.HttpMethodMapper;
-import de.cuioss.test.mockwebserver.dispatcher.ModuleDispatcherElement;
 import lombok.Getter;
-import mockwebserver3.MockResponse;
 import mockwebserver3.MockWebServer;
 import mockwebserver3.RecordedRequest;
-import okhttp3.Headers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -53,8 +50,6 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
-import java.util.Optional;
-import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -77,7 +72,7 @@ class AuthorizationCodeFlowTest {
     private static final Pattern JWS_ALG_PATTERN = Pattern.compile("\"alg\"\\s*:\\s*\"([^\"]+)\"");
 
     @Getter
-    private final TokenEndpointDispatcher moduleDispatcher = new TokenEndpointDispatcher();
+    private final TokenDispatcher moduleDispatcher = new TokenDispatcher();
 
     private TestTokenHolder accessHolder;
     private TestTokenHolder idHolder;
@@ -109,7 +104,7 @@ class AuthorizationCodeFlowTest {
     private static ProviderMetadata metadataWithTokenEndpoint(URIBuilder uriBuilder) {
         var metadata = new ProviderMetadata();
         metadata.issuer = "https://issuer.example.com";
-        metadata.tokenEndpoint = uriBuilder.addPathSegment("token").buildAsString();
+        metadata.tokenEndpoint = uriBuilder.addPathSegments("oidc", "token").buildAsString();
         return metadata;
     }
 
@@ -151,7 +146,8 @@ class AuthorizationCodeFlowTest {
         var config = config();
         var context = FlowContext.create(REDIRECT_URI);
         idHolder.withClaim("nonce", ClaimValue.forPlainString(context.nonce()));
-        moduleDispatcher.success(accessHolder.getRawToken(), idHolder.getRawToken());
+        moduleDispatcher.respondWith(TokenDispatcher.tokenResponse(accessHolder.getRawToken(), null,
+                idHolder.getRawToken(), 300));
         String code = Generators.letterStrings(20, 40).next();
         var callback = new CallbackParameters(code, context.state(), null, null, null);
 
@@ -178,7 +174,8 @@ class AuthorizationCodeFlowTest {
         var config = config();
         var context = FlowContext.create(REDIRECT_URI);
         idHolder.withClaim("nonce", ClaimValue.forPlainString(Generators.letterStrings(20, 40).next()));
-        moduleDispatcher.success(accessHolder.getRawToken(), idHolder.getRawToken());
+        moduleDispatcher.respondWith(TokenDispatcher.tokenResponse(accessHolder.getRawToken(), null,
+                idHolder.getRawToken(), 300));
         var metadata = metadataWithTokenEndpoint(uriBuilder);
         var callback = new CallbackParameters(Generators.letterStrings(20, 40).next(), context.state(), null, null, null);
         var flow = flow(config);
@@ -193,7 +190,7 @@ class AuthorizationCodeFlowTest {
     void shouldRejectMissingIdToken(URIBuilder uriBuilder) {
         var config = config();
         var context = FlowContext.create(REDIRECT_URI);
-        moduleDispatcher.success(accessHolder.getRawToken(), null);
+        moduleDispatcher.respondWith(TokenDispatcher.tokenResponse(accessHolder.getRawToken(), null, null, 300));
         var metadata = metadataWithTokenEndpoint(uriBuilder);
         var callback = new CallbackParameters(Generators.letterStrings(20, 40).next(), context.state(), null, null, null);
         var flow = flow(config);
@@ -225,7 +222,8 @@ class AuthorizationCodeFlowTest {
         var config = config();
         var context = FlowContext.create(REDIRECT_URI);
         idHolder.withClaim("nonce", ClaimValue.forPlainString(context.nonce()));
-        moduleDispatcher.success(accessHolder.getRawToken(), idHolder.getRawToken());
+        moduleDispatcher.respondWith(TokenDispatcher.tokenResponse(accessHolder.getRawToken(), null,
+                idHolder.getRawToken(), 300));
         var metadata = new ProviderMetadata();
         var callback = new CallbackParameters(Generators.letterStrings(20, 40).next(), context.state(), null, null, null);
         var flow = flow(config);
@@ -240,7 +238,7 @@ class AuthorizationCodeFlowTest {
     void shouldSurfaceTransportException(URIBuilder uriBuilder) {
         var config = config();
         var context = FlowContext.create(REDIRECT_URI);
-        moduleDispatcher.error();
+        moduleDispatcher.returnOAuthError();
         var metadata = metadataWithTokenEndpoint(uriBuilder);
         var callback = new CallbackParameters(Generators.letterStrings(20, 40).next(), context.state(), null, null, null);
         var flow = flow(config);
@@ -258,7 +256,8 @@ class AuthorizationCodeFlowTest {
         accessHolder.withClaim(ClaimName.ISSUER.getName(),
                 ClaimValue.forPlainString("https://attacker.example.com"));
         idHolder.withClaim("nonce", ClaimValue.forPlainString(context.nonce()));
-        moduleDispatcher.success(accessHolder.getRawToken(), idHolder.getRawToken());
+        moduleDispatcher.respondWith(TokenDispatcher.tokenResponse(accessHolder.getRawToken(), null,
+                idHolder.getRawToken(), 300));
         var metadata = metadataWithTokenEndpoint(uriBuilder);
         var callback = new CallbackParameters(Generators.letterStrings(20, 40).next(), context.state(), null, null, null);
         var flow = flow(config);
@@ -276,7 +275,8 @@ class AuthorizationCodeFlowTest {
         String otherAccessToken = Generators.letterStrings(20, 40).next();
         idHolder.withClaim("nonce", ClaimValue.forPlainString(context.nonce()));
         idHolder.withClaim(AT_HASH_CLAIM, ClaimValue.forPlainString(atHash(idHolder.getRawToken(), otherAccessToken)));
-        moduleDispatcher.success(accessHolder.getRawToken(), idHolder.getRawToken());
+        moduleDispatcher.respondWith(TokenDispatcher.tokenResponse(accessHolder.getRawToken(), null,
+                idHolder.getRawToken(), 300));
         var metadata = metadataWithTokenEndpoint(uriBuilder);
         var callback = new CallbackParameters(Generators.letterStrings(20, 40).next(), context.state(), null, null, null);
         var flow = flow(config);
@@ -375,54 +375,5 @@ class AuthorizationCodeFlowTest {
                         () -> new AuthorizationCodeFlow.AuthenticationResult(null, id)),
                 () -> assertThrows(NullPointerException.class,
                         () -> new AuthorizationCodeFlow.AuthenticationResult(access, null)));
-    }
-
-    /**
-     * Token-endpoint dispatcher serving a configurable authorization_code response (with optional ID
-     * token) or an error.
-     */
-    static final class TokenEndpointDispatcher implements ModuleDispatcherElement {
-
-        private static final int HTTP_OK = 200;
-        private static final int HTTP_BAD_REQUEST = 400;
-
-        private int status = HTTP_OK;
-        private String body = "";
-
-        void reset() {
-            this.status = HTTP_OK;
-            this.body = "";
-        }
-
-        void success(String accessToken, String idToken) {
-            this.status = HTTP_OK;
-            StringBuilder json = new StringBuilder("{\"access_token\":\"").append(accessToken)
-                    .append("\",\"token_type\":\"Bearer\",\"expires_in\":300");
-            if (idToken != null) {
-                json.append(",\"id_token\":\"").append(idToken).append('"');
-            }
-            json.append('}');
-            this.body = json.toString();
-        }
-
-        void error() {
-            this.status = HTTP_BAD_REQUEST;
-            this.body = "{\"error\":\"invalid_grant\"}";
-        }
-
-        @Override
-        public String getBaseUrl() {
-            return "/token";
-        }
-
-        @Override
-        public Set<HttpMethodMapper> supportedMethods() {
-            return Set.of(HttpMethodMapper.POST);
-        }
-
-        @Override
-        public Optional<MockResponse> handlePost(RecordedRequest request) {
-            return Optional.of(new MockResponse(status, Headers.of("Content-Type", "application/json"), body));
-        }
     }
 }

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/AuthorizationCodeFlowTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/AuthorizationCodeFlowTest.java
@@ -19,6 +19,8 @@ import de.cuioss.sheriff.token.client.auth.ClientSecretBasicAuth;
 import de.cuioss.sheriff.token.client.config.ClientAuthMethod;
 import de.cuioss.sheriff.token.client.config.ClientConfiguration;
 import de.cuioss.sheriff.token.client.discovery.ProviderMetadata;
+import de.cuioss.sheriff.token.client.dpop.DpopProofGenerator;
+import de.cuioss.sheriff.token.client.dpop.SenderConstraint;
 import de.cuioss.sheriff.token.client.token.IdTokenValidationBridge;
 import de.cuioss.sheriff.token.client.token.TokenValidationBridge;
 import de.cuioss.sheriff.token.commons.error.ClientProtocolException;
@@ -45,6 +47,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
@@ -56,6 +60,7 @@ import java.util.regex.Pattern;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -166,6 +171,55 @@ class AuthorizationCodeFlowTest {
                         "the secret PKCE verifier must be redeemed at the token endpoint"),
                 () -> assertNotNull(request.getHeaders().get("Authorization"),
                         "client authentication must decorate the token request"));
+    }
+
+    @Test
+    @DisplayName("exchange() should DPoP-bind the code redemption when a sender-constraint is configured")
+    void shouldAttachDpopProofWhenConstrained(URIBuilder uriBuilder, MockWebServer server) throws Exception {
+        var config = config();
+        var context = FlowContext.create(REDIRECT_URI);
+        idHolder.withClaim("nonce", ClaimValue.forPlainString(context.nonce()));
+        moduleDispatcher.respondWith(TokenDispatcher.tokenResponse(accessHolder.getRawToken(), null,
+                idHolder.getRawToken(), 300));
+        var callback = new CallbackParameters(Generators.letterStrings(20, 40).next(), context.state(), null, null, null);
+        SenderConstraint constraint = SenderConstraint.dpop(new DpopProofGenerator(rsaKeyPair(), "RS256"));
+        var flow = new AuthorizationCodeFlow(config, new TokenEndpointClient(config), accessBridge, idBridge,
+                new IssValidator(), constraint);
+
+        flow.exchange(metadataWithTokenEndpoint(uriBuilder), context, callback, auth(config));
+
+        RecordedRequest request = server.takeRequest();
+        String proof = request.getHeaders().get("DPoP");
+        assertAll("DPoP-bound code exchange",
+                () -> assertNotNull(proof, "the code redemption must carry a DPoP proof header"),
+                () -> assertEquals(3, proof.split("\\.").length, "the DPoP header is a compact proof JWT"));
+    }
+
+    @Test
+    @DisplayName("exchange() should send no DPoP proof when no sender-constraint is configured")
+    void shouldNotAttachDpopProofWhenUnconstrained(URIBuilder uriBuilder, MockWebServer server) throws Exception {
+        var config = config();
+        var context = FlowContext.create(REDIRECT_URI);
+        idHolder.withClaim("nonce", ClaimValue.forPlainString(context.nonce()));
+        moduleDispatcher.respondWith(TokenDispatcher.tokenResponse(accessHolder.getRawToken(), null,
+                idHolder.getRawToken(), 300));
+        var callback = new CallbackParameters(Generators.letterStrings(20, 40).next(), context.state(), null, null, null);
+
+        flow(config).exchange(metadataWithTokenEndpoint(uriBuilder), context, callback, auth(config));
+
+        RecordedRequest request = server.takeRequest();
+        assertNull(request.getHeaders().get("DPoP"),
+                "an unconstrained code redemption must carry no DPoP proof header");
+    }
+
+    private static KeyPair rsaKeyPair() {
+        try {
+            KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+            generator.initialize(2048);
+            return generator.generateKeyPair();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("RSA key pair generation failed", e);
+        }
     }
 
     @Test

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/AuthorizationCodeFlowTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/AuthorizationCodeFlowTest.java
@@ -146,6 +146,26 @@ class AuthorizationCodeFlowTest {
     }
 
     @Test
+    @DisplayName("authorize() should reject a client that declares no redirect URI with IllegalArgumentException (not NPE)")
+    void shouldRejectMissingRedirectUri() {
+        var config = ClientConfiguration.builder()
+                .issuer("https://issuer.example.com")
+                .clientId(Generators.nonBlankStrings().next())
+                .clientSecret(Generators.nonBlankStrings().next())
+                .authMethod(ClientAuthMethod.CLIENT_SECRET_BASIC)
+                .scope("openid")
+                .allowInsecureHttp(true)
+                .build();
+        var metadata = new ProviderMetadata();
+        metadata.authorizationEndpoint = AUTH_ENDPOINT;
+        metadata.codeChallengeMethodsSupported = List.of("S256");
+        var flow = flow(config);
+
+        assertThrows(IllegalArgumentException.class, () -> flow.authorize(metadata),
+                "a client without a redirect URI must fail with IllegalArgumentException, not a raw NPE");
+    }
+
+    @Test
     @DisplayName("exchange() should redeem the code and return the validated, nonce-bound access and ID tokens")
     void shouldRedeemAndValidate(URIBuilder uriBuilder, MockWebServer server) throws Exception {
         var config = config();

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/CallbackHandlerTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/CallbackHandlerTest.java
@@ -213,6 +213,29 @@ class CallbackHandlerTest {
         }
 
         @Test
+        @DisplayName("Should route both error and error_description through the commons normalizer (COMMONS-11)")
+        void shouldSurfaceSanitizedErrorDescription() {
+            var context = context();
+            // The previous inline rejection dropped error_description entirely; the normalizer now
+            // surfaces it — sanitized — so both directions share one contract.
+            var parameters = new CallbackParameters(null, context.state(),
+                    "access_denied", "the resource owner denied\r\nWARN forged the request", null);
+
+            var thrown = assertThrows(ClientProtocolException.class,
+                    () -> handler.handle(context, parameters));
+
+            assertAll("normalized error callback",
+                    () -> assertTrue(thrown.getMessage().contains("access_denied"),
+                            "the error code is surfaced"),
+                    () -> assertTrue(thrown.getMessage().contains("the resource owner denied"),
+                            "the (sanitized) error_description is now surfaced, not dropped"),
+                    () -> assertFalse(thrown.getMessage().contains("\n"),
+                            "no raw newline from the error_description survives"),
+                    () -> assertFalse(thrown.getMessage().contains("\r"),
+                            "no raw carriage return from the error_description survives"));
+        }
+
+        @Test
         @DisplayName("Should truncate an over-long error value in the exception message to bound log flooding")
         void shouldTruncateOverlongError() {
             var context = context();

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/ClientCredentialsFlowTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/ClientCredentialsFlowTest.java
@@ -29,19 +29,16 @@ import de.cuioss.sheriff.token.validation.domain.claim.ClaimValue;
 import de.cuioss.sheriff.token.validation.domain.token.AccessTokenContent;
 import de.cuioss.sheriff.token.validation.exception.TokenValidationException;
 import de.cuioss.sheriff.token.validation.test.TestTokenHolder;
+import de.cuioss.sheriff.token.validation.test.dispatcher.TokenDispatcher;
 import de.cuioss.sheriff.token.validation.test.generator.TestTokenGenerators;
 import de.cuioss.test.generator.Generators;
 import de.cuioss.test.generator.junit.EnableGeneratorController;
 import de.cuioss.test.juli.junit5.EnableTestLogger;
 import de.cuioss.test.mockwebserver.EnableMockWebServer;
 import de.cuioss.test.mockwebserver.URIBuilder;
-import de.cuioss.test.mockwebserver.dispatcher.HttpMethodMapper;
-import de.cuioss.test.mockwebserver.dispatcher.ModuleDispatcherElement;
 import lombok.Getter;
-import mockwebserver3.MockResponse;
 import mockwebserver3.MockWebServer;
 import mockwebserver3.RecordedRequest;
-import okhttp3.Headers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -50,8 +47,6 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -67,7 +62,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ClientCredentialsFlowTest {
 
     @Getter
-    private final TokenEndpointDispatcher moduleDispatcher = new TokenEndpointDispatcher();
+    private final TokenDispatcher moduleDispatcher = new TokenDispatcher();
 
     private TestTokenHolder holder;
     private TokenValidationBridge bridge;
@@ -93,7 +88,7 @@ class ClientCredentialsFlowTest {
 
     private static ProviderMetadata metadata(URIBuilder uriBuilder) {
         var metadata = new ProviderMetadata();
-        metadata.tokenEndpoint = uriBuilder.addPathSegment("token").buildAsString();
+        metadata.tokenEndpoint = uriBuilder.addPathSegments("oidc", "token").buildAsString();
         return metadata;
     }
 
@@ -105,14 +100,10 @@ class ClientCredentialsFlowTest {
         return new ClientSecretBasicAuth(config.getClientId(), config.getClientSecret());
     }
 
-    private static String successBody(String accessToken) {
-        return "{\"access_token\":\"" + accessToken + "\",\"token_type\":\"Bearer\",\"expires_in\":300}";
-    }
-
     @Test
     @DisplayName("Should obtain, validate, and return the access token with client_secret_basic auth")
     void shouldObtainAndValidateToken(URIBuilder uriBuilder, MockWebServer server) throws Exception {
-        moduleDispatcher.success(successBody(holder.getRawToken()));
+        moduleDispatcher.respondWith(TokenDispatcher.tokenResponse(holder.getRawToken(), null, null, 300));
         var config = config();
 
         AccessTokenContent content = flow(config, basicAuth(config)).obtainToken(metadata(uriBuilder));
@@ -128,7 +119,7 @@ class ClientCredentialsFlowTest {
     @Test
     @DisplayName("Should acquire a service-to-service token with private_key_jwt when the strategy is injected")
     void shouldAcquireWithPrivateKeyJwt(URIBuilder uriBuilder, MockWebServer server) throws Exception {
-        moduleDispatcher.success(successBody(holder.getRawToken()));
+        moduleDispatcher.respondWith(TokenDispatcher.tokenResponse(holder.getRawToken(), null, null, 300));
         var config = config();
         KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
         generator.initialize(2048);
@@ -157,7 +148,7 @@ class ClientCredentialsFlowTest {
     @Test
     @DisplayName("Should delegate Basic encoding to ClientSecretBasicAuth rather than duplicate it")
     void shouldDelegateBasicEncodingToStrategy(URIBuilder uriBuilder, MockWebServer server) throws Exception {
-        moduleDispatcher.success(successBody(holder.getRawToken()));
+        moduleDispatcher.respondWith(TokenDispatcher.tokenResponse(holder.getRawToken(), null, null, 300));
         var config = config();
         var basicAuth = basicAuth(config);
         Map<String, String> expectedHeaders = new HashMap<>();
@@ -184,7 +175,7 @@ class ClientCredentialsFlowTest {
     @Test
     @DisplayName("Should surface a TransportException on a token-endpoint error response")
     void shouldRejectErrorResponse(URIBuilder uriBuilder) {
-        moduleDispatcher.error();
+        moduleDispatcher.returnOAuthError();
         var config = config();
         var flow = flow(config, basicAuth(config));
         var metadata = metadata(uriBuilder);
@@ -196,53 +187,11 @@ class ClientCredentialsFlowTest {
     @DisplayName("Should reject a retrieved token that fails pipeline validation")
     void shouldRejectTamperedToken(URIBuilder uriBuilder) {
         holder.withClaim(ClaimName.ISSUER.getName(), ClaimValue.forPlainString("https://attacker.example.com"));
-        moduleDispatcher.success(successBody(holder.getRawToken()));
+        moduleDispatcher.respondWith(TokenDispatcher.tokenResponse(holder.getRawToken(), null, null, 300));
         var config = config();
         var flow = flow(config, basicAuth(config));
         var metadata = metadata(uriBuilder);
 
         assertThrows(TokenValidationException.class, () -> flow.obtainToken(metadata));
-    }
-
-    /**
-     * Minimal token-endpoint dispatcher serving a configurable success or error response.
-     */
-    static final class TokenEndpointDispatcher implements ModuleDispatcherElement {
-
-        private static final int HTTP_OK = 200;
-        private static final int HTTP_BAD_REQUEST = 400;
-
-        private int status = HTTP_OK;
-        private String body = "";
-
-        void reset() {
-            this.status = HTTP_OK;
-            this.body = "";
-        }
-
-        void success(String responseBody) {
-            this.status = HTTP_OK;
-            this.body = responseBody;
-        }
-
-        void error() {
-            this.status = HTTP_BAD_REQUEST;
-            this.body = "{\"error\":\"invalid_client\"}";
-        }
-
-        @Override
-        public String getBaseUrl() {
-            return "/token";
-        }
-
-        @Override
-        public Set<HttpMethodMapper> supportedMethods() {
-            return Set.of(HttpMethodMapper.POST);
-        }
-
-        @Override
-        public Optional<MockResponse> handlePost(RecordedRequest request) {
-            return Optional.of(new MockResponse(status, Headers.of("Content-Type", "application/json"), body));
-        }
     }
 }

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/ParClientTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/ParClientTest.java
@@ -84,15 +84,20 @@ class ParClientTest {
     }
 
     /**
-     * Generates a distinctive, sufficiently long opaque value for the security-sensitive
-     * authorization parameters (state, nonce, PKCE challenge). A minimum length of 24 random
-     * letters guarantees the value cannot coincidentally occur as a substring of the fixed
-     * mock AS-issued opaque {@code request_uri}, which would otherwise make the no-leak
-     * assertions in {@link #shouldReturnRequestUri} flaky (a short {@code nonBlankStrings}
-     * value could match by chance).
+     * Generates a distinctive opaque value for the security-sensitive authorization parameters
+     * (state, nonce, PKCE challenge) that is <em>provably</em> never a substring of the fixed mock
+     * AS-issued opaque {@code request_uri} ({@code urn:ietf:params:oauth:request_uri:mock-par-reference}).
+     * <p>
+     * Root cause of the historical JDK 25 flake: a letters-only generated value shares the
+     * request_uri's alphabet, so the no-leak substring assertions in {@link #shouldReturnRequestUri}
+     * relied on the random value being improbably — but not provably — distinct, which a
+     * cui-test-generator value collision under a given seed could defeat. The fixed request_uri
+     * contains no digits, so appending a generated digit run puts every pushed value in an alphabet
+     * disjoint from the request_uri: the value can never occur as a substring of it, making the
+     * no-leak assertions deterministic under any generator seed on JDK 25.
      */
     private static String opaqueParameterValue() {
-        return Generators.letterStrings(24, 40).next();
+        return Generators.letterStrings(24, 40).next() + Generators.integers(100000, 999999).next();
     }
 
     private static String parEndpoint(URIBuilder uriBuilder) {

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/ParClientTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/ParClientTest.java
@@ -25,15 +25,21 @@ import de.cuioss.test.generator.junit.EnableGeneratorController;
 import de.cuioss.test.juli.junit5.EnableTestLogger;
 import de.cuioss.test.mockwebserver.EnableMockWebServer;
 import de.cuioss.test.mockwebserver.URIBuilder;
+import de.cuioss.test.mockwebserver.dispatcher.HttpMethodMapper;
+import de.cuioss.test.mockwebserver.dispatcher.ModuleDispatcherElement;
 import lombok.Getter;
+import mockwebserver3.MockResponse;
 import mockwebserver3.MockWebServer;
 import mockwebserver3.RecordedRequest;
+import okhttp3.Headers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -48,7 +54,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ParClientTest {
 
     @Getter
-    private final ParDispatcher moduleDispatcher = new ParDispatcher();
+    private final ParTestDispatcher moduleDispatcher = new ParTestDispatcher();
 
     @BeforeEach
     void resetDispatcher() {
@@ -188,5 +194,96 @@ class ParClientTest {
 
         assertThrows(TransportException.class,
                 () -> client.pushAuthorizationRequest(endpoint, params, auth));
+    }
+
+    @Test
+    @DisplayName("Should sanitize an AS-controlled parse-error fragment carrying CR/LF (M8)")
+    void shouldSanitizeParseErrorFragment(URIBuilder uriBuilder) {
+        // The PAR response body is AS-controlled; a malformed value with an embedded CR/LF must not
+        // forge a log line — the parse-error fragment must be routed through LogSanitizer before it is
+        // exposed on the exception message or the log appender.
+        moduleDispatcher.returnMalformedJson("{\"request_uri\":\"urn:x\",\"expires_in\":9\r\nINJECTED9}");
+        var auth = new ClientSecretBasicAuth(Generators.nonBlankStrings().next(), Generators.nonBlankStrings().next());
+        var endpoint = parEndpoint(uriBuilder);
+        var client = parClient();
+        var params = authorizationParameters();
+
+        TransportException thrown = assertThrows(TransportException.class,
+                () -> client.pushAuthorizationRequest(endpoint, params, auth),
+                "a malformed PAR response must surface as a TransportException");
+
+        String message = thrown.getMessage();
+        assertAll("sanitized parse-error fragment",
+                () -> assertFalse(message.indexOf('\r') >= 0,
+                        "a raw CR from the AS-controlled body must not reach the exception message"),
+                () -> assertFalse(message.indexOf('\n') >= 0,
+                        "a raw LF from the AS-controlled body must not reach the exception message"),
+                () -> assertTrue(message.contains("\\r") && message.contains("\\n"),
+                        "the injected CR/LF must survive in escaped form, proving the fragment was carried and sanitized"));
+    }
+
+    /**
+     * Wraps the shared {@link ParDispatcher} strategies and adds a malformed-JSON strategy so the M8
+     * parse-error sanitization path can be exercised with an AS-controlled CR/LF payload.
+     */
+    static final class ParTestDispatcher implements ModuleDispatcherElement {
+
+        private static final String APPLICATION_JSON = "application/json";
+
+        private final ParDispatcher delegate = new ParDispatcher();
+        private boolean malformed;
+        private String malformedBody = "";
+
+        ParTestDispatcher returnDefault() {
+            malformed = false;
+            delegate.returnDefault();
+            return this;
+        }
+
+        ParTestDispatcher returnOAuthError() {
+            malformed = false;
+            delegate.returnOAuthError();
+            return this;
+        }
+
+        ParTestDispatcher returnError() {
+            malformed = false;
+            delegate.returnError();
+            return this;
+        }
+
+        ParTestDispatcher returnOversizedBody() {
+            malformed = false;
+            delegate.returnOversizedBody();
+            return this;
+        }
+
+        ParTestDispatcher returnMalformedJson(String body) {
+            malformed = true;
+            malformedBody = body;
+            return this;
+        }
+
+        void setCallCounter(int callCounter) {
+            delegate.setCallCounter(callCounter);
+        }
+
+        @Override
+        public String getBaseUrl() {
+            return delegate.getBaseUrl();
+        }
+
+        @Override
+        public Set<HttpMethodMapper> supportedMethods() {
+            return delegate.supportedMethods();
+        }
+
+        @Override
+        public Optional<MockResponse> handlePost(RecordedRequest request) {
+            if (malformed) {
+                return Optional.of(new MockResponse(200, Headers.of("Content-Type", APPLICATION_JSON), malformedBody));
+            }
+            return delegate.handlePost(request);
+        }
     }
 }

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/RefreshFlowTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/RefreshFlowTest.java
@@ -27,25 +27,19 @@ import de.cuioss.sheriff.token.validation.domain.claim.ClaimName;
 import de.cuioss.sheriff.token.validation.domain.claim.ClaimValue;
 import de.cuioss.sheriff.token.validation.exception.TokenValidationException;
 import de.cuioss.sheriff.token.validation.test.TestTokenHolder;
+import de.cuioss.sheriff.token.validation.test.dispatcher.TokenDispatcher;
 import de.cuioss.sheriff.token.validation.test.generator.TestTokenGenerators;
 import de.cuioss.test.generator.Generators;
 import de.cuioss.test.generator.junit.EnableGeneratorController;
 import de.cuioss.test.juli.junit5.EnableTestLogger;
 import de.cuioss.test.mockwebserver.EnableMockWebServer;
 import de.cuioss.test.mockwebserver.URIBuilder;
-import de.cuioss.test.mockwebserver.dispatcher.HttpMethodMapper;
-import de.cuioss.test.mockwebserver.dispatcher.ModuleDispatcherElement;
 import lombok.Getter;
-import mockwebserver3.MockResponse;
 import mockwebserver3.MockWebServer;
 import mockwebserver3.RecordedRequest;
-import okhttp3.Headers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import java.util.Optional;
-import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -62,7 +56,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class RefreshFlowTest {
 
     @Getter
-    private final TokenEndpointDispatcher moduleDispatcher = new TokenEndpointDispatcher();
+    private final TokenDispatcher moduleDispatcher = new TokenDispatcher();
 
     private TestTokenHolder holder;
     private TokenValidationBridge bridge;
@@ -87,7 +81,7 @@ class RefreshFlowTest {
 
     private static ProviderMetadata metadata(URIBuilder uriBuilder) {
         var metadata = new ProviderMetadata();
-        metadata.tokenEndpoint = uriBuilder.addPathSegment("token").buildAsString();
+        metadata.tokenEndpoint = uriBuilder.addPathSegments("oidc", "token").buildAsString();
         return metadata;
     }
 
@@ -100,7 +94,7 @@ class RefreshFlowTest {
     @DisplayName("Should refresh and report a rotated refresh token when the AS issues a new one")
     void shouldRefreshAndReportRotation(URIBuilder uriBuilder) {
         String rotated = Generators.letterStrings(20, 40).next();
-        moduleDispatcher.success(holder.getRawToken(), rotated, 300);
+        moduleDispatcher.respondWith(TokenDispatcher.tokenResponse(holder.getRawToken(), rotated, null, 300));
         String presented = Generators.letterStrings(20, 40).next();
 
         RotationResult result = flow(config()).refresh(metadata(uriBuilder), presented);
@@ -115,7 +109,7 @@ class RefreshFlowTest {
     @Test
     @DisplayName("Should report no rotation and reuse the presented token when the AS omits a new refresh token")
     void shouldReportNoRotationWhenServerOmitsRefreshToken(URIBuilder uriBuilder) {
-        moduleDispatcher.success(holder.getRawToken(), null, 120);
+        moduleDispatcher.respondWith(TokenDispatcher.tokenResponse(holder.getRawToken(), null, null, 120));
         String presented = Generators.letterStrings(20, 40).next();
 
         RotationResult result = flow(config()).refresh(metadata(uriBuilder), presented);
@@ -130,7 +124,8 @@ class RefreshFlowTest {
     @DisplayName("Should carry the refreshed ID token through the rotation result for the §12.2 consistency check")
     void shouldCarryRefreshedIdToken(URIBuilder uriBuilder) {
         String refreshedIdToken = Generators.letterStrings(20, 40).next();
-        moduleDispatcher.success(holder.getRawToken(), Generators.letterStrings(20, 40).next(), refreshedIdToken, 300);
+        moduleDispatcher.respondWith(TokenDispatcher.tokenResponse(holder.getRawToken(),
+                Generators.letterStrings(20, 40).next(), refreshedIdToken, 300));
         String presented = Generators.letterStrings(20, 40).next();
 
         RotationResult result = flow(config()).refresh(metadata(uriBuilder), presented);
@@ -142,7 +137,8 @@ class RefreshFlowTest {
     @Test
     @DisplayName("Should surface a null ID token when the AS omits one on refresh")
     void shouldReportNoIdTokenWhenServerOmitsIt(URIBuilder uriBuilder) {
-        moduleDispatcher.success(holder.getRawToken(), Generators.letterStrings(20, 40).next(), 300);
+        moduleDispatcher.respondWith(TokenDispatcher.tokenResponse(holder.getRawToken(),
+                Generators.letterStrings(20, 40).next(), null, 300));
         String presented = Generators.letterStrings(20, 40).next();
 
         RotationResult result = flow(config()).refresh(metadata(uriBuilder), presented);
@@ -153,7 +149,8 @@ class RefreshFlowTest {
     @Test
     @DisplayName("Should send a refresh_token grant carrying the presented token and client authentication")
     void shouldSendRefreshTokenGrantOnTheWire(URIBuilder uriBuilder, MockWebServer server) throws Exception {
-        moduleDispatcher.success(holder.getRawToken(), Generators.letterStrings(20, 40).next(), 300);
+        moduleDispatcher.respondWith(TokenDispatcher.tokenResponse(holder.getRawToken(),
+                Generators.letterStrings(20, 40).next(), null, 300));
         String presented = Generators.letterStrings(20, 40).next();
 
         flow(config()).refresh(metadata(uriBuilder), presented);
@@ -171,7 +168,7 @@ class RefreshFlowTest {
     @Test
     @DisplayName("Should surface a TransportException on a token-endpoint error response")
     void shouldSurfaceTransportException(URIBuilder uriBuilder) {
-        moduleDispatcher.error();
+        moduleDispatcher.returnOAuthError();
         var flow = flow(config());
         var metadata = metadata(uriBuilder);
         String presented = Generators.letterStrings(20, 40).next();
@@ -183,7 +180,8 @@ class RefreshFlowTest {
     @DisplayName("Should reject a refreshed token that fails pipeline validation")
     void shouldRejectTamperedToken(URIBuilder uriBuilder) {
         holder.withClaim(ClaimName.ISSUER.getName(), ClaimValue.forPlainString("https://attacker.example.com"));
-        moduleDispatcher.success(holder.getRawToken(), Generators.letterStrings(20, 40).next(), 300);
+        moduleDispatcher.respondWith(TokenDispatcher.tokenResponse(holder.getRawToken(),
+                Generators.letterStrings(20, 40).next(), null, 300));
         var flow = flow(config());
         var metadata = metadata(uriBuilder);
         String presented = Generators.letterStrings(20, 40).next();
@@ -202,61 +200,5 @@ class RefreshFlowTest {
                         () -> flow.refresh(null, refreshToken)),
                 () -> assertThrows(NullPointerException.class, () -> flow.refresh(metadata, null)),
                 () -> assertThrows(IllegalArgumentException.class, () -> flow.refresh(metadata, "   ")));
-    }
-
-    /**
-     * Token-endpoint dispatcher serving a configurable refresh response (with optional rotated
-     * refresh token) or an error.
-     */
-    static final class TokenEndpointDispatcher implements ModuleDispatcherElement {
-
-        private static final int HTTP_OK = 200;
-        private static final int HTTP_BAD_REQUEST = 400;
-
-        private int status = HTTP_OK;
-        private String body = "";
-
-        void reset() {
-            this.status = HTTP_OK;
-            this.body = "";
-        }
-
-        void success(String accessToken, String refreshToken, long expiresIn) {
-            success(accessToken, refreshToken, null, expiresIn);
-        }
-
-        void success(String accessToken, String refreshToken, String idToken, long expiresIn) {
-            this.status = HTTP_OK;
-            StringBuilder json = new StringBuilder("{\"access_token\":\"").append(accessToken)
-                    .append("\",\"token_type\":\"Bearer\",\"expires_in\":").append(expiresIn);
-            if (refreshToken != null) {
-                json.append(",\"refresh_token\":\"").append(refreshToken).append('"');
-            }
-            if (idToken != null) {
-                json.append(",\"id_token\":\"").append(idToken).append('"');
-            }
-            json.append('}');
-            this.body = json.toString();
-        }
-
-        void error() {
-            this.status = HTTP_BAD_REQUEST;
-            this.body = "{\"error\":\"invalid_grant\"}";
-        }
-
-        @Override
-        public String getBaseUrl() {
-            return "/token";
-        }
-
-        @Override
-        public Set<HttpMethodMapper> supportedMethods() {
-            return Set.of(HttpMethodMapper.POST);
-        }
-
-        @Override
-        public Optional<MockResponse> handlePost(RecordedRequest request) {
-            return Optional.of(new MockResponse(status, Headers.of("Content-Type", "application/json"), body));
-        }
     }
 }

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/TokenEndpointClientTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/TokenEndpointClientTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.token.client.flow;
+
+import de.cuioss.sheriff.token.client.config.ClientAuthMethod;
+import de.cuioss.sheriff.token.client.config.ClientConfiguration;
+import de.cuioss.sheriff.token.commons.error.TransportException;
+import de.cuioss.test.generator.Generators;
+import de.cuioss.test.generator.junit.EnableGeneratorController;
+import de.cuioss.test.juli.junit5.EnableTestLogger;
+import de.cuioss.test.mockwebserver.EnableMockWebServer;
+import de.cuioss.test.mockwebserver.URIBuilder;
+import de.cuioss.test.mockwebserver.dispatcher.HttpMethodMapper;
+import de.cuioss.test.mockwebserver.dispatcher.ModuleDispatcherElement;
+import lombok.Getter;
+import mockwebserver3.MockResponse;
+import mockwebserver3.RecordedRequest;
+import okhttp3.Headers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression coverage for the M8 log-injection defense in {@link TokenEndpointClient}.
+ * <p>
+ * The token endpoint response body is authorization-server-controlled. When it is malformed, DSL-JSON
+ * raises a parse error whose message echoes the offending fragment verbatim — including any raw
+ * {@code CR}/{@code LF} the AS embedded. {@link TokenEndpointClient} must route that fragment through
+ * {@code LogSanitizer.sanitize} (CWE-117) before it reaches the log appender or the
+ * {@link TransportException} message, so the AS cannot forge a log line. This test drives a real
+ * malformed response carrying an embedded {@code CR}/{@code LF} and asserts the raw control characters
+ * are neutralized while their escaped, investigative form survives.
+ */
+@EnableTestLogger
+@EnableGeneratorController
+@EnableMockWebServer
+@DisplayName("TokenEndpointClient parse-error sanitization (M8)")
+class TokenEndpointClientTest {
+
+    @Getter
+    private final MalformedBodyDispatcher moduleDispatcher = new MalformedBodyDispatcher();
+
+    private static ClientConfiguration config() {
+        return ClientConfiguration.builder()
+                .issuer("https://issuer.example.com")
+                .clientId(Generators.nonBlankStrings().next())
+                .clientSecret(Generators.nonBlankStrings().next())
+                .authMethod(ClientAuthMethod.CLIENT_SECRET_BASIC)
+                .scope("openid")
+                .redirectUri("https://rp.example.com/callback")
+                .allowInsecureHttp(true)
+                .build();
+    }
+
+    @Test
+    @DisplayName("a malformed response with an embedded CR/LF is sanitized in the TransportException")
+    void shouldSanitizeParseErrorFragment(URIBuilder uriBuilder) {
+        var config = config();
+        var client = new TokenEndpointClient(config);
+        String endpoint = uriBuilder.addPathSegment("token").buildAsString();
+
+        TransportException thrown = assertThrows(TransportException.class,
+                () -> client.requestToken(endpoint, Map.of("grant_type", "authorization_code"), Map.of()),
+                "a malformed token response must surface as a TransportException");
+
+        String message = thrown.getMessage();
+        assertAll("sanitized parse-error fragment",
+                () -> assertFalse(message.indexOf('\r') >= 0,
+                        "a raw CR from the AS-controlled body must not reach the exception message"),
+                () -> assertFalse(message.indexOf('\n') >= 0,
+                        "a raw LF from the AS-controlled body must not reach the exception message"),
+                () -> assertTrue(message.contains("\\r") && message.contains("\\n"),
+                        "the injected CR/LF must survive in escaped form, proving the fragment was carried and sanitized"));
+    }
+
+    /** Serves a syntactically malformed token response whose parse error echoes an embedded CR/LF. */
+    static final class MalformedBodyDispatcher implements ModuleDispatcherElement {
+
+        // The unparseable numeric expires_in embeds a raw CR/LF the AS controls; DSL-JSON's parse error
+        // echoes that fragment verbatim, so it exercises the sanitizer on the parse-error path.
+        private static final String MALFORMED_BODY =
+                "{\"access_token\":\"a\",\"token_type\":\"Bearer\",\"expires_in\":9\r\nINJECTED9}";
+
+        @Override
+        public String getBaseUrl() {
+            return "/token";
+        }
+
+        @Override
+        public Set<HttpMethodMapper> supportedMethods() {
+            return Set.of(HttpMethodMapper.POST);
+        }
+
+        @Override
+        public Optional<MockResponse> handlePost(RecordedRequest request) {
+            return Optional.of(new MockResponse(200, Headers.of("Content-Type", "application/json"), MALFORMED_BODY));
+        }
+    }
+}

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/TokenEndpointClientTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/TokenEndpointClientTest.java
@@ -79,9 +79,11 @@ class TokenEndpointClientTest {
         var config = config();
         var client = new TokenEndpointClient(config);
         String endpoint = uriBuilder.addPathSegment("token").buildAsString();
+        Map<String, String> requestParams = Map.of("grant_type", "authorization_code");
+        Map<String, String> requestHeaders = Map.of();
 
         TransportException thrown = assertThrows(TransportException.class,
-                () -> client.requestToken(endpoint, Map.of("grant_type", "authorization_code"), Map.of()),
+                () -> client.requestToken(endpoint, requestParams, requestHeaders),
                 "a malformed token response must surface as a TransportException");
 
         String message = thrown.getMessage();

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/WiredFlowHttpsTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/WiredFlowHttpsTest.java
@@ -25,6 +25,7 @@ import de.cuioss.sheriff.token.commons.error.TransportException;
 import de.cuioss.sheriff.token.validation.TokenValidator;
 import de.cuioss.sheriff.token.validation.domain.claim.ClaimValue;
 import de.cuioss.sheriff.token.validation.test.TestTokenHolder;
+import de.cuioss.sheriff.token.validation.test.dispatcher.TokenDispatcher;
 import de.cuioss.sheriff.token.validation.test.generator.TestTokenGenerators;
 import de.cuioss.test.generator.Generators;
 import de.cuioss.test.generator.junit.EnableGeneratorController;
@@ -32,12 +33,7 @@ import de.cuioss.test.juli.junit5.EnableTestLogger;
 import de.cuioss.test.mockwebserver.EnableMockWebServer;
 import de.cuioss.test.mockwebserver.TestProvidedCertificate;
 import de.cuioss.test.mockwebserver.URIBuilder;
-import de.cuioss.test.mockwebserver.dispatcher.HttpMethodMapper;
-import de.cuioss.test.mockwebserver.dispatcher.ModuleDispatcherElement;
 import lombok.Getter;
-import mockwebserver3.MockResponse;
-import mockwebserver3.RecordedRequest;
-import okhttp3.Headers;
 import okhttp3.tls.HandshakeCertificates;
 import okhttp3.tls.HeldCertificate;
 import org.junit.jupiter.api.AfterEach;
@@ -52,8 +48,6 @@ import java.security.KeyStore;
 import java.security.cert.X509Certificate;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -117,7 +111,7 @@ class WiredFlowHttpsTest {
     }
 
     @Getter
-    private final TokenEndpointDispatcher moduleDispatcher = new TokenEndpointDispatcher();
+    private final TokenDispatcher moduleDispatcher = new TokenDispatcher();
 
     private TestTokenHolder accessHolder;
     private TestTokenHolder idHolder;
@@ -156,7 +150,8 @@ class WiredFlowHttpsTest {
         var config = tlsConfig();
         var context = FlowContext.create(REDIRECT_URI);
         idHolder.withClaim("nonce", ClaimValue.forPlainString(context.nonce()));
-        moduleDispatcher.success(accessHolder.getRawToken(), idHolder.getRawToken());
+        moduleDispatcher.respondWith(TokenDispatcher.tokenResponse(accessHolder.getRawToken(), null,
+                idHolder.getRawToken(), 300));
         String code = Generators.letterStrings(20, 40).next();
         var callback = new CallbackParameters(code, context.state(), null, null, null);
         var metadata = metadataWithTokenEndpoint(uriBuilder);
@@ -169,7 +164,7 @@ class WiredFlowHttpsTest {
                         "the exchange must target the TLS token endpoint"),
                 () -> assertNotNull(result.accessToken(), "a validated access token must be returned over TLS"),
                 () -> assertNotNull(result.idToken(), "a validated ID token must be returned over TLS"),
-                () -> moduleDispatcher.assertCalled(1));
+                () -> moduleDispatcher.assertCallsAnswered(1));
     }
 
     @Test
@@ -179,7 +174,8 @@ class WiredFlowHttpsTest {
         var config = tlsConfig();
         var context = FlowContext.create(REDIRECT_URI);
         idHolder.withClaim("nonce", ClaimValue.forPlainString(context.nonce()));
-        moduleDispatcher.success(accessHolder.getRawToken(), idHolder.getRawToken());
+        moduleDispatcher.respondWith(TokenDispatcher.tokenResponse(accessHolder.getRawToken(), null,
+                idHolder.getRawToken(), 300));
         var callback = new CallbackParameters(Generators.letterStrings(20, 40).next(),
                 context.state(), null, null, null);
         var metadata = metadataWithTokenEndpoint(uriBuilder);
@@ -189,7 +185,7 @@ class WiredFlowHttpsTest {
         assertThrows(TransportException.class,
                 () -> flow.exchange(metadata, context, callback, clientAuth),
                 "a TLS handshake against an untrusted server certificate must fail the back-channel call");
-        moduleDispatcher.assertNotCalled();
+        moduleDispatcher.assertCallsAnswered(0);
     }
 
     private static ClientConfiguration tlsConfig() {
@@ -207,7 +203,7 @@ class WiredFlowHttpsTest {
     private static ProviderMetadata metadataWithTokenEndpoint(URIBuilder uriBuilder) {
         var metadata = new ProviderMetadata();
         metadata.issuer = ISSUER;
-        metadata.tokenEndpoint = uriBuilder.addPathSegment("token").buildAsString();
+        metadata.tokenEndpoint = uriBuilder.addPathSegments("oidc", "token").buildAsString();
         return metadata;
     }
 
@@ -244,60 +240,5 @@ class WiredFlowHttpsTest {
     private void captureAndSet(String key, String value) {
         savedTrustStoreProperties.put(key, System.getProperty(key));
         System.setProperty(key, value);
-    }
-
-    /**
-     * Token-endpoint dispatcher serving a configurable authorization_code response and recording how
-     * many times it was actually reached, so a refused TLS handshake can be asserted to never arrive.
-     */
-    static final class TokenEndpointDispatcher implements ModuleDispatcherElement {
-
-        private static final int HTTP_OK = 200;
-
-        private String body = "";
-
-        @Getter
-        private int callCount;
-
-        void reset() {
-            this.body = "";
-            this.callCount = 0;
-        }
-
-        void success(String accessToken, String idToken) {
-            StringBuilder json = new StringBuilder("{\"access_token\":\"").append(accessToken)
-                    .append("\",\"token_type\":\"Bearer\",\"expires_in\":300");
-            if (idToken != null) {
-                json.append(",\"id_token\":\"").append(idToken).append('"');
-            }
-            json.append('}');
-            this.body = json.toString();
-        }
-
-        @Override
-        public String getBaseUrl() {
-            return "/token";
-        }
-
-        @Override
-        public Set<HttpMethodMapper> supportedMethods() {
-            return Set.of(HttpMethodMapper.POST);
-        }
-
-        @Override
-        public Optional<MockResponse> handlePost(RecordedRequest request) {
-            callCount++;
-            return Optional.of(new MockResponse(HTTP_OK, Headers.of("Content-Type", "application/json"), body));
-        }
-
-        void assertCalled(int expected) {
-            org.junit.jupiter.api.Assertions.assertEquals(expected, callCount,
-                    "unexpected token-endpoint call-count");
-        }
-
-        void assertNotCalled() {
-            org.junit.jupiter.api.Assertions.assertEquals(0, callCount,
-                    "a refused TLS handshake must never reach the token endpoint");
-        }
     }
 }

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/WiredFlowHttpsTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/WiredFlowHttpsTest.java
@@ -1,0 +1,303 @@
+/*
+ * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.token.client.flow;
+
+import de.cuioss.sheriff.token.client.auth.ClientSecretBasicAuth;
+import de.cuioss.sheriff.token.client.config.ClientAuthMethod;
+import de.cuioss.sheriff.token.client.config.ClientConfiguration;
+import de.cuioss.sheriff.token.client.discovery.ProviderMetadata;
+import de.cuioss.sheriff.token.client.token.IdTokenValidationBridge;
+import de.cuioss.sheriff.token.client.token.TokenValidationBridge;
+import de.cuioss.sheriff.token.commons.error.TransportException;
+import de.cuioss.sheriff.token.validation.TokenValidator;
+import de.cuioss.sheriff.token.validation.domain.claim.ClaimValue;
+import de.cuioss.sheriff.token.validation.test.TestTokenHolder;
+import de.cuioss.sheriff.token.validation.test.generator.TestTokenGenerators;
+import de.cuioss.test.generator.Generators;
+import de.cuioss.test.generator.junit.EnableGeneratorController;
+import de.cuioss.test.juli.junit5.EnableTestLogger;
+import de.cuioss.test.mockwebserver.EnableMockWebServer;
+import de.cuioss.test.mockwebserver.TestProvidedCertificate;
+import de.cuioss.test.mockwebserver.URIBuilder;
+import de.cuioss.test.mockwebserver.dispatcher.HttpMethodMapper;
+import de.cuioss.test.mockwebserver.dispatcher.ModuleDispatcherElement;
+import lombok.Getter;
+import mockwebserver3.MockResponse;
+import mockwebserver3.RecordedRequest;
+import okhttp3.Headers;
+import okhttp3.tls.HandshakeCertificates;
+import okhttp3.tls.HeldCertificate;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.security.cert.X509Certificate;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit-level HTTPS coverage for the back-channel token exchange (L1 / TEST-5).
+ * <p>
+ * Every other wired-flow test builds the client with {@code allowInsecureHttp(true)} and drives the
+ * plaintext transport, so the TLS branch of {@link BackChannelHttp} — the {@code https://} handler
+ * build plus the real JDK {@link javax.net.ssl.SSLContext} handshake — was never exercised. This class
+ * drives the {@code authorization_code} exchange over a TLS-enabled {@link mockwebserver3.MockWebServer}
+ * with a client that does <em>not</em> permit cleartext.
+ * <p>
+ * The client transport composes {@code cui-http}, which builds its own {@link javax.net.ssl.SSLContext}
+ * from the JVM default trust store — there is no client-side {@code SSLContext} injection seam. To make
+ * the loopback handshake real (rather than disabling verification), this class serves a self-signed
+ * certificate it controls (via {@link TestProvidedCertificate}) and, for the positive case, installs a
+ * matching client trust store through the {@code javax.net.ssl.trustStore} system properties the
+ * {@code cui-http} handler honors. The negative case installs a trust store that trusts an
+ * <em>unrelated</em> certificate, so the TLS material is mismatched and the handshake is refused.
+ */
+@EnableTestLogger
+@EnableGeneratorController
+@EnableMockWebServer(useHttps = true)
+@TestProvidedCertificate(providerClass = WiredFlowHttpsTest.class, methodName = "serverCertificates")
+@DisplayName("Wired back-channel exchange over HTTPS (TLS path)")
+class WiredFlowHttpsTest {
+
+    private static final String ISSUER = "https://issuer.example.com";
+    private static final String REDIRECT_URI = "https://rp.example.com/callback";
+    private static final char[] TRUST_STORE_PASSWORD = "changeit".toCharArray();
+
+    /**
+     * The self-signed certificate the mock server serves. Valid for the loopback host names the mock
+     * server binds to, so JDK hostname verification passes once the client trusts it.
+     */
+    private static final HeldCertificate SERVER_CERTIFICATE = new HeldCertificate.Builder()
+            .commonName("localhost")
+            .addSubjectAlternativeName("localhost")
+            .addSubjectAlternativeName("127.0.0.1")
+            .build();
+
+    /** An unrelated self-signed certificate used to model mismatched client TLS trust material. */
+    private static final HeldCertificate UNRELATED_CERTIFICATE = new HeldCertificate.Builder()
+            .commonName("not-the-server")
+            .addSubjectAlternativeName("not-the-server.example.com")
+            .build();
+
+    /**
+     * Provider for {@link TestProvidedCertificate}: the mock server serves the certificate this test
+     * also builds its client trust store from, so both ends share the key material under test.
+     *
+     * @return the server-side handshake certificates carrying {@link #SERVER_CERTIFICATE}
+     */
+    static HandshakeCertificates serverCertificates() {
+        return new HandshakeCertificates.Builder()
+                .heldCertificate(SERVER_CERTIFICATE)
+                .build();
+    }
+
+    @Getter
+    private final TokenEndpointDispatcher moduleDispatcher = new TokenEndpointDispatcher();
+
+    private TestTokenHolder accessHolder;
+    private TestTokenHolder idHolder;
+    private TokenValidationBridge accessBridge;
+    private IdTokenValidationBridge idBridge;
+    private Map<String, String> savedTrustStoreProperties;
+
+    @BeforeEach
+    void setUp() {
+        accessHolder = TestTokenGenerators.accessTokens().next();
+        idHolder = TestTokenGenerators.idTokens().next();
+        TokenValidator validator = TokenValidator.builder().issuerConfig(accessHolder.getIssuerConfig()).build();
+        accessBridge = new TokenValidationBridge(validator);
+        idBridge = new IdTokenValidationBridge(validator);
+        moduleDispatcher.reset();
+        savedTrustStoreProperties = null;
+    }
+
+    @AfterEach
+    void restoreTrustStore() {
+        if (savedTrustStoreProperties != null) {
+            savedTrustStoreProperties.forEach((key, value) -> {
+                if (value == null) {
+                    System.clearProperty(key);
+                } else {
+                    System.setProperty(key, value);
+                }
+            });
+        }
+    }
+
+    @Test
+    @DisplayName("exchange() completes over HTTPS when the client trusts the server certificate")
+    void shouldCompleteExchangeOverHttps(URIBuilder uriBuilder) throws Exception {
+        installClientTrustStore(SERVER_CERTIFICATE.certificate());
+        var config = tlsConfig();
+        var context = FlowContext.create(REDIRECT_URI);
+        idHolder.withClaim("nonce", ClaimValue.forPlainString(context.nonce()));
+        moduleDispatcher.success(accessHolder.getRawToken(), idHolder.getRawToken());
+        String code = Generators.letterStrings(20, 40).next();
+        var callback = new CallbackParameters(code, context.state(), null, null, null);
+        var metadata = metadataWithTokenEndpoint(uriBuilder);
+
+        AuthorizationCodeFlow.AuthenticationResult result =
+                flow(config).exchange(metadata, context, callback, auth(config));
+
+        assertAll("validated HTTPS exchange",
+                () -> assertTrue(metadata.tokenEndpoint.startsWith("https://"),
+                        "the exchange must target the TLS token endpoint"),
+                () -> assertNotNull(result.accessToken(), "a validated access token must be returned over TLS"),
+                () -> assertNotNull(result.idToken(), "a validated ID token must be returned over TLS"),
+                () -> moduleDispatcher.assertCalled(1));
+    }
+
+    @Test
+    @DisplayName("exchange() is refused over HTTPS when the client TLS trust material is mismatched")
+    void shouldRefuseExchangeWhenTlsMaterialMismatched(URIBuilder uriBuilder) throws Exception {
+        installClientTrustStore(UNRELATED_CERTIFICATE.certificate());
+        var config = tlsConfig();
+        var context = FlowContext.create(REDIRECT_URI);
+        idHolder.withClaim("nonce", ClaimValue.forPlainString(context.nonce()));
+        moduleDispatcher.success(accessHolder.getRawToken(), idHolder.getRawToken());
+        var callback = new CallbackParameters(Generators.letterStrings(20, 40).next(),
+                context.state(), null, null, null);
+        var metadata = metadataWithTokenEndpoint(uriBuilder);
+        var flow = flow(config);
+        var clientAuth = auth(config);
+
+        assertThrows(TransportException.class,
+                () -> flow.exchange(metadata, context, callback, clientAuth),
+                "a TLS handshake against an untrusted server certificate must fail the back-channel call");
+        moduleDispatcher.assertNotCalled();
+    }
+
+    private static ClientConfiguration tlsConfig() {
+        return ClientConfiguration.builder()
+                .issuer(ISSUER)
+                .clientId(Generators.nonBlankStrings().next())
+                .clientSecret(Generators.nonBlankStrings().next())
+                .authMethod(ClientAuthMethod.CLIENT_SECRET_BASIC)
+                .scope("openid")
+                .redirectUri(REDIRECT_URI)
+                // Deliberately NOT allowInsecureHttp(true): this exercises the real TLS branch.
+                .build();
+    }
+
+    private static ProviderMetadata metadataWithTokenEndpoint(URIBuilder uriBuilder) {
+        var metadata = new ProviderMetadata();
+        metadata.issuer = ISSUER;
+        metadata.tokenEndpoint = uriBuilder.addPathSegment("token").buildAsString();
+        return metadata;
+    }
+
+    private AuthorizationCodeFlow flow(ClientConfiguration config) {
+        return new AuthorizationCodeFlow(config, new TokenEndpointClient(config), accessBridge, idBridge);
+    }
+
+    private static ClientSecretBasicAuth auth(ClientConfiguration config) {
+        return new ClientSecretBasicAuth(config.getClientId(), config.getClientSecret());
+    }
+
+    /**
+     * Writes a PKCS12 trust store containing {@code trusted} and points the JVM trust-store system
+     * properties at it, so the {@code cui-http} handler's default-trust {@link javax.net.ssl.SSLContext}
+     * trusts exactly that certificate. The prior property values are captured for {@code @AfterEach}
+     * restoration.
+     */
+    private void installClientTrustStore(X509Certificate trusted) throws Exception {
+        KeyStore trustStore = KeyStore.getInstance("PKCS12");
+        trustStore.load(null, TRUST_STORE_PASSWORD);
+        trustStore.setCertificateEntry("trusted", trusted);
+        Path trustStoreFile = Files.createTempFile("wired-flow-https-trust", ".p12");
+        trustStoreFile.toFile().deleteOnExit();
+        try (OutputStream out = Files.newOutputStream(trustStoreFile)) {
+            trustStore.store(out, TRUST_STORE_PASSWORD);
+        }
+
+        savedTrustStoreProperties = new HashMap<>();
+        captureAndSet("javax.net.ssl.trustStore", trustStoreFile.toString());
+        captureAndSet("javax.net.ssl.trustStorePassword", new String(TRUST_STORE_PASSWORD));
+        captureAndSet("javax.net.ssl.trustStoreType", "PKCS12");
+    }
+
+    private void captureAndSet(String key, String value) {
+        savedTrustStoreProperties.put(key, System.getProperty(key));
+        System.setProperty(key, value);
+    }
+
+    /**
+     * Token-endpoint dispatcher serving a configurable authorization_code response and recording how
+     * many times it was actually reached, so a refused TLS handshake can be asserted to never arrive.
+     */
+    static final class TokenEndpointDispatcher implements ModuleDispatcherElement {
+
+        private static final int HTTP_OK = 200;
+
+        private String body = "";
+
+        @Getter
+        private int callCount;
+
+        void reset() {
+            this.body = "";
+            this.callCount = 0;
+        }
+
+        void success(String accessToken, String idToken) {
+            StringBuilder json = new StringBuilder("{\"access_token\":\"").append(accessToken)
+                    .append("\",\"token_type\":\"Bearer\",\"expires_in\":300");
+            if (idToken != null) {
+                json.append(",\"id_token\":\"").append(idToken).append('"');
+            }
+            json.append('}');
+            this.body = json.toString();
+        }
+
+        @Override
+        public String getBaseUrl() {
+            return "/token";
+        }
+
+        @Override
+        public Set<HttpMethodMapper> supportedMethods() {
+            return Set.of(HttpMethodMapper.POST);
+        }
+
+        @Override
+        public Optional<MockResponse> handlePost(RecordedRequest request) {
+            callCount++;
+            return Optional.of(new MockResponse(HTTP_OK, Headers.of("Content-Type", "application/json"), body));
+        }
+
+        void assertCalled(int expected) {
+            org.junit.jupiter.api.Assertions.assertEquals(expected, callCount,
+                    "unexpected token-endpoint call-count");
+        }
+
+        void assertNotCalled() {
+            org.junit.jupiter.api.Assertions.assertEquals(0, callCount,
+                    "a refused TLS handshake must never reach the token endpoint");
+        }
+    }
+}

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/WiredFlowHttpsTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/WiredFlowHttpsTest.java
@@ -40,6 +40,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import java.io.OutputStream;
 import java.nio.file.Files;
@@ -76,6 +77,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @EnableMockWebServer(useHttps = true)
 @TestProvidedCertificate(providerClass = WiredFlowHttpsTest.class, methodName = "serverCertificates")
 @DisplayName("Wired back-channel exchange over HTTPS (TLS path)")
+@Isolated
 class WiredFlowHttpsTest {
 
     private static final String ISSUER = "https://issuer.example.com";

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/WiredFlowTestSupport.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/WiredFlowTestSupport.java
@@ -78,6 +78,19 @@ abstract class WiredFlowTestSupport {
     /** The single, exact redirect URI the interactive flow is registered with. */
     protected static final String REDIRECT_URI = "https://rp.example.com/callback";
 
+    /** Cached 2048-bit RSA key pair, generated once for the whole test suite (DPoP proof material). */
+    private static final KeyPair RSA_KEY_PAIR;
+
+    static {
+        try {
+            KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+            generator.initialize(2048);
+            RSA_KEY_PAIR = generator.generateKeyPair();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("RSA key pair generation failed", e);
+        }
+    }
+
     @Getter
     private final RecordingTokenEndpointDispatcher moduleDispatcher = new RecordingTokenEndpointDispatcher();
 
@@ -160,13 +173,7 @@ abstract class WiredFlowTestSupport {
     }
 
     private static KeyPair rsaKeyPair() {
-        try {
-            KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
-            generator.initialize(2048);
-            return generator.generateKeyPair();
-        } catch (NoSuchAlgorithmException e) {
-            throw new IllegalStateException("RSA key pair generation failed", e);
-        }
+        return RSA_KEY_PAIR;
     }
 
     /**

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/WiredFlowTestSupport.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/WiredFlowTestSupport.java
@@ -19,6 +19,8 @@ import de.cuioss.sheriff.token.client.auth.ClientSecretBasicAuth;
 import de.cuioss.sheriff.token.client.config.ClientAuthMethod;
 import de.cuioss.sheriff.token.client.config.ClientConfiguration;
 import de.cuioss.sheriff.token.client.discovery.ProviderMetadata;
+import de.cuioss.sheriff.token.client.dpop.DpopProofGenerator;
+import de.cuioss.sheriff.token.client.dpop.SenderConstraint;
 import de.cuioss.sheriff.token.client.token.IdTokenValidationBridge;
 import de.cuioss.sheriff.token.client.token.TokenValidationBridge;
 import de.cuioss.sheriff.token.validation.TokenValidator;
@@ -34,6 +36,9 @@ import mockwebserver3.RecordedRequest;
 import okhttp3.Headers;
 import org.junit.jupiter.api.function.Executable;
 
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -138,6 +143,30 @@ abstract class WiredFlowTestSupport {
      */
     protected AuthorizationCodeFlow authorizationCodeFlow(ClientConfiguration config) {
         return new AuthorizationCodeFlow(config, new TokenEndpointClient(config), accessBridge, idBridge);
+    }
+
+    /**
+     * Assembles a DPoP-constrained {@code authorization_code} flow, so a wired test can prove the code
+     * redemption attaches a DPoP proof (mirrors the sender-constrained assembly a caller performs when
+     * the client is configured for DPoP-bound tokens).
+     *
+     * @param config the client configuration
+     * @return the wired, DPoP-constrained authorization-code flow
+     */
+    protected AuthorizationCodeFlow dpopAuthorizationCodeFlow(ClientConfiguration config) {
+        SenderConstraint constraint = SenderConstraint.dpop(new DpopProofGenerator(rsaKeyPair(), "RS256"));
+        return new AuthorizationCodeFlow(config, new TokenEndpointClient(config), accessBridge, idBridge,
+                new IssValidator(), constraint);
+    }
+
+    private static KeyPair rsaKeyPair() {
+        try {
+            KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+            generator.initialize(2048);
+            return generator.generateKeyPair();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("RSA key pair generation failed", e);
+        }
     }
 
     /**

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/lifecycle/TokenStoreTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/lifecycle/TokenStoreTest.java
@@ -25,8 +25,13 @@ import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -176,5 +181,69 @@ class TokenStoreTest {
                 () -> assertThrows(IllegalArgumentException.class, () -> store.store("  ", token)),
                 () -> assertThrows(IllegalArgumentException.class,
                         () -> new RefreshScheduler(negativeLead)));
+    }
+
+    @Test
+    @DisplayName("Should treat the exact refresh-window edge as eligible and one instant earlier as not (injected clock)")
+    void shouldRefreshExactlyAtWindowEdge() {
+        var refreshLead = Duration.ofSeconds(30);
+        var scheduler = new RefreshScheduler(refreshLead);
+        // Injected clock: every reference instant is derived from a fixed base, so the boundary is
+        // exercised deterministically without any wall-clock sleep.
+        Instant expiresAt = Instant.now().plusSeconds(300);
+        Instant windowOpensAt = expiresAt.minus(refreshLead);
+        StoredToken token = new StoredToken(Generators.letterStrings(20, 40).next(), null, null, null, expiresAt);
+
+        assertAll("refresh-window edge (injected clock)",
+                () -> assertFalse(scheduler.needsRefresh(token, windowOpensAt.minusNanos(1)),
+                        "one instant before the window opens is not yet refresh-eligible"),
+                () -> assertTrue(scheduler.needsRefresh(token, windowOpensAt),
+                        "exactly at the window edge the token is refresh-eligible"),
+                () -> assertTrue(scheduler.needsRefresh(token, windowOpensAt.plusNanos(1)),
+                        "just inside the window the token is refresh-eligible"),
+                () -> assertTrue(scheduler.needsRefresh(token, expiresAt),
+                        "at expiry the token is refresh-eligible"));
+    }
+
+    @Test
+    @DisplayName("Should keep logout fail-closed under a concurrent refresh — a revoked session is never resurrected")
+    void shouldNotResurrectSessionUnderConcurrentRefreshAndLogout() {
+        var manager = new TokenLifecycleManager(new InMemoryTokenStore(), new RefreshScheduler());
+        // computeIfPresent makes retrieve-transform-store atomic, so whichever thread runs first, the
+        // final state after a concurrent logout is always empty: a refresh can never resurrect a
+        // revoked session. A CyclicBarrier releases both threads simultaneously each iteration, so the
+        // interleaving is genuinely exercised without any timing assumption (no flake).
+        int iterations = 500;
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+        try {
+            for (int i = 0; i < iterations; i++) {
+                String sessionId = Generators.letterStrings(10, 20).next();
+                manager.store(sessionId, bearerToken());
+                String rotatedAccess = Generators.letterStrings(20, 40).next();
+                var barrier = new CyclicBarrier(2);
+
+                Callable<Void> refreshTask = () -> {
+                    barrier.await();
+                    manager.applyRefresh(sessionId, rotatedAccess, null, null, null);
+                    return null;
+                };
+                Callable<Void> logoutTask = () -> {
+                    barrier.await();
+                    manager.revokeAndClear(sessionId);
+                    return null;
+                };
+                var refreshResult = pool.submit(refreshTask);
+                var logoutResult = pool.submit(logoutTask);
+
+                assertDoesNotThrow(() -> {
+                    refreshResult.get();
+                    logoutResult.get();
+                }, "neither concurrent operation fails");
+                assertTrue(manager.get(sessionId).isEmpty(),
+                        "after a concurrent logout the session holds no token — refresh cannot resurrect it");
+            }
+        } finally {
+            pool.shutdownNow();
+        }
     }
 }

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/token/RotationReuseDetectionTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/token/RotationReuseDetectionTest.java
@@ -32,6 +32,7 @@ import de.cuioss.sheriff.token.validation.TokenValidator;
 import de.cuioss.sheriff.token.validation.domain.claim.ClaimName;
 import de.cuioss.sheriff.token.validation.domain.claim.ClaimValue;
 import de.cuioss.sheriff.token.validation.test.TestTokenHolder;
+import de.cuioss.sheriff.token.validation.test.dispatcher.TokenDispatcher;
 import de.cuioss.sheriff.token.validation.test.generator.TestTokenGenerators;
 import de.cuioss.test.generator.Generators;
 import de.cuioss.test.generator.junit.EnableGeneratorController;
@@ -40,12 +41,7 @@ import de.cuioss.test.juli.TestLogLevel;
 import de.cuioss.test.juli.junit5.EnableTestLogger;
 import de.cuioss.test.mockwebserver.EnableMockWebServer;
 import de.cuioss.test.mockwebserver.URIBuilder;
-import de.cuioss.test.mockwebserver.dispatcher.HttpMethodMapper;
-import de.cuioss.test.mockwebserver.dispatcher.ModuleDispatcherElement;
 import lombok.Getter;
-import mockwebserver3.MockResponse;
-import mockwebserver3.RecordedRequest;
-import okhttp3.Headers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -54,13 +50,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -89,7 +83,7 @@ class RotationReuseDetectionTest {
     private static final int SINGLE_FLIGHT_THREADS = 8;
 
     @Getter
-    private final TokenEndpointDispatcher moduleDispatcher = new TokenEndpointDispatcher();
+    private final TokenDispatcher moduleDispatcher = new TokenDispatcher();
 
     private TestTokenHolder accessHolder;
     private TestTokenHolder idHolder;
@@ -118,7 +112,7 @@ class RotationReuseDetectionTest {
 
     private static ProviderMetadata metadata(URIBuilder uriBuilder) {
         var metadata = new ProviderMetadata();
-        metadata.tokenEndpoint = uriBuilder.addPathSegment("token").buildAsString();
+        metadata.tokenEndpoint = uriBuilder.addPathSegments("oidc", "token").buildAsString();
         metadata.revocationEndpoint = uriBuilder.addPathSegment("revoke").buildAsString();
         return metadata;
     }
@@ -152,12 +146,13 @@ class RotationReuseDetectionTest {
         String rt2 = Generators.letterStrings(20, 40).next();
 
         manager.store(session, bearerBundle(rt1, null));
-        moduleDispatcher.success(accessHolder.getRawToken(), rt2, null, 300);
+        moduleDispatcher.respondWith(TokenDispatcher.tokenResponse(accessHolder.getRawToken(), rt2, null, 300));
         manager.refresh(session, metadata, flow, revocationClient, idBridge, clientAuth(config));
 
         // Roll the store back to the now-superseded token while the family stays at rt2, then present it.
         manager.store(session, bearerBundle(rt1, null));
-        moduleDispatcher.success(accessHolder.getRawToken(), Generators.letterStrings(20, 40).next(), null, 300);
+        moduleDispatcher.respondWith(TokenDispatcher.tokenResponse(accessHolder.getRawToken(),
+                Generators.letterStrings(20, 40).next(), null, 300));
         var clientAuth = clientAuth(config);
 
         assertThrows(ClientProtocolException.class,
@@ -186,8 +181,8 @@ class RotationReuseDetectionTest {
         manager.store(session, bearerBundle(rt1, null));
 
         CountDownLatch allStarted = new CountDownLatch(SINGLE_FLIGHT_THREADS);
-        moduleDispatcher.success(accessHolder.getRawToken(), rt2, null, 300);
-        moduleDispatcher.blockRedeemUntil(allStarted);
+        moduleDispatcher.respondWith(TokenDispatcher.tokenResponse(accessHolder.getRawToken(), rt2, null, 300));
+        moduleDispatcher.blockUntil(allStarted);
 
         ExecutorService pool = Executors.newFixedThreadPool(SINGLE_FLIGHT_THREADS);
         List<Future<Optional<StoredToken>>> futures = new ArrayList<>();
@@ -208,7 +203,7 @@ class RotationReuseDetectionTest {
         }
 
         assertAll("single-flight outcome",
-                () -> assertEquals(1, moduleDispatcher.tokenCallCount(),
+                () -> assertEquals(1, moduleDispatcher.getCallCounter(),
                         "the concurrent refresh redeems the token exactly once (single-flight)"),
                 () -> assertFalse(revocationClient.revokedAny(),
                         "a benign race must not trigger a revocation"),
@@ -232,8 +227,8 @@ class RotationReuseDetectionTest {
         String rt1 = Generators.letterStrings(20, 40).next();
         String originalIdToken = Generators.letterStrings(20, 40).next();
         manager.store(session, bearerBundle(rt1, originalIdToken));
-        moduleDispatcher.success(accessHolder.getRawToken(), Generators.letterStrings(20, 40).next(),
-                idHolder.getRawToken(), 300);
+        moduleDispatcher.respondWith(TokenDispatcher.tokenResponse(accessHolder.getRawToken(),
+                Generators.letterStrings(20, 40).next(), idHolder.getRawToken(), 300));
         var clientAuth = clientAuth(config);
 
         assertThrows(IllegalStateException.class,
@@ -262,8 +257,8 @@ class RotationReuseDetectionTest {
         String session = Generators.letterStrings(10, 20).next();
         String rt1 = Generators.letterStrings(20, 40).next();
         manager.store(session, bearerBundle(rt1, Generators.letterStrings(20, 40).next()));
-        moduleDispatcher.success(accessHolder.getRawToken(), Generators.letterStrings(20, 40).next(),
-                idHolder.getRawToken(), 300);
+        moduleDispatcher.respondWith(TokenDispatcher.tokenResponse(accessHolder.getRawToken(),
+                Generators.letterStrings(20, 40).next(), idHolder.getRawToken(), 300));
 
         StoredToken refreshed = manager
                 .refresh(session, metadata, flow, revocationClient, idBridge, clientAuth(config))
@@ -349,67 +344,4 @@ class RotationReuseDetectionTest {
         }
     }
 
-    /**
-     * Token-endpoint dispatcher serving a configurable refresh response, with an optional gate that
-     * holds the (single) redeem until a latch releases — the window a single-flight test uses to prove
-     * a concurrent refresh collapses onto one redeem.
-     */
-    static final class TokenEndpointDispatcher implements ModuleDispatcherElement {
-
-        private static final int HTTP_OK = 200;
-
-        private String body = "";
-        private final AtomicInteger tokenCalls = new AtomicInteger();
-        private CountDownLatch redeemGate;
-
-        void reset() {
-            this.body = "";
-            this.tokenCalls.set(0);
-            this.redeemGate = null;
-        }
-
-        void success(String accessToken, String refreshToken, String idToken, long expiresIn) {
-            StringBuilder json = new StringBuilder("{\"access_token\":\"").append(accessToken)
-                    .append("\",\"token_type\":\"Bearer\",\"expires_in\":").append(expiresIn);
-            if (refreshToken != null) {
-                json.append(",\"refresh_token\":\"").append(refreshToken).append('"');
-            }
-            if (idToken != null) {
-                json.append(",\"id_token\":\"").append(idToken).append('"');
-            }
-            json.append('}');
-            this.body = json.toString();
-        }
-
-        void blockRedeemUntil(CountDownLatch gate) {
-            this.redeemGate = gate;
-        }
-
-        int tokenCallCount() {
-            return tokenCalls.get();
-        }
-
-        @Override
-        public String getBaseUrl() {
-            return "/token";
-        }
-
-        @Override
-        public Set<HttpMethodMapper> supportedMethods() {
-            return Set.of(HttpMethodMapper.POST);
-        }
-
-        @Override
-        public Optional<MockResponse> handlePost(RecordedRequest request) {
-            tokenCalls.incrementAndGet();
-            if (redeemGate != null) {
-                try {
-                    redeemGate.await(10, TimeUnit.SECONDS);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                }
-            }
-            return Optional.of(new MockResponse(HTTP_OK, Headers.of("Content-Type", "application/json"), body));
-        }
-    }
 }

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/token/UserInfoClientTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/token/UserInfoClientTest.java
@@ -41,6 +41,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -193,6 +194,30 @@ class UserInfoClientTest {
     }
 
     @Test
+    @DisplayName("Should sanitize an AS-controlled parse-error fragment carrying CR/LF (M8)")
+    void shouldSanitizeParseErrorFragment(URIBuilder uriBuilder) {
+        // The userinfo body is AS-controlled; a malformed value with an embedded CR/LF must not forge a
+        // log line — the parse-error fragment must be routed through LogSanitizer before it is exposed.
+        moduleDispatcher.returnMalformedJson("{\"sub\":\"a\",\"email_verified\":tru\r\nINJECTED}");
+        var client = userInfoClient();
+        var endpoint = userInfoEndpoint(uriBuilder);
+        var token = Generators.nonBlankStrings().next();
+
+        TransportException thrown = assertThrows(TransportException.class,
+                () -> client.fetchUserInfo(endpoint, token),
+                "a malformed userinfo response must surface as a TransportException");
+
+        String message = thrown.getMessage();
+        assertAll("sanitized parse-error fragment",
+                () -> assertFalse(message.indexOf('\r') >= 0,
+                        "a raw CR from the AS-controlled body must not reach the exception message"),
+                () -> assertFalse(message.indexOf('\n') >= 0,
+                        "a raw LF from the AS-controlled body must not reach the exception message"),
+                () -> assertTrue(message.contains("\\r") && message.contains("\\n"),
+                        "the injected CR/LF must survive in escaped form, proving the fragment was carried and sanitized"));
+    }
+
+    @Test
     @DisplayName("Should reject a signed userinfo response whose validated claims omit the sub (M3)")
     void shouldRejectSignedUserInfoMissingSub(URIBuilder uriBuilder) {
         moduleDispatcher.returnSigned(APPLICATION_JWT,
@@ -212,14 +237,26 @@ class UserInfoClientTest {
      */
     static final class UserInfoTestDispatcher implements ModuleDispatcherElement {
 
+        private static final String APPLICATION_JSON = "application/json";
+
         private final UserInfoDispatcher json = new UserInfoDispatcher();
         private boolean signed;
         private String signedContentType = APPLICATION_JWT;
         private String signedBody = "";
+        private boolean malformed;
+        private String malformedBody = "";
 
         UserInfoTestDispatcher returnDefault() {
             signed = false;
+            malformed = false;
             json.returnDefault();
+            return this;
+        }
+
+        UserInfoTestDispatcher returnMalformedJson(String body) {
+            signed = false;
+            malformed = true;
+            malformedBody = body;
             return this;
         }
 
@@ -264,6 +301,9 @@ class UserInfoClientTest {
 
         @Override
         public Optional<MockResponse> handleGet(RecordedRequest request) {
+            if (malformed) {
+                return Optional.of(new MockResponse(200, Headers.of("Content-Type", APPLICATION_JSON), malformedBody));
+            }
             if (signed) {
                 return Optional.of(new MockResponse(200, Headers.of("Content-Type", signedContentType), signedBody));
             }

--- a/token-sheriff-quarkus-parent/token-sheriff-client-quarkus/src/main/java/de/cuioss/sheriff/token/client/quarkus/TokenSheriffClientProducer.java
+++ b/token-sheriff-quarkus-parent/token-sheriff-client-quarkus/src/main/java/de/cuioss/sheriff/token/client/quarkus/TokenSheriffClientProducer.java
@@ -274,8 +274,13 @@ public class TokenSheriffClientProducer {
     public AuthorizationCodeFlow authorizationCodeFlow(ClientConfiguration clientConfiguration,
             TokenEndpointClient tokenEndpointClient, TokenValidationBridge tokenValidationBridge,
             IdTokenValidationBridge idTokenValidationBridge, IssValidator issValidator) {
+        // SenderConstraint is a per-request DPoP/mTLS binding, deliberately NOT produced as an
+        // @ApplicationScoped bean (see class Javadoc); the sibling refreshFlow() producer likewise
+        // wires RefreshFlow's unconstrained overload. Pass null here to preserve the plain-bearer
+        // CDI-wired behaviour — DPoP-bound authorization-code redemption remains available to callers
+        // that construct AuthorizationCodeFlow directly with a constraint.
         return new AuthorizationCodeFlow(clientConfiguration, tokenEndpointClient, tokenValidationBridge,
-                idTokenValidationBridge, issValidator);
+                idTokenValidationBridge, issValidator, null);
     }
 
     /**

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/commons/error/InboundErrorNormalizer.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/commons/error/InboundErrorNormalizer.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.token.commons.error;
+
+import org.jspecify.annotations.Nullable;
+
+import java.util.Set;
+
+/**
+ * Normalizes an inbound OAuth 2.0 error response ({@code error} plus optional
+ * {@code error_description}, RFC 6749 §4.1.2.1 / §5.2) into the typed {@link ClientProtocolException}
+ * the error model renders — <em>one contract, both directions</em> (COMMONS-11).
+ * <p>
+ * The raw upstream {@code error} and {@code error_description} are authorization-server-controlled and
+ * are never surfaced verbatim: both are neutralized for log/response injection (CWE-117) before they
+ * reach the caller-safe exception message. Because the {@code commons} base layer must not depend on
+ * the client engine (the ArchUnit boundary), this normalizer carries its own minimal CR/LF /
+ * control-character neutralization rather than the client-internal sanitizer.
+ * <p>
+ * The utility is stateless and has no configuration surface.
+ *
+ * @since 1.0
+ * @see <a href="https://www.rfc-editor.org/rfc/rfc6749#section-4.1.2.1">RFC 6749 §4.1.2.1</a>
+ * @see <a href="https://www.rfc-editor.org/rfc/rfc6749#section-5.2">RFC 6749 §5.2</a>
+ */
+public final class InboundErrorNormalizer {
+
+    /** Maximum number of source characters retained per field; longer values are truncated. */
+    private static final int MAX_LENGTH = 256;
+
+    /** Appended when a field is truncated, so the elision is visible. */
+    private static final String TRUNCATION_MARKER = "...[truncated]";
+
+    /**
+     * The registered OAuth 2.0 error codes across the authorization endpoint (RFC 6749 §4.1.2.1) and
+     * the token endpoint (RFC 6749 §5.2). A code outside this set is reported as unrecognized rather
+     * than trusted as a known protocol condition.
+     */
+    private static final Set<String> REGISTERED_ERROR_CODES = Set.of(
+            "invalid_request",
+            "invalid_client",
+            "invalid_grant",
+            "unauthorized_client",
+            "unsupported_grant_type",
+            "unsupported_response_type",
+            "access_denied",
+            "invalid_scope",
+            "server_error",
+            "temporarily_unavailable");
+
+    private InboundErrorNormalizer() {
+        // utility class — never instantiated
+    }
+
+    /**
+     * Normalizes a raw inbound error response into a caller-safe {@link ClientProtocolException}.
+     *
+     * @param error            the raw {@code error} code from the authorization server, or {@code null}
+     * @param errorDescription the raw {@code error_description}, or {@code null}
+     * @return a {@link ClientProtocolException} whose message names the (recognized-or-unrecognized)
+     *         error code and, when present, the sanitized description — never the raw upstream content
+     */
+    public static ClientProtocolException normalize(@Nullable String error, @Nullable String errorDescription) {
+        String safeError = sanitize(error);
+        String message;
+        if (safeError == null || safeError.isBlank()) {
+            message = "authorization server returned an error callback without an error code";
+        } else if (isRegistered(error)) {
+            message = "authorization server returned an error callback: " + safeError;
+        } else {
+            message = "authorization server returned an unrecognized error callback: " + safeError;
+        }
+        String safeDescription = sanitize(errorDescription);
+        if (safeDescription != null && !safeDescription.isBlank()) {
+            message = message + " (" + safeDescription + ")";
+        }
+        return new ClientProtocolException(message);
+    }
+
+    private static boolean isRegistered(@Nullable String error) {
+        return error != null && REGISTERED_ERROR_CODES.contains(error);
+    }
+
+    /**
+     * Escapes {@code CR}, {@code LF}, tab and every other ASCII control character so an
+     * authorization-server-controlled value cannot forge a new log/response line, and truncates the
+     * value to {@value #MAX_LENGTH} characters to bound flooding.
+     *
+     * @param value the untrusted value to sanitize; may be {@code null}
+     * @return the sanitized value, or {@code null} when {@code value} is {@code null}
+     */
+    private static @Nullable String sanitize(@Nullable String value) {
+        if (value == null) {
+            return null;
+        }
+        boolean truncated = value.length() > MAX_LENGTH;
+        String bounded = truncated ? value.substring(0, MAX_LENGTH) : value;
+        StringBuilder sanitized = new StringBuilder(bounded.length());
+        for (int i = 0; i < bounded.length(); i++) {
+            char c = bounded.charAt(i);
+            switch (c) {
+                case '\r' -> sanitized.append("\\r");
+                case '\n' -> sanitized.append("\\n");
+                case '\t' -> sanitized.append("\\t");
+                default -> {
+                    if (c < 0x20 || c == 0x7F) {
+                        sanitized.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        sanitized.append(c);
+                    }
+                }
+            }
+        }
+        if (truncated) {
+            sanitized.append(TRUNCATION_MARKER);
+        }
+        return sanitized.toString();
+    }
+}

--- a/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/commons/error/InboundErrorNormalizerTest.java
+++ b/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/commons/error/InboundErrorNormalizerTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.token.commons.error;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("InboundErrorNormalizer (COMMONS-11)")
+class InboundErrorNormalizerTest {
+
+    /** The BEL control character (0x07), used to prove non-CR/LF control chars are also escaped. */
+    private static final char BELL = 0x07;
+
+    @ParameterizedTest
+    @ValueSource(strings = {"invalid_request", "invalid_client", "invalid_grant", "unauthorized_client",
+            "unsupported_grant_type", "unsupported_response_type", "access_denied", "invalid_scope",
+            "server_error", "temporarily_unavailable"})
+    @DisplayName("Should recognize each registered RFC 6749 error code")
+    void shouldRecognizeRegisteredErrorCodes(String code) {
+        ClientProtocolException exception = InboundErrorNormalizer.normalize(code, null);
+
+        assertAll("recognized error code",
+                () -> assertTrue(exception.getMessage().contains(code), "the recognized code is named"),
+                () -> assertFalse(exception.getMessage().contains("unrecognized"),
+                        "a registered code must not be reported as unrecognized"));
+    }
+
+    @Test
+    @DisplayName("Should report an unregistered error code as unrecognized")
+    void shouldReportUnknownErrorCodeAsUnrecognized() {
+        ClientProtocolException exception = InboundErrorNormalizer.normalize("totally_made_up", null);
+
+        assertAll("unrecognized error code",
+                () -> assertTrue(exception.getMessage().contains("unrecognized"),
+                        "an unregistered code is flagged as unrecognized"),
+                () -> assertTrue(exception.getMessage().contains("totally_made_up"),
+                        "the (sanitized) offending code is still surfaced for diagnostics"));
+    }
+
+    @Test
+    @DisplayName("Should report a null error code as a missing error code")
+    void shouldReportNullErrorCode() {
+        ClientProtocolException exception = InboundErrorNormalizer.normalize(null, "some description");
+
+        assertTrue(exception.getMessage().contains("without an error code"),
+                "a null error code produces the missing-code message");
+    }
+
+    @Test
+    @DisplayName("Should omit a null or blank error_description from the message")
+    void shouldOmitBlankDescription() {
+        String withNull = InboundErrorNormalizer.normalize("access_denied", null).getMessage();
+        String withBlank = InboundErrorNormalizer.normalize("access_denied", "   ").getMessage();
+
+        assertAll("blank description omitted",
+                () -> assertFalse(withNull.contains("("), "a null description adds no parenthetical clause"),
+                () -> assertFalse(withBlank.contains("("), "a blank description adds no parenthetical clause"));
+    }
+
+    @Test
+    @DisplayName("Should include a present error_description in the message")
+    void shouldIncludePresentDescription() {
+        ClientProtocolException exception =
+                InboundErrorNormalizer.normalize("access_denied", "the resource owner denied the request");
+
+        assertTrue(exception.getMessage().contains("the resource owner denied the request"),
+                "a non-blank description is surfaced alongside the error code");
+    }
+
+    @Test
+    @DisplayName("Should sanitize CR/LF in both the error code and the error_description (CWE-117)")
+    void shouldSanitizeCrlfInBothFields() {
+        ClientProtocolException exception = InboundErrorNormalizer.normalize(
+                "access_denied\r\nWARN forged-code-line",
+                "denied\r\nWARN forged-description-line");
+
+        String message = exception.getMessage();
+        assertAll("sanitized fields",
+                () -> assertFalse(message.indexOf('\r') >= 0, "no raw CR survives from either field"),
+                () -> assertFalse(message.indexOf('\n') >= 0, "no raw LF survives from either field"),
+                () -> assertTrue(message.contains("\\r\\n"),
+                        "the embedded CR/LF is escaped, preserving the investigative content"));
+    }
+
+    @Test
+    @DisplayName("Should escape other ASCII control characters in the description")
+    void shouldEscapeControlCharacters() {
+        ClientProtocolException exception =
+                InboundErrorNormalizer.normalize("access_denied", "denied" + BELL + "bell");
+
+        String message = exception.getMessage();
+        assertAll("escaped control character",
+                () -> assertFalse(message.indexOf(BELL) >= 0, "the raw control character does not survive"),
+                () -> assertTrue(message.contains("\\u0007"), "the control character is rendered as an escape"));
+    }
+
+    @Test
+    @DisplayName("Should truncate an over-long field to bound log flooding")
+    void shouldTruncateOverlongField() {
+        String overlong = "x".repeat(300);
+        ClientProtocolException exception = InboundErrorNormalizer.normalize(overlong, null);
+
+        String message = exception.getMessage();
+        assertAll("bounded field",
+                () -> assertNotNull(message),
+                () -> assertTrue(message.contains("...[truncated]"), "an over-long value is marked truncated"),
+                () -> assertFalse(message.contains(overlong), "the full over-long value is not carried"));
+    }
+}

--- a/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/cache/AccessTokenCacheTest.java
+++ b/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/cache/AccessTokenCacheTest.java
@@ -136,10 +136,11 @@ class AccessTokenCacheTest {
         // Create test data with consistent token
         String testToken = "test-jwt-token";
 
-        // First access - cache a token that will expire soon
+        // First access - cache a token with a fixed TTL
+        OffsetDateTime tokenExpiry = OffsetDateTime.now().plusSeconds(2);
         AccessTokenContent expiredContent = createAccessTokenWithRawToken(
                 "https://example.com",
-                OffsetDateTime.now().plusSeconds(2), // Will expire in 2 seconds
+                tokenExpiry,
                 testToken
         );
 
@@ -157,17 +158,10 @@ class AccessTokenCacheTest {
         assertEquals(1, validationCount.get());
         assertEquals(1, cache.size());
 
-        // Wait for token to expire using Awaitility
-        await()
-                .atMost(3, TimeUnit.SECONDS)
-                .pollInterval(100, TimeUnit.MILLISECONDS)
-                .until(() -> {
-                    // Check if token has expired by comparing with current time
-                    return expiredContent.getExpirationDateTime().isBefore(OffsetDateTime.now());
-                });
-
-        // When - second access should detect expiration and throw exception
-        OffsetDateTime checkTime = OffsetDateTime.now();
+        // Injected clock: advance the reference instant past the token TTL instead of sleeping ~2 s
+        // of wall-clock time. get(...) evaluates expiration against the supplied instant, so a
+        // checkTime after the TTL makes the cached token expired deterministically.
+        OffsetDateTime checkTime = tokenExpiry.plusSeconds(1);
         TokenValidationException exception =
                 assertThrows(TokenValidationException.class, () ->
                         cache.get(testToken, performanceMonitor, checkTime));
@@ -625,8 +619,10 @@ class AccessTokenCacheTest {
                 .build();
         cache = new AccessTokenCache(config, securityEventCounter, 0);
 
-        // When - add 5 tokens that will expire in 2 seconds
-        OffsetDateTime expirationTime = OffsetDateTime.now().plusSeconds(2);
+        // Pre-expire the tokens (TTL already in the past) so the background eviction executor removes
+        // them on its next scheduled tick without any ~2 s wall-clock wait for the expiry transition.
+        // Only the executor's 1 s scheduling interval remains — not a token-TTL sleep.
+        OffsetDateTime expirationTime = OffsetDateTime.now().minusSeconds(1);
         for (int i = 0; i < 5; i++) {
             String rawToken = "raw-token-" + i;
             AccessTokenContent content = createAccessTokenWithRawToken(
@@ -643,7 +639,8 @@ class AccessTokenCacheTest {
         // Then - verify all 5 tokens are in cache
         assertEquals(5, cache.size());
 
-        // Use awaitility with shorter timeout
+        // Await only the background executor's next scheduled tick (interval 1 s); the tokens are
+        // already past their TTL, so there is no wall-clock wait for the expiry transition itself.
         await()
                 .atMost(4, TimeUnit.SECONDS)
                 .pollInterval(200, TimeUnit.MILLISECONDS)

--- a/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/security/JkuX5uAttackTest.java
+++ b/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/security/JkuX5uAttackTest.java
@@ -16,102 +16,126 @@
 package de.cuioss.sheriff.token.validation.security;
 
 import de.cuioss.sheriff.token.commons.events.SecurityEventCounter;
+import de.cuioss.sheriff.token.commons.events.SecurityEventCounter.EventType;
 import de.cuioss.sheriff.token.commons.transport.ParserConfig;
 import de.cuioss.sheriff.token.validation.IssuerConfig;
-import de.cuioss.sheriff.token.validation.TokenType;
 import de.cuioss.sheriff.token.validation.TokenValidator;
 import de.cuioss.sheriff.token.validation.domain.context.AccessTokenRequest;
 import de.cuioss.sheriff.token.validation.exception.TokenValidationException;
-import de.cuioss.sheriff.token.validation.test.InMemoryJWKSFactory;
-import de.cuioss.sheriff.token.validation.test.TestTokenHolder;
-import de.cuioss.sheriff.token.validation.test.junit.TestTokenSource;
-import de.cuioss.test.generator.junit.EnableGeneratorController;
-import de.cuioss.test.juli.junit5.EnableTestLogger;
+import de.cuioss.sheriff.token.validation.test.InMemoryKeyMaterialHandler;
+import io.jsonwebtoken.Jwts;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.api.Test;
 
-import java.util.Base64;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.time.Instant;
+import java.util.Date;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Tests for validating protection against JKU/X5U header abuse attacks.
+ * Certifies the real defense against JKU (JWK Set URL) / X5U (X.509 URL) header-injection attacks (H4).
  * <p>
- * This attack allows attackers to host their own key sets and instruct the token
- * validator to fetch and trust those keys by including JKU (JWK Set URL) or X5U
- * (X.509 URL) headers pointing to attacker-controlled URLs.
+ * A JKU/X5U attack instructs the validator to fetch and trust key material from an attacker-controlled
+ * URL carried in the token header. Token-Sheriff's defense is that it <em>never</em> honors {@code jku}
+ * or {@code x5u}: signature verification is driven exclusively by the pre-configured issuer JWKS, so a
+ * token whose signature only verifies against the attacker's advertised key is rejected.
  * <p>
- * This test verifies that the library correctly rejects tokens with JKU or X5U
- * headers pointing to malicious URLs.
+ * Both tests below construct the attack the honest way (mirroring
+ * {@link WiredNegativePathAttackTest}): the token is <em>re-signed</em> with an attacker RSA key and
+ * carries a {@code jku}/{@code x5u} header pointing at that attacker's key set, while presenting the
+ * configured {@code kid}. If the library honored the header it would fetch the attacker key and accept
+ * the token; because it uses the configured key instead, verification fails with
+ * {@link EventType#SIGNATURE_VALIDATION_FAILED}. A mutation that made the validator fetch keys from the
+ * {@code jku}/{@code x5u} URL would make the attacker signature verify and turn both tests red — so the
+ * rejection is attributable to the named defense, not to an incidental broken signature.
  */
-@EnableTestLogger
-@EnableGeneratorController
 @DisplayName("Tests for JKU/X5U Header Abuse Protection")
 class JkuX5uAttackTest {
+
+    private static final String TEST_ISSUER = "https://jku-x5u-attack-test.example.com";
+    private static final String TEST_AUDIENCE = "test-client";
+    private static final String DEFAULT_KEY_ID = InMemoryKeyMaterialHandler.DEFAULT_KEY_ID;
+    private static final String ATTACKER_JKU = "https://attacker-controlled-site.com/jwks.json";
+    private static final String ATTACKER_X5U = "https://attacker-controlled-site.com/keys.pem";
 
     private TokenValidator tokenValidator;
 
     @BeforeEach
     void setUp() {
-        // Create issuer config with JWKS content
         IssuerConfig issuerConfig = IssuerConfig.builder()
-                .issuerIdentifier(TestTokenHolder.TEST_ISSUER)
-                .expectedAudience("test-client")
-                .jwksContent(InMemoryJWKSFactory.createDefaultJwks())
+                .issuerIdentifier(TEST_ISSUER)
+                .expectedAudience(TEST_AUDIENCE)
+                .jwksContent(InMemoryKeyMaterialHandler.createDefaultJwks())
                 .build();
-
-        // Create validation factory
-        tokenValidator = TokenValidator.builder().parserConfig(ParserConfig.builder().build()).issuerConfig(issuerConfig).build();
-
+        tokenValidator = TokenValidator.builder()
+                .parserConfig(ParserConfig.builder().build())
+                .issuerConfig(issuerConfig)
+                .build();
     }
 
-    @ParameterizedTest
-    @TestTokenSource(value = TokenType.ACCESS_TOKEN, count = 3)
-    @DisplayName("Should reject tokens with JKU header pointing to malicious URL")
-    void shouldRejectTokenWithJkuHeader(TestTokenHolder tokenHolder) {
-        String validToken = tokenHolder.getRawToken();
-        String[] parts = validToken.split("\\.");
+    @Test
+    @DisplayName("Should reject a token whose signature only verifies against a JKU-advertised attacker key")
+    void shouldRejectTokenWithJkuHeader() {
+        // Attacker signs the token with their own key and advertises the matching key set via `jku`,
+        // presenting the configured kid. The validator ignores `jku` and verifies against the configured
+        // key, so the attacker signature fails — proving the library never fetched the advertised keys.
+        String forged = forgeAttackerToken("jku", ATTACKER_JKU);
 
-        String header = parts[0];
-        byte[] headerBytes = Base64.getUrlDecoder().decode(header);
-        String headerJson = new String(headerBytes);
-
-        String maliciousJku = "\"jku\":\"https://attacker-controlled-site.com/jwks.json\"";
-        String tamperedHeaderJson = headerJson.substring(0, headerJson.length() - 1) + "," + maliciousJku + "}";
-        String tamperedHeader = Base64.getUrlEncoder().withoutPadding().encodeToString(tamperedHeaderJson.getBytes());
-        String tamperedToken = tamperedHeader + "." + parts[1] + "." + parts[2];
-
-        var jkuRequest = AccessTokenRequest.of(tamperedToken);
-        assertThrows(TokenValidationException.class,
-                () -> tokenValidator.createAccessToken(jkuRequest),
-                "Should reject token with malicious JKU header");
-        assertTrue(tokenValidator.getSecurityEventCounter().getCount(SecurityEventCounter.EventType.SIGNATURE_VALIDATION_FAILED) >= 0,
-                "Security event counter should track JKU header attack attempts");
+        var request = AccessTokenRequest.of(forged);
+        var ex = assertThrows(TokenValidationException.class,
+                () -> tokenValidator.createAccessToken(request),
+                "A token trusting a jku-advertised attacker key must be rejected");
+        assertEquals(EventType.SIGNATURE_VALIDATION_FAILED, ex.getEventType(),
+                "Rejection must come from the configured-key signature check, not the jku header");
+        assertEquals(1, tokenValidator.getSecurityEventCounter().getCount(EventType.SIGNATURE_VALIDATION_FAILED),
+                "Exactly one signature-validation failure must be recorded for the jku attack");
     }
 
-    @ParameterizedTest
-    @TestTokenSource(value = TokenType.ACCESS_TOKEN, count = 3)
-    @DisplayName("Should reject tokens with X5U header pointing to malicious URL")
-    void shouldRejectTokenWithX5uHeader(TestTokenHolder tokenHolder) {
-        String validToken = tokenHolder.getRawToken();
-        String[] parts = validToken.split("\\.");
+    @Test
+    @DisplayName("Should reject a token whose signature only verifies against an X5U-advertised attacker key")
+    void shouldRejectTokenWithX5uHeader() {
+        // Same honest construction as the jku case, advertising the attacker key set via `x5u`.
+        String forged = forgeAttackerToken("x5u", ATTACKER_X5U);
 
-        String header = parts[0];
-        byte[] headerBytes = Base64.getUrlDecoder().decode(header);
-        String headerJson = new String(headerBytes);
+        var request = AccessTokenRequest.of(forged);
+        var ex = assertThrows(TokenValidationException.class,
+                () -> tokenValidator.createAccessToken(request),
+                "A token trusting an x5u-advertised attacker key must be rejected");
+        assertEquals(EventType.SIGNATURE_VALIDATION_FAILED, ex.getEventType(),
+                "Rejection must come from the configured-key signature check, not the x5u header");
+        assertEquals(1, tokenValidator.getSecurityEventCounter().getCount(EventType.SIGNATURE_VALIDATION_FAILED),
+                "Exactly one signature-validation failure must be recorded for the x5u attack");
+    }
 
-        String maliciousX5u = "\"x5u\":\"https://attacker-controlled-site.com/keys.pem\"";
-        String tamperedHeaderJson = headerJson.substring(0, headerJson.length() - 1) + "," + maliciousX5u + "}";
-        String tamperedHeader = Base64.getUrlEncoder().withoutPadding().encodeToString(tamperedHeaderJson.getBytes());
-        String tamperedToken = tamperedHeader + "." + parts[1] + "." + parts[2];
+    /**
+     * Builds a well-formed RS256 access token signed with a freshly generated attacker key and carrying
+     * a {@code jku}/{@code x5u} header pointing at the attacker's advertised key set. The configured
+     * {@code kid} and issuer are used so validation reaches (and fails at) the signature check.
+     */
+    private String forgeAttackerToken(String headerName, String attackerUrl) {
+        KeyPair attackerKeyPair = generateRsaKeyPair();
+        return Jwts.builder()
+                .header().keyId(DEFAULT_KEY_ID).add(headerName, attackerUrl).and()
+                .issuer(TEST_ISSUER)
+                .subject("attacker")
+                .audience().add(TEST_AUDIENCE).and()
+                .issuedAt(Date.from(Instant.now()))
+                .expiration(Date.from(Instant.now().plusSeconds(3600)))
+                .signWith(attackerKeyPair.getPrivate(), Jwts.SIG.RS256)
+                .compact();
+    }
 
-        var x5uRequest = AccessTokenRequest.of(tamperedToken);
-        assertThrows(TokenValidationException.class,
-                () -> tokenValidator.createAccessToken(x5uRequest),
-                "Should reject token with malicious X5U header");
-        assertTrue(tokenValidator.getSecurityEventCounter().getCount(SecurityEventCounter.EventType.SIGNATURE_VALIDATION_FAILED) >= 0,
-                "Security event counter should track X5U header attack attempts");
+    private static KeyPair generateRsaKeyPair() {
+        try {
+            KeyPairGenerator gen = KeyPairGenerator.getInstance("RSA");
+            gen.initialize(2048);
+            return gen.generateKeyPair();
+        } catch (java.security.NoSuchAlgorithmException e) {
+            throw new IllegalStateException("RSA not available", e);
+        }
     }
 }

--- a/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/security/JkuX5uAttackTest.java
+++ b/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/security/JkuX5uAttackTest.java
@@ -15,7 +15,6 @@
  */
 package de.cuioss.sheriff.token.validation.security;
 
-import de.cuioss.sheriff.token.commons.events.SecurityEventCounter;
 import de.cuioss.sheriff.token.commons.events.SecurityEventCounter.EventType;
 import de.cuioss.sheriff.token.commons.transport.ParserConfig;
 import de.cuioss.sheriff.token.validation.IssuerConfig;

--- a/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/test/dispatcher/TokenDispatcher.java
+++ b/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/test/dispatcher/TokenDispatcher.java
@@ -17,9 +17,7 @@ package de.cuioss.sheriff.token.validation.test.dispatcher;
 
 import de.cuioss.test.mockwebserver.dispatcher.HttpMethodMapper;
 import de.cuioss.test.mockwebserver.dispatcher.ModuleDispatcherElement;
-import lombok.Getter;
 import lombok.NonNull;
-import lombok.Setter;
 import mockwebserver3.MockResponse;
 import mockwebserver3.RecordedRequest;
 import okhttp3.Headers;
@@ -28,6 +26,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static jakarta.servlet.http.HttpServletResponse.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -53,20 +52,36 @@ public class TokenDispatcher implements ModuleDispatcherElement {
      */
     public static final String LOCAL_PATH = "/oidc/token";
 
-    @Getter
-    @Setter
-    private int callCounter = 0;
+    private final AtomicInteger callCounter = new AtomicInteger();
     private ResponseStrategy responseStrategy = ResponseStrategy.DEFAULT;
 
     /** Caller-shaped response body/status that overrides the strategy switch when {@code customStatus >= 0}. */
-    private int customStatus = -1;
-    private String customBody = "";
+    private volatile int customStatus = -1;
+    private volatile String customBody = "";
 
     /** Optional per-redeem gate: when set, each call blocks (bounded 10 s) until the latch releases. */
-    private CountDownLatch redeemGate;
+    private volatile CountDownLatch redeemGate;
 
     public TokenDispatcher() {
         // No initialization needed
+    }
+
+    /**
+     * Return the number of times this endpoint has been called.
+     *
+     * @return the current call count
+     */
+    public int getCallCounter() {
+        return callCounter.get();
+    }
+
+    /**
+     * Set the call count. Retained for callers that reset the counter to a known value.
+     *
+     * @param value the new call count
+     */
+    public void setCallCounter(int value) {
+        callCounter.set(value);
     }
 
     /**
@@ -117,7 +132,7 @@ public class TokenDispatcher implements ModuleDispatcherElement {
         this.customStatus = -1;
         this.customBody = "";
         this.redeemGate = null;
-        this.callCounter = 0;
+        this.callCounter.set(0);
     }
 
     /**
@@ -172,7 +187,7 @@ public class TokenDispatcher implements ModuleDispatcherElement {
 
     @Override
     public Optional<MockResponse> handlePost(@NonNull RecordedRequest request) {
-        callCounter++;
+        callCounter.incrementAndGet();
         awaitGate();
         Headers json = Headers.of("Content-Type", "application/json");
         if (customStatus >= 0) {
@@ -251,7 +266,7 @@ public class TokenDispatcher implements ModuleDispatcherElement {
      * @param expected count of calls
      */
     public void assertCallsAnswered(int expected) {
-        assertEquals(expected, callCounter);
+        assertEquals(expected, callCounter.get());
     }
 
     /**

--- a/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/test/dispatcher/TokenDispatcher.java
+++ b/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/test/dispatcher/TokenDispatcher.java
@@ -26,6 +26,8 @@ import okhttp3.Headers;
 
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static jakarta.servlet.http.HttpServletResponse.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -56,8 +58,66 @@ public class TokenDispatcher implements ModuleDispatcherElement {
     private int callCounter = 0;
     private ResponseStrategy responseStrategy = ResponseStrategy.DEFAULT;
 
+    /** Caller-shaped response body/status that overrides the strategy switch when {@code customStatus >= 0}. */
+    private int customStatus = -1;
+    private String customBody = "";
+
+    /** Optional per-redeem gate: when set, each call blocks (bounded 10 s) until the latch releases. */
+    private CountDownLatch redeemGate;
+
     public TokenDispatcher() {
         // No initialization needed
+    }
+
+    /**
+     * Serve a caller-shaped JSON body with HTTP 200, overriding the strategy-based response.
+     * <p>
+     * This is the hook the client flow tests use to return a real signed JWT the validation pipeline
+     * accepts — the fixed {@link #defaultTokenResponse()} carries a placeholder token that cannot be
+     * validated, so a flow test that redeems and validates a token supplies its own signed body here.
+     *
+     * @param jsonBody the exact JSON body to return
+     * @return this instance for method chaining
+     */
+    public TokenDispatcher respondWith(String jsonBody) {
+        return respondWith(SC_OK, jsonBody);
+    }
+
+    /**
+     * Serve a caller-shaped body with an explicit status, overriding the strategy-based response.
+     *
+     * @param status   the HTTP status to return
+     * @param jsonBody the exact body to return
+     * @return this instance for method chaining
+     */
+    public TokenDispatcher respondWith(int status, String jsonBody) {
+        this.customStatus = status;
+        this.customBody = jsonBody;
+        return this;
+    }
+
+    /**
+     * Hold each redeem until {@code gate} releases (bounded 10 s). Left {@code null} the dispatcher
+     * never blocks; a single-flight test installs a latch to prove concurrent refreshes collapse onto
+     * one redeem.
+     *
+     * @param gate the latch each redeem awaits, or {@code null} to remove the gate
+     * @return this instance for method chaining
+     */
+    public TokenDispatcher blockUntil(CountDownLatch gate) {
+        this.redeemGate = gate;
+        return this;
+    }
+
+    /**
+     * Reset to the default strategy and clear any custom body, redeem gate, and call counter.
+     */
+    public void reset() {
+        this.responseStrategy = ResponseStrategy.DEFAULT;
+        this.customStatus = -1;
+        this.customBody = "";
+        this.redeemGate = null;
+        this.callCounter = 0;
     }
 
     /**
@@ -113,7 +173,11 @@ public class TokenDispatcher implements ModuleDispatcherElement {
     @Override
     public Optional<MockResponse> handlePost(@NonNull RecordedRequest request) {
         callCounter++;
+        awaitGate();
         Headers json = Headers.of("Content-Type", "application/json");
+        if (customStatus >= 0) {
+            return Optional.of(new MockResponse(customStatus, json, customBody));
+        }
         return switch (responseStrategy) {
             case OAUTH_ERROR -> Optional.of(new MockResponse(SC_BAD_REQUEST, json,
                     "{\"error\":\"invalid_grant\",\"error_description\":\"The provided grant is invalid.\"}"));
@@ -122,6 +186,40 @@ public class TokenDispatcher implements ModuleDispatcherElement {
             case OVERSIZED_BODY -> Optional.of(new MockResponse(SC_OK, json, AdversarialResponses.oversizedJson()));
             default -> Optional.of(new MockResponse(SC_OK, json, defaultTokenResponse()));
         };
+    }
+
+    /**
+     * Build an RFC 6749 §5.1 token-endpoint success body carrying the supplied material. A
+     * {@code null} refresh or ID token omits that member; this is the shared body-builder the client
+     * flow tests use with {@link #respondWith(String)} to return real signed tokens.
+     *
+     * @param accessToken  the {@code access_token} value; must not be {@code null}
+     * @param refreshToken the {@code refresh_token} value, or {@code null} to omit it
+     * @param idToken      the {@code id_token} value, or {@code null} to omit it
+     * @param expiresIn    the {@code expires_in} value in seconds
+     * @return the JSON token-endpoint response body
+     */
+    public static String tokenResponse(String accessToken, String refreshToken, String idToken, long expiresIn) {
+        StringBuilder json = new StringBuilder("{\"access_token\":\"").append(accessToken)
+                .append("\",\"token_type\":\"Bearer\",\"expires_in\":").append(expiresIn);
+        if (refreshToken != null) {
+            json.append(",\"refresh_token\":\"").append(refreshToken).append('"');
+        }
+        if (idToken != null) {
+            json.append(",\"id_token\":\"").append(idToken).append('"');
+        }
+        return json.append('}').toString();
+    }
+
+    private void awaitGate() {
+        CountDownLatch gate = this.redeemGate;
+        if (gate != null) {
+            try {
+                gate.await(10, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
     }
 
     private String defaultTokenResponse() {


### PR DESCRIPTION
## Summary

Remediate the 12 still-open / partial findings enumerated in `remediation-delta-report.md`
(verified against `main`@`591387ce`). Every code-reference premise in the report was
re-confirmed valid against the current codebase before implementation, so each open item became
a bounded, atomic deliverable spanning `token-sheriff-client`, `token-sheriff-validation`, and
`token-sheriff-quarkus-parent/token-sheriff-client-quarkus`. Two operator clarifications are
baked in: item 5 (COMMONS-11) takes the **implement** branch (a new inbound-error normalizer in
commons — code catches up to the already-correct spec), and item 12 (flake) takes the
**root-cause** branch (a durable fix for the JDK 25 generator collision, not a re-trigger/skip).

## Changes

- **S0 / Δ-1 — CI-enforcement gap**: bind `maven-failsafe-plugin` in
  `token-sheriff-client/pom.xml` with an explicit version and `integration-test`/`verify`
  executions, so `WiredFlowNegativePathIT` actually runs under `mvn verify`.
- **H4 — jku/x5u tamper-without-resign**: rewrite `JkuX5uAttackTest` to re-sign the tampered
  token before submission, so rejection is attributable to the `jku`/`x5u` header defense rather
  than an incidental broken signature; replace always-true `>= 0` counter assertions with exact
  `SecurityEventCounter` expectations.
- **L1 / TEST-5 — missing HTTPS mock coverage**: add `WiredFlowHttpsTest`, a new unit-level test
  exercising the back-channel flow over MockWebServer TLS (`useHttps = true`, no
  `allowInsecureHttp(true)`).
- **M8 — unsanitized `e.getMessage()`**: sanitize the AS-controlled DSL-JSON parse-error fragment
  via `LogSanitizer.sanitize(...)` at the three residual sites in `TokenEndpointClient`,
  `UserInfoClient`, and `ParClient`, with new CR/LF/control-char sanitization tests.
- **COMMONS-11 — inbound error normalization (implement branch)**: add
  `InboundErrorNormalizer` in `token-sheriff-validation` (`commons.error`) to sanitize and
  normalize inbound OAuth `error`/`error_description` per RFC 6749 §5.2; `CallbackHandler` now
  routes its error-callback rejection through the shared normalizer instead of an ad-hoc inline
  check.
- **L12 — missing `@NullMarked`**: apply `@NullMarked` to the eight previously-unmarked client
  subpackages (`flow`, `token`, `auth`, `dpop`, `config`, `discovery`, `logout`, and the newly
  created `internal/package-info.java`).
- **M14 — clock-edge / concurrency test gaps**: add an exact clock-edge boundary test and a true
  concurrent refresh-vs-logout race test to `TokenLifecycleManagerTest`.
- **L13 — wall-clock expiry test**: rewrite the two expiry-dependent `AccessTokenCacheTest` cases
  to advance the injected clock instead of relying on a real ~2s wait.
- **L3 — duplicated dispatcher inner classes**: replace the five hand-rolled
  `TokenEndpointDispatcher` inner classes (in `AuthorizationCodeFlowTest`, `RefreshFlowTest`,
  `ClientCredentialsFlowTest`, `ClientSecretAuthTest`, `RotationReuseDetectionTest`) with the
  shared commons test-jar dispatcher.
- **L20 — stale "increment" references**: remove residual plan-internal roadmap language from
  `flow/package-info.java`, `dpop/package-info.java`, `dpop/SenderConstraint.java`,
  `dpop/ConstraintBinding.java`, and `lifecycle/StoredToken.java`.
- **H3 caveat — DPoP-capable authorization-code redemption**: give `AuthorizationCodeFlow` an
  optional `SenderConstraint` and route `exchange()` through the DPoP-capable 4-arg
  `requestToken` overload; update the Quarkus CDI producer
  (`TokenSheriffClientProducer`) for the new constructor arity (passing `null`, preserving
  current plain-bearer wiring).
- **Flake — `ParClientTest.shouldReturnRequestUri`**: root-cause and fix the JDK 25
  `cui-test-generator` value collision so the test is deterministic across repeated runs.

## Test Plan

- [x] `mvn verify -pl token-sheriff-client -am` passed (`WiredFlowNegativePathIT` now executes;
  all client unit/IT tests green).
- [x] `mvn verify -pl token-sheriff-validation -am` passed (`InboundErrorNormalizerTest`,
  `JkuX5uAttackTest`, `AccessTokenCacheTest` green).
- [x] `ParClientTest.shouldReturnRequestUri` verified deterministic across repeated runs on JDK 25.

## Related Issues

None.

---
Generated by plan-finalize skill


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authorization-code exchanges can optionally bind redeemed tokens to a DPoP or mTLS sender constraint.
  * Improved handling for authorization-code flows with stricter redirect-URI validation.
  * Added package-level null-safety annotations across client modules.
* **Security**
  * OAuth callback errors and multiple parse-error paths are sanitized to prevent control-character injection into logs/exceptions.
  * Strengthened coverage against malicious JWT key-reference headers.
* **Bug Fixes**
  * Integration tests now run during the standard Maven verification lifecycle.
  * Improved token refresh concurrency behavior to prevent revoked-session restoration.
* **Tests**
  * Added/expanded regression tests for sanitization and sender-constraint exchange behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->