### PR TITLE
fix(quarkus-integration-tests): declare explicit client-quarkus-deployment dependency

### DIFF
--- a/token-sheriff-quarkus-parent/token-sheriff-quarkus-integration-tests/pom.xml
+++ b/token-sheriff-quarkus-parent/token-sheriff-quarkus-integration-tests/pom.xml
@@ -60,6 +60,17 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Client Deployment Module for Quarkus Extension: explicit dependency forces correct
+             reactor ordering under the -T1C parallel build (Quarkus's implicit runtime->deployment
+             artifact linkage is invisible to Maven's dependency graph), mirroring the validation
+             deployment module above. -->
+        <dependency>
+            <groupId>de.cuioss.sheriff.token</groupId>
+            <artifactId>token-sheriff-client-quarkus-deployment</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
         <!-- Dev-UI runtime: required for Dev-UI to work in dev mode.
              The conditional-dev-dependency mechanism in quarkus-vertx-http should
              automatically include this in dev mode, but fails to resolve the


### PR DESCRIPTION
## Summary
- Release 0.9.2's automated Release workflow failed during `release:perform`: `token-sheriff-quarkus-integration-tests` couldn't resolve `token-sheriff-client-quarkus-deployment:jar:0.9.2` from any repo.
- Root cause: under the `-T1C` parallel reactor build (`.mvn/maven.config`), Maven only enforces build ordering via explicit POM dependency edges. Quarkus's implicit runtime→deployment artifact linkage isn't visible to Maven's graph, so the deployment module could be scheduled after (or concurrently with) the integration-tests module's `generate-code` phase, which needs it already installed.
- Fix: add an explicit test-scope dependency on `token-sheriff-client-quarkus-deployment`, mirroring the existing `token-sheriff-validation-quarkus-deployment` dependency that already works around this for the other extension.

## Test plan
- [x] `./mvnw -B install -DskipTests -pl token-sheriff-quarkus-parent/token-sheriff-client-quarkus-deployment,token-sheriff-quarkus-parent/token-sheriff-quarkus-integration-tests -am` succeeds locally under the repo's default `-T1C` parallel build
- [ ] CI green
- [ ] Retry the 0.9.2 Release workflow after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved integration test build reliability and consistency.
  * Parallel builds now follow the correct module build order, reducing potential build failures and improving development workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->