### PR TITLE
docs: refresh stale AsciiDoc/README status across modules

### DIFF
--- a/.plan/project-architecture/benchmarking-common/enriched.json
+++ b/.plan/project-architecture/benchmarking-common/enriched.json
@@ -1,6 +1,8 @@
 {
   "best_practices": [],
-  "insights": [],
+  "insights": [
+    "Pre-existing JaCoCo coverage baseline debt: instruction 0.70 and branch 0.57 are below the 0.80 threshold. Standing debt predating current work \u2014 coverage-threshold Q-Gate findings against this module on unrelated plans are expected and were accepted (plan full-review-adoc-documents, 2026-07-16). All tests pass; the shortfall is baseline, not regression."
+  ],
   "internal_dependencies": [],
   "key_dependencies": [
     "org.openjdk.jmh:jmh-core",

--- a/.plan/project-architecture/token-sheriff-validation/enriched.json
+++ b/.plan/project-architecture/token-sheriff-validation/enriched.json
@@ -1,6 +1,8 @@
 {
   "best_practices": [],
-  "insights": [],
+  "insights": [
+    "Pre-existing JaCoCo coverage baseline debt: branch coverage 0.75 is below the 0.80 threshold. Standing debt predating current work \u2014 coverage-threshold Q-Gate findings against this module on unrelated plans are expected and were accepted (plan full-review-adoc-documents, 2026-07-16). All tests pass; the shortfall is baseline, not regression."
+  ],
   "internal_dependencies": [],
   "key_dependencies": [
     "de.cuioss:cui-java-tools",

--- a/README.md
+++ b/README.md
@@ -174,9 +174,9 @@ For detailed architectural information, see:
 | Module | Description |
 | --- | --- |
 | [`token-sheriff-validation`](token-sheriff-validation/README.adoc) | Core JWT validation engine. Also carries the `commons` base layer (`de.cuioss.sheriff.token.commons.*`: transport, error model, events, metrics), enforced by ArchUnit. |
-| [`token-sheriff-client`](token-sheriff-client/README.adoc) | Framework-agnostic OIDC/OAuth **client** engine (token retrieval, userinfo, revocation, introspection, end-session, PAR). Depends on `token-sheriff-validation`. _Wired, empty skeleton (Plan 05) — no functional content yet._ |
+| [`token-sheriff-client`](token-sheriff-client/README.adoc) | Framework-agnostic OIDC/OAuth **client** engine: OIDC discovery, authorization-code / client-credentials / refresh flows with PKCE and PAR, client authentication (`client_secret_basic`/`client_secret_post`, `private_key_jwt`, mTLS), DPoP proof generation, token lifecycle management (store, refresh scheduling, revocation), logout/end-session, and userinfo. Depends on `token-sheriff-validation`. |
 | [`token-sheriff-validation-quarkus`](token-sheriff-quarkus-parent/README.adoc) | Quarkus extension (runtime + deployment) for token validation. |
-| `token-sheriff-client-quarkus` | Quarkus extension (runtime + deployment) that wires the client engine into Quarkus, building on the validation extension. _Wired, empty skeleton (Plan 05)._ |
+| `token-sheriff-client-quarkus` | Quarkus extension (runtime + deployment) that wires the client engine into Quarkus: CDI producer (`TokenSheriffClientProducer`), configuration mapping (`ClientRuntimeConfig`), and exception mapping, building on the validation extension. |
 | [`bom`](bom/pom.xml) | Bill of Materials for all Token-Sheriff artifacts. |
 | [`benchmarking`](benchmarking/README.adoc) | JMH micro-benchmarks and WRK integration load tests. |
 

--- a/benchmarking/README.adoc
+++ b/benchmarking/README.adoc
@@ -1,6 +1,6 @@
 = Token-Sheriff Benchmarking
-:toc:
-:toclevels: 2
+:toc: left
+:toclevels: 3
 :toc-title: Table of Contents
 :sectnums:
 :source-highlighter: highlight.js
@@ -165,6 +165,8 @@ See link:doc/workflow.adoc[Benchmark Workflow] for the complete process.
 
 * link:doc/Analysis-03.2026-Integration.adoc[Integration Benchmark Analysis (March 2026)] - WRK-based HTTP load testing with resource monitoring
 * link:doc/Analysis-03.2026-Micro.adoc[Micro-Benchmark Analysis (March 2026)] - JMH library performance and validation pipeline breakdown
+* link:doc/Analysis-03.2026-JFR-Profiling.adoc[JFR Profiling Analysis (March 2026)] - JFR-based variance and hotspot analysis
+* link:doc/Analysis-03.2026-Latency-Decomposition.adoc[Latency Decomposition Analysis (March 2026)] - End-to-end latency breakdown
 
 == Development
 

--- a/benchmarking/benchmark-core/README.adoc
+++ b/benchmarking/benchmark-core/README.adoc
@@ -58,11 +58,11 @@ Performance benchmarking for JWT token validation core library using JMH.
 ----
 # Single benchmark
 ./mvnw clean verify -pl benchmarking/benchmark-core -Pbenchmark \
-  -Djmh.include=TokenValidatorBenchmark
+  -Djmh.include=SimpleCoreValidationBenchmark
 
 # Multiple benchmarks
 ./mvnw clean verify -pl benchmarking/benchmark-core -Pbenchmark \
-  -Djmh.include="TokenValidator|JwksClient"
+  -Djmh.include="SimpleCoreValidation|SimpleErrorLoad"
 ----
 
 == Benchmarks
@@ -74,7 +74,6 @@ Performance benchmarking for JWT token validation core library using JMH.
 
 === JFR-Enabled Benchmarks
 
-* `UnifiedJfrBenchmark` - Combined benchmark with Java Flight Recorder integration
 * `CoreJfrBenchmark` - Core validation with JFR profiling
 * `ErrorJfrBenchmark` - Error scenarios with JFR profiling
 * `MixedJfrBenchmark` - Mixed validation scenarios with JFR profiling

--- a/benchmarking/benchmarking-common/README.adoc
+++ b/benchmarking/benchmarking-common/README.adoc
@@ -17,30 +17,20 @@ This module provides centralized components used by all benchmark modules to ens
 [source]
 ----
 de.cuioss.benchmarking.common/
-├── base/                    # Abstract benchmark base classes
 ├── config/                  # Configuration management
 ├── constants/               # Benchmark constants
 ├── converter/               # Result format converters (JMH, WRK)
 ├── http/                    # HTTP client utilities
 ├── jfr/                     # Java Flight Recorder integration
-├── metrics/                 # Metrics collection interfaces
+├── metrics/                 # Metrics collection and Prometheus integration
 ├── model/                   # Benchmark data model
 ├── output/                  # Output directory structure management
 ├── report/                  # Report and artifact generation
-├── repository/              # Token and data repositories
 ├── runner/                  # Benchmark execution orchestration
-├── token/                   # Token provider abstraction
 └── util/                    # General utilities and helpers
 ----
 
 == Components
-
-=== Benchmark Base Classes (`base/`)
-
-* **AbstractBenchmarkBase** - Abstract base class for all benchmark implementations
-  - Logging infrastructure and HTTP client management
-  - Common configuration fields and utility methods for HTTP operations
-  - Metrics export hooks
 
 === Configuration Management (`config/`)
 
@@ -60,9 +50,6 @@ de.cuioss.benchmarking.common/
   - Benchmark names for throughput and latency tests
   - Project name for dashboard display
 
-* **IntegrationConfiguration** - Configuration record for integration benchmarks
-  - Service URLs and metrics endpoints
-
 === Constants (`constants/`)
 
 * **BenchmarkConstants** - Consolidated constants using DSL-Style Nested Constants Pattern
@@ -75,6 +62,7 @@ de.cuioss.benchmarking.common/
 * **BenchmarkConverter** - Interface for converting benchmark formats to central BenchmarkData model
 * **JmhBenchmarkConverter** - Converts JMH JSON results to BenchmarkData
 * **WrkBenchmarkConverter** - Converts WRK benchmark output to BenchmarkData
+* **ReportMetadataFactory** - Builds report metadata shared by the converters
 
 === HTTP Utilities (`http/`)
 
@@ -88,7 +76,6 @@ de.cuioss.benchmarking.common/
 
 * **JfrInstrumentation** - Central management for JFR event recording
 * **JfrVarianceAnalyzer** - Analysis of JFR recordings for variance metrics
-* **JfrSupport** - Detection and validation of JFR availability
 * **OperationEvent** - Custom JFR event for individual operation tracking
 * **OperationStatisticsEvent** - Custom JFR event for periodic statistics
 * **BenchmarkPhaseEvent** - Custom JFR event for benchmark lifecycle phases
@@ -106,11 +93,7 @@ de.cuioss.benchmarking.common/
 
 * **PrometheusClient** - Low-level HTTP client for Prometheus API queries
 
-* **IterationTimestampParser** - Parses JMH iteration timestamp data for precise metrics windows
-
 * **BenchmarkMetricsTransformer** - Transforms raw benchmark data into metrics format
-
-* **MetricsTransformer** - General metrics transformation utilities
 
 * **MetricsJsonExporter** - Exports metrics data to JSON format
 
@@ -164,28 +147,6 @@ de.cuioss.benchmarking.common/
   - API endpoints for programmatic access
   - SEO optimization (robots.txt, sitemap.xml)
 
-=== Repository Components (`repository/`)
-
-* **KeycloakTokenRepository** - JWT token management for benchmarks
-  - Token pool management with rotation
-  - Keycloak integration for token fetching
-  - Shared instance pattern for benchmark reuse
-  - Configurable pool size and refresh thresholds
-  - Implements TokenProvider interface
-
-* **TokenRepositoryConfig** - Configuration for TokenRepository
-  - Keycloak connection parameters
-  - Authentication credentials
-  - Timeout and SSL verification settings
-  - Token refresh thresholds
-
-=== Token Abstraction (`token/`)
-
-* **TokenProvider** - Common interface for providing JWT tokens for benchmark testing
-  - Abstracts token provisioning mechanism for different implementations
-  - Supports MockTokenRepository (in-memory) and KeycloakTokenRepository (real tokens)
-  - Efficient token rotation for realistic usage patterns
-
 === Benchmark Execution (`runner/`)
 
 * **AbstractBenchmarkRunner** - Abstract base class for benchmark execution
@@ -200,12 +161,6 @@ de.cuioss.benchmarking.common/
   - Creates GitHub Pages deployment structure
 
 === Utilities (`util/`)
-
-* **BenchmarkLoggingSetup** - Unified logging configuration
-  - Dual output to console and timestamped log files
-  - Captures System.out/err and JMH output
-  - Configurable log levels and package filtering
-  - Automatic cleanup and reset capabilities
 
 * **BenchmarkingLogMessages** - Centralized log message definitions
   - Consistent logging format across modules
@@ -255,26 +210,6 @@ public class MyBenchmarkRunner extends AbstractBenchmarkRunner {
         new MyBenchmarkRunner().runBenchmark();
     }
 }
-----
-
-=== Setup Token Repository
-
-[source,java]
-----
-import de.cuioss.benchmarking.common.repository.KeycloakTokenRepository;
-import de.cuioss.benchmarking.common.repository.TokenRepositoryConfig;
-
-TokenRepositoryConfig config = TokenRepositoryConfig.builder()
-    .keycloakBaseUrl("https://localhost:1443")
-    .realm("benchmark")
-    .clientId("benchmark-client")
-    .clientSecret("benchmark-secret")
-    .tokenPoolSize(100)
-    .verifySsl(false)
-    .build();
-
-KeycloakTokenRepository repository = new KeycloakTokenRepository(config);
-String token = repository.getNextToken();
 ----
 
 === Collect Metrics

--- a/benchmarking/benchmarking-common/doc/LogMessages.adoc
+++ b/benchmarking/benchmarking-common/doc/LogMessages.adoc
@@ -29,74 +29,46 @@ All messages follow the format: `Benchmarking-[identifier]: [message]`
 | 004 | ARTIFACTS_GENERATED | All artifacts generated successfully
 | 005 | PROCESSING_RESULTS | Processing %s benchmark results to generate artifacts
 | 006 | BENCHMARK_TYPE_DETECTED | Detected benchmark type: %s
-| 007 | GENERATING_BADGES | Generating performance badges for %s benchmarks
-| 008 | GENERATING_METRICS | Generating performance metrics
 | 009 | GENERATING_REPORTS | Generating HTML reports
 | 010 | GENERATING_GITHUB_PAGES | Generating GitHub Pages deployment structure
-| 011 | WRITING_SUMMARY | Writing benchmark summary file
-| 012 | GENERATING_METRICS_JSON | Generating metrics JSON for %s benchmark results
 | 013 | METRICS_FILE_GENERATED | Generated metrics file: %s
-| 014 | INDIVIDUAL_METRICS_GENERATED | Generated %s individual metric files
 | 015 | BADGE_GENERATED | Generated %s badge: %s
 | 016 | PREPARING_GITHUB_PAGES | Preparing GitHub Pages deployment structure
-| 017 | SOURCE_DIRECTORY | Source: %s
 | 018 | DEPLOY_DIRECTORY | Deploy: %s
 | 019 | GITHUB_PAGES_READY | GitHub Pages deployment structure ready
 | 020 | GENERATING_INDEX_PAGE | Generating index page for %s benchmark results
 | 021 | INDEX_PAGE_GENERATED | Generated index page: %s
 | 022 | GENERATING_TRENDS_PAGE | Generating trends page
 | 023 | TRENDS_PAGE_GENERATED | Generated trends page: %s
-| 024 | WRITING_BENCHMARK_SUMMARY | Writing benchmark summary for %s %s results
-| 025 | SUMMARY_FILE_GENERATED | Generated summary file: %s
 | 026 | JMH_RESULT_COPIED | Copied JMH result to data directory: %s
 | 027 | JWT_BENCHMARKS_STARTING | JWT validation micro benchmarks starting - Key cache initialized
 | 028 | KEY_PREGENERATION_STARTING | BenchmarkKeyCache: Starting RSA key pre-generation...
 | 029 | KEY_PREGENERATION_COMPLETED | BenchmarkKeyCache: Pre-generated keys for %s issuer configurations in %s ms
-| 030 | UNIFIED_REPORT_GENERATION_START | Starting unified report generation
-| 031 | UNIFIED_REPORT_GENERATION_COMPLETE | Unified report generation completed
-| 032 | GENERATING_DATA_FILE | Generating benchmark data JSON file
-| 033 | DATA_FILE_GENERATED | Generated data file: %s
-| 034 | GENERATING_HTML_FILES | Generating HTML report files
-| 035 | HTML_FILES_GENERATED | Generated HTML files in: %s
-| 036 | GENERATING_BADGES_UNIFIED | Generating performance badges
-| 037 | BADGES_GENERATED | Generated badges in: %s
-| 038 | GENERATING_API_ENDPOINTS | Generating API endpoint files
-| 039 | API_ENDPOINTS_GENERATED | Generated API endpoints in: %s
-| 040 | COPYING_PROMETHEUS_METRICS | Copying Prometheus metrics to deployment directory
-| 041 | PROMETHEUS_METRICS_COPIED | Copied Prometheus metrics to: %s
-| 042 | COPYING_SUPPORT_FILES | Copying support files (CSS, JS)
-| 043 | SUPPORT_FILES_COPIED | Copied support files to: %s
 | 044 | KEY_CACHE_INITIALIZED | BenchmarkKeyCache: Initialized with %s configurations
-| 045 | QUARKUS_BENCHMARKS_STARTING | Quarkus JWT integration benchmarks starting - Service: %s, Keycloak: %s
-| 046 | PROCESSING_RESULTS_STARTING | QuarkusIntegrationRunner.processResults() - Starting with %s results
 | 047 | RESULTS_AVAILABLE | Results available at: %s
 | 048 | WRK_PROCESSING_START | Start processing WRK results
 | 049 | JFR_BENCHMARKS_STARTING | JFR-instrumented benchmarks starting - Key cache initialized
 | 050 | JFR_RECORDING_PATH | JFR recording will be saved to: %s
 | 051 | JFR_BENCHMARK_COMPLETED | JFR benchmark completed. To analyze variance:
 | 052 | JFR_VARIANCE_COMMAND | java -cp "target/classes:target/dependency/*" de.cuioss.sheriff.token.validation.benchmark.jfr.JfrVarianceAnalyzer %s
-| 053 | ITERATION_WINDOWS_PARSED | Parsed %s iteration windows from %s
-| 054 | USING_PRECISE_TIMESTAMPS | Using precise timestamps for benchmark '%s': %s to %s
 | 055 | BENCHMARK_RUNNER_STARTING_WITH_DETAILS | Starting CUI benchmark runner - Type: %s, Output: %s
 | 056 | BENCHMARKS_COMPLETED_WITH_ARTIFACTS | Benchmarks completed successfully with %s results, artifacts in %s
 | 057 | PROMETHEUS_ENABLED | Prometheus metrics collection enabled - URL: %s
 | 058 | PROMETHEUS_DISABLED | Prometheus metrics collection disabled - Prometheus not available at: %s
-| 059 | COLLECTING_PROMETHEUS_METRICS | Collecting real-time metrics from Prometheus at: %s
 | 060 | COLLECTING_WRK_PROMETHEUS_METRICS | Collecting real-time metrics for WRK benchmark '%s' from Prometheus
 | 061 | PROMETHEUS_METRICS_SAVED | Prometheus metrics saved to: %s/%s%s
-| 062 | USING_SESSION_TIMESTAMPS | Using session timestamps for benchmark '%s': %s to %s
-| 063 | COLLECTING_BENCHMARK_METRICS | Collecting Prometheus metrics for benchmark '%s'
 | 064 | COLLECTING_REALTIME_METRICS | Collecting real-time metrics for benchmark '%s' from %s to %s
 | 065 | REALTIME_METRICS_EXPORTED | Exported real-time metrics for '%s' to: %s
 | 066 | HTTP_CLIENT_CREATED | Created Java HttpClient with version: %s, timeout: %ss
 | 067 | USING_HTTP_1_1 | Using HTTP/1.1 only (configured via -D%s=http1)
 | 068 | USING_HTTP_2 | Using HTTP/2 (default or -D%s=http2)
 | 069 | PROMETHEUS_CONNECTIVITY_ADVICE | Ensure Prometheus is running and accessible. You can verify with: curl %s/api/v1/query?query=up
-| 070 | USING_EXTERNAL_HISTORY_DIR | Using external history directory: %s
 | 071 | HISTORY_DIR_NOT_FOUND | History directory not found: %s
 | 072 | ARCHIVED_BENCHMARK_DATA | Archived benchmark data to %s
 | 073 | REMOVED_HISTORY_FILE | Removed old history file: %s
 |===
+
+NOTE: Identifier gaps (007, 008, 011, 012, 014, 017, 024, 025, 030-043, 045, 046, 053, 054, 059, 062, 063, 070) belong to messages that have been removed from the class; their identifiers are not reused.
 
 == WARN Level Messages (100-199)
 
@@ -104,34 +76,23 @@ All messages follow the format: `Benchmarking-[identifier]: [message]`
 |===
 | ID | Constant | Message Template
 
-| 100 | FAILED_COPY_HTML | Failed to copy HTML file: %s
-| 101 | FAILED_COPY_BADGE | Failed to copy badge file: %s
-| 102 | FAILED_COPY_DATA | Failed to copy data file: %s
 | 103 | ISSUE_DURING_INDEX_GENERATION | Issue during %s
-| 104 | KEY_CACHE_MISS | BenchmarkKeyCache miss for count=%s. Generating keys during benchmark!
 | 105 | INVALID_METRICS_TYPE | Invalid metrics data type: expected TokenValidatorMonitor, got %s
-| 106 | TIMESTAMP_FILE_NOT_EXIST | Timestamp file does not exist: %s
-| 107 | FAILED_PARSE_TIMESTAMP_LINE | Failed to parse timestamp line: %s
-| 108 | FAILED_PARSE_TIMESTAMP_FILE | Failed to parse timestamp file, using session-wide timestamps: %s
-| 109 | NO_TIMESTAMP_DATA | No timestamp data found for benchmark '%s', using session timestamps
-| 110 | NO_MEASUREMENT_WINDOWS | No measurement windows found for benchmark '%s', using session timestamps
 | 111 | FAILED_QUERY_METRIC | Failed to query metric '%s': %s
-| 112 | OVERWRITING_START_TIME | Overwriting existing start time for benchmark: %s
-| 113 | INVALID_TIMESTAMPS | Invalid timestamps for benchmark '%s': start=%s, end=%s
 | 114 | FAILED_COLLECT_PROMETHEUS | Failed to collect Prometheus metrics: %s
 | 115 | SKIPPING_PROMETHEUS_COLLECTION | Skipping Prometheus metrics collection - Prometheus not available at URL: %s
 | 116 | MISSING_TIMESTAMPS_FOR_COLLECTION | Cannot collect metrics for benchmark '%s' - missing timestamps
-| 117 | NO_VALID_TIMESTAMPS | No valid timestamps found for benchmark '%s', skipping metrics collection. Available timestamps: %s
-| 118 | FAILED_COLLECT_BENCHMARK_METRICS | Failed to collect metrics for benchmark '%s': %s
 | 119 | FAILED_CREATE_TARGET_DIR | Failed to create target directory: %s
 | 120 | FAILED_READ_METRICS_FILE | Failed to read existing metrics file %s: %s
-| 121 | FAILED_DELETE_CORRUPTED_FILE | Failed to delete corrupted metrics file
+| 121 | CORRUPT_METRICS_FILE_PRESERVED | Corrupt metrics file preserved as: %s
 | 122 | UNKNOWN_RESULT_FORMAT | Unknown result format: %s, defaulting to JSON
 | 123 | UNKNOWN_TIME_UNIT | Unknown time unit '%s' in '%s', defaulting to seconds
-| 124 | TOKEN_POOL_EMPTY | Token pool is empty, fetching single token
 | 125 | ISSUE_PARSING_HISTORY_FILE | Issue during parsing history file: %s
 | 126 | SECRET_PROPERTY_ON_FORK_COMMAND_LINE | Secret system property '%s' is forwarded on the forked JVM command line and may be visible in process listings
+| 127 | FAILED_PRESERVE_CORRUPT_FILE | Failed to move corrupt metrics file aside: %s
 |===
+
+NOTE: Identifier gaps (100-102, 104, 106-110, 112, 113, 117, 118, 124) belong to messages that have been removed from the class; their identifiers are not reused.
 
 == ERROR Level Messages (200-299)
 
@@ -155,10 +116,11 @@ All messages follow the format: `Benchmarking-[identifier]: [message]`
 | 213 | FAILED_COLLECT_PROMETHEUS_BENCHMARK | Failed to collect Prometheus metrics for benchmark '%s' from URL: %s
 | 214 | PROMETHEUS_CONNECTIVITY_FAILED | Prometheus connectivity check failed at URL: %s - Error: %s (%s)
 | 215 | FAILED_COLLECT_REALTIME_PROMETHEUS | Failed to collect Prometheus metrics for benchmark '%s': %s
-| 216 | FAILED_FETCH_TOKEN | Failed to fetch token. Status: %s, Body: %s
 | 217 | FAILED_PARSE_WRK_FILE | Failed to parse WRK file: %s
 | 218 | JFR_VARIANCE_USAGE | Usage: JfrVarianceAnalyzer <path-to-jfr-file>
 |===
+
+NOTE: Identifier 216 belonged to a message that has been removed from the class; the identifier is not reused.
 
 == Usage
 
@@ -171,9 +133,9 @@ import static de.cuioss.benchmarking.common.util.BenchmarkingLogMessages.WARN;
 import static de.cuioss.benchmarking.common.util.BenchmarkingLogMessages.ERROR;
 
 // Example usage:
-LOGGER.info(INFO.BENCHMARK_RUNNER_STARTING.format());
-LOGGER.warn(WARN.KEY_CACHE_MISS.format(count));
-LOGGER.error(e, ERROR.EXPORT_FAILED.format());
+LOGGER.info(INFO.BENCHMARK_RUNNER_STARTING_WITH_DETAILS, benchmarkType, outputDir);
+LOGGER.warn(WARN.FAILED_QUERY_METRIC, metricName, errorMessage);
+LOGGER.error(e, ERROR.EXPORT_FAILED);
 ----
 
 == Notes

--- a/benchmarking/doc/Analysis-03.2026-JFR-Profiling.adoc
+++ b/benchmarking/doc/Analysis-03.2026-JFR-Profiling.adoc
@@ -1,7 +1,9 @@
 = JFR Profiling Analysis - March 2026
-:toc:
-:toc-placement: preamble
+:toc: left
 :toclevels: 3
+:toc-title: Table of Contents
+:sectnums:
+:source-highlighter: highlight.js
 
 == Recording Configuration
 

--- a/benchmarking/doc/Architecture.adoc
+++ b/benchmarking/doc/Architecture.adoc
@@ -38,11 +38,11 @@ The Token-Sheriff benchmarking infrastructure consists of three specialized modu
                      │
                      ▼
 ┌─────────────────────────────────────────────────────────┐
-│              benchmarking-common                    │
+│              benchmarking-common                        │
 │  • Benchmark runners and configuration                  │
 │  • Metrics collection and transformation                │
 │  • Report and badge generation                          │
-│  • Token management                                     │
+│  • JFR instrumentation support                          │
 │  • HTTP utilities                                       │
 └──────────────┬──────────────────────────────────────────┘
                │
@@ -53,12 +53,12 @@ The Token-Sheriff benchmarking infrastructure consists of three specialized modu
 │core          │  │                         │
 │              │  │ Shell-based WRK testing │
 │JMH Benchmarks│  │ 1 Java post-processor   │
-└──────────────┘  └─────────────────────────┘
-      │                      │
-      ▼                      ▼
+└──────┬───────┘  └────────────┬────────────┘
+       │                       │
+       ▼                       ▼
 ┌──────────────┐  ┌─────────────────────────┐
-│token-sheriff-      │  │Docker Containers:       │
-│core          │  │ • Quarkus App           │
+│token-sheriff-│  │Docker Containers:       │
+│validation    │  │ • Quarkus App           │
 │              │  │ • Keycloak              │
 │              │  │ • Prometheus            │
 └──────────────┘  └─────────────────────────┘
@@ -76,41 +76,37 @@ Foundation framework providing shared utilities, configuration, metrics processi
 |Component |Key Classes
 
 |Benchmark Execution
-|`AbstractBenchmarkRunner`, `BenchmarkResultProcessor`, `AbstractBenchmarkBase`
+|`AbstractBenchmarkRunner`, `BenchmarkResultProcessor`
 
 |Configuration
-|`BenchmarkConfiguration`, `BenchmarkType`, `IntegrationConfiguration`, `ReportConfiguration`
+|`BenchmarkConfiguration`, `BenchmarkType`, `ReportConfiguration`
 
 |Metrics Collection
 |`PrometheusClient`, `PrometheusMetricsManager`, `MetricsOrchestrator`
 
 |Metrics Processing
-|`BenchmarkMetricsTransformer`, `MetricsTransformer`, `MetricsComputer`, `StatisticsCalculator`
+|`BenchmarkMetricsTransformer`, `MetricsJsonExporter`, `MetricsComputer`, `StatisticsCalculator`
 
 |Report Generation
-|`ReportGenerator`, `BadgeGenerator`, `GitHubPagesGenerator`, `ReportDataGenerator`
+|`ReportGenerator`, `BadgeGenerator`, `GitHubPagesGenerator`, `ReportDataGenerator`, `HistoricalDataManager`, `TrendDataProcessor`
 
 |Data Conversion
-|`JmhBenchmarkConverter`, `WrkBenchmarkConverter`, `BenchmarkConverter`
-
-|Token Management
-|`KeycloakTokenRepository`, `TokenRepositoryConfig`, `TokenProvider`
+|`JmhBenchmarkConverter`, `WrkBenchmarkConverter`, `BenchmarkConverter`, `ReportMetadataFactory`
 
 |HTTP Utilities
 |`HttpClientFactory`
 
 |JFR Support
-|`JfrInstrumentation`, `JfrSupport`, `JfrVarianceAnalyzer`
+|`JfrInstrumentation`, `JfrVarianceAnalyzer`, `BenchmarkPhaseEvent`, `OperationEvent`, `OperationStatisticsEvent`
 
 |Utilities
-|`JsonSerializationHelper`, `BenchmarkLoggingSetup`, `OutputDirectoryStructure`
+|`JsonSerializationHelper`, `BenchmarkingLogMessages`, `OutputDirectoryStructure`
 |===
 
 === Package Structure
 [source]
 ----
 de.cuioss.benchmarking.common/
-├── base/          # Base classes for benchmarks
 ├── config/        # Configuration classes
 ├── constants/     # Constants
 ├── converter/     # Result converters (JMH/WRK → BenchmarkData)
@@ -120,9 +116,7 @@ de.cuioss.benchmarking.common/
 ├── model/         # Data models (BenchmarkData)
 ├── output/        # Output directory management
 ├── report/        # Report and badge generation
-├── repository/    # Token repositories
 ├── runner/        # Benchmark runner framework
-├── token/         # Token provider interfaces
 └── util/          # General utilities
 ----
 
@@ -141,10 +135,13 @@ Executes JMH-based micro-benchmarks directly against the JWT validation library 
 |`SimpleCoreValidationBenchmark`, `SimpleErrorLoadBenchmark`
 
 |JFR Benchmarks
-|`CoreJfrBenchmark`, `ErrorJfrBenchmark`, `MixedJfrBenchmark`, `UnifiedJfrBenchmark`
+|`CoreJfrBenchmark`, `ErrorJfrBenchmark`, `MixedJfrBenchmark`
+
+|Base Classes and Delegates
+|`AbstractBenchmark`, `AbstractJfrBenchmark`, `BenchmarkDelegate`, `CoreValidationDelegate`, `ErrorLoadDelegate`
 
 |Runners
-|`CoreBenchmarkRunner`, `JfrBenchmarkRunner`
+|`CoreBenchmarkRunner`, `JfrBenchmarkRunner`, `ConcurrencySweepRunner`
 
 |Support Classes
 |`BenchmarkKeyCache`, `MockTokenRepository`, `LibraryMetricsExporter`
@@ -154,6 +151,8 @@ Executes JMH-based micro-benchmarks directly against the JWT validation library 
 
 * `benchmark` - Standard JMH benchmarks (< 10 minutes)
 * `benchmark-jfr` - Benchmarks with Java Flight Recorder profiling
+* `benchmark-concurrency-sweep` - `measureAverageTime` at 1, 10, 50, 100 threads
+* `analyze-jfr` - Analyze an existing JFR recording (`-Djfr.file=...`)
 * `quick` - Reduced iterations for fast testing
 
 === Configuration
@@ -208,6 +207,7 @@ Prometheus:  http://localhost:9090
 === Maven Profiles
 
 * `benchmark` - Full lifecycle: build containers, run tests, collect metrics, stop containers
+* `benchmark-jfr` - JFR profiling run via `jfr_benchmark_dispatcher.sh` (200s duration, JFR compose overlay)
 * `quick` - Reduced duration (30s), skips container lifecycle
 * `autoscale` - 8 threads, 200 connections
 * `stress` - 10 threads, 150 connections
@@ -253,7 +253,6 @@ Does the code generate reports/badges/artifacts?
 * Metrics collection or transformation
 * Report/badge generation
 * Configuration management
-* Token management
 * HTTP client utilities
 
 === Place in benchmark-core when:
@@ -279,7 +278,6 @@ Does the code generate reports/badges/artifacts?
 public final void runBenchmark() throws IOException, RunnerException {
     BenchmarkConfiguration config = createConfiguration();
     validateConfiguration(config);
-    prometheusMetricsManager.clear();
     Path outputPath = Path.of(config.resultsDirectory());
     Files.createDirectories(outputPath);
     try {
@@ -287,7 +285,9 @@ public final void runBenchmark() throws IOException, RunnerException {
         beforeBenchmark(config);           // pre-benchmark hook
         Options options = buildCommonOptions(config).build();
         Collection<RunResult> results = executeBenchmark(options);
-        processTimestampData(results, outputPath);
+        if (results.isEmpty()) {
+            throw new IllegalStateException("No benchmark results produced");
+        }
         processResults(results, config);
         afterBenchmark(results, config);   // post-benchmark hook
     } finally {
@@ -334,7 +334,7 @@ Converter (JmhBenchmarkConverter / WrkBenchmarkConverter)
 BenchmarkData (unified model)
         │
         ▼
-MetricsTransformer / BenchmarkMetricsTransformer
+BenchmarkMetricsTransformer
         │
         ├──> BadgeGenerator → JSON badges
         ├──> ReportGenerator → HTML reports

--- a/benchmarking/doc/JFR-Instrumentation.adoc
+++ b/benchmarking/doc/JFR-Instrumentation.adoc
@@ -32,7 +32,6 @@ Individual operation metrics captured per validation:
 * `metadataKey` / `metadataValue` - Custom metadata (e.g., issuer)
 * `success` - Operation result (true/false)
 * `errorType` - Type of error if operation failed
-* `cached` - Whether result was served from cache
 * `concurrentOperations` - Number of concurrent operations at execution time
 
 === Statistics (1-second intervals)
@@ -50,7 +49,6 @@ Periodic statistics events aggregated over 1-second windows:
 * `variance` - Variance (nanoseconds²)
 * `coefficientOfVariation` - CV as percentage
 * `concurrentThreads` - Active threads during period
-* `cacheHitRate` - Percentage of cache hits
 
 == Variance Interpretation
 
@@ -93,7 +91,6 @@ Individual operation timing event with metadata.
 * `concurrentOperations` - Concurrent operation count
 * `metadataKey` / `metadataValue` - Custom metadata pairs
 * `errorType` - Error classification if failed
-* `cached` - Cache hit indicator
 
 === de.cuioss.benchmark.OperationStatistics
 
@@ -118,7 +115,6 @@ Periodic performance snapshot (emitted every 1 second).
 * `variance` - Variance (ns²)
 * `coefficientOfVariation` - CV percentage
 * `concurrentThreads` - Active thread count
-* `cacheHitRate` - Cache hit percentage
 
 == Analysis Tools
 

--- a/benchmarking/doc/benchmark-metrics.adoc
+++ b/benchmarking/doc/benchmark-metrics.adoc
@@ -290,7 +290,7 @@ IMPORTANT: **Metrics collection failures NEVER fail the build**. Builds continue
 Comprehensive test coverage:
 
 * **PrometheusClientTest**: API client testing with mock responses
-* **MetricsTransformerTest**: Aggregation and transformation logic
+* **BenchmarkMetricsTransformerTest**: Aggregation and transformation logic
 * **MetricsJsonExporterTest**: End-to-end metrics JSON export
 
 Test data: `benchmarking-common/src/test/resources/metrics/`
@@ -314,7 +314,7 @@ Collected metrics enable analysis of:
 2. **Real-time**: Captures metrics during actual benchmark execution
 3. **Time-aligned**: Metrics correlate with benchmark phases
 4. **Unified**: Single orchestrator handles WRK and JMH benchmarks
-5. **Professional**: Industry-standard Prometheus/Grafana stack
+5. **Standard tooling**: Prometheus time-series collection and query API
 6. **Build-safe**: Failures never break builds
 7. **Testable**: Comprehensive test coverage with real data
 

--- a/benchmarking/doc/local-testing.adoc
+++ b/benchmarking/doc/local-testing.adoc
@@ -139,7 +139,7 @@ The `gh-pages-ready/` directory contains a complete, self-contained report struc
 * **API Endpoints** (`api/` directory):
   - `benchmarks.json` - All benchmark results
   - `latest.json` - Latest run metadata
-  - `status.json` - Quality gate status
+  - `status.json` - Run status and last-run timestamp
 
 * **Historical Data** (`history/` directory):
   - Timestamped JSON files for trend analysis

--- a/benchmarking/doc/performance-scoring.adoc
+++ b/benchmarking/doc/performance-scoring.adoc
@@ -10,7 +10,11 @@
 
 A weighted performance score combining throughput, latency, and error resilience into a single metric.
 
-== Formula
+Two formulas exist (both in `MetricsComputer`): one for micro (JMH) benchmarks and one for integration (WRK) benchmarks.
+
+== Micro (JMH) Formula
+
+Implemented by `MetricsComputer.calculatePerformanceScore`:
 
 [source,text]
 ----
@@ -28,8 +32,6 @@ Note: Scores are not capped, allowing exceptional performance to exceed 100.
 Final scores are rounded to the nearest integer.
 ----
 
-== Metrics
-
 === Throughput (50% weight)
 
 * Measures: Average operations per second across all throughput benchmarks
@@ -42,7 +44,21 @@ Final scores are rounded to the nearest integer.
 * Score normalized: 1 ms = 100 points (inverse relationship)
 * Lower is better, no upper limit on score
 
+== Integration (WRK) Formula
+
+Implemented by `MetricsComputer.computeIntegrationScore` — a capped 0-100 scale:
+
+[source,text]
+----
+Integration Score = Throughput_Score + Latency_Score
+
+- Throughput_Score = min(50, Throughput ÷ 200)   // capped at 50 (10,000 req/s = 50 points)
+- Latency_Score    = max(0, 50 − Latency_ms ÷ 2) // floored at 0
+----
+
 == Score Interpretation
+
+Micro (JMH) grades from `getPerformanceGrade`:
 
 [cols="1,1,2", options="header"]
 |===
@@ -73,24 +89,22 @@ Final scores are rounded to the nearest integer.
 |Poor performance - optimization required
 |===
 
+Integration (WRK) grades from `gradeIntegration` use different thresholds and have no A+: A ≥ 90, B ≥ 80, C ≥ 70, D ≥ 60, F < 60.
+
 == Example Calculation
 
 [source,text]
 ----
-Integration Benchmark:
-Average Throughput: 5,847 ops/sec
+Integration Benchmark (computeIntegrationScore):
+Average Throughput: 5,847 req/sec
 Average Latency: 1.17 ms
 
-Throughput_Score = 5847 ÷ 100 = 58.47
-Latency_Score = 100 ÷ 1.17 = 85.47
+Throughput_Score = min(50, 5847 ÷ 200) = 29
+Latency_Score = max(0, 50 − 1.17 ÷ 2) = 49
 
-Raw Score = (58.47 × 0.5) + (85.47 × 0.5)
-          = 29.24 + 42.74
-          = 71.97
+Integration Score = 29 + 49 = 78 (Grade C)
 
-Performance Score = round(71.97) = 72 (Grade C)
-
-Micro Benchmark:
+Micro Benchmark (calculatePerformanceScore):
 Average Throughput: 83,909 ops/sec
 Average Latency: 0.35 ms
 

--- a/benchmarking/doc/workflow.adoc
+++ b/benchmarking/doc/workflow.adoc
@@ -25,23 +25,27 @@ The benchmark processing is automatically triggered in GitHub Actions:
    - Set up JDK 21 with Maven cache
    - Build entire project (all modules, tests skipped)
 
-2. **Micro Benchmarks**
+2. **Historical Data Preparation**
+   - Fetch previous benchmark history from `cuioss.github.io` (micro and integration)
+   - Prepare it via `benchmarking/scripts/benchmark-pages.py prepare-history` for trend calculation
+
+3. **Micro Benchmarks**
    - Run JMH benchmarks using `benchmark` profile
    - Automatically generates artifacts in `target/benchmark-results`
    - Creates performance badges, reports, and metrics
 
-3. **WRK Load Testing Benchmarks**
+4. **WRK Load Testing Benchmarks**
    - Start Quarkus and Keycloak containers
    - Run WRK HTTP load tests
    - Collect Prometheus metrics
    - Automatically generates WRK-specific artifacts
 
-4. **Artifact Combination**
-   - Merge artifacts from both benchmark modules
+5. **Artifact Combination**
+   - Merge artifacts from both benchmark modules via `benchmark-pages.py assemble`
    - Create unified GitHub Pages structure
    - Add metadata and timestamps
 
-5. **Deployment**
+6. **Deployment**
    - Deploy combined results to cuioss.github.io
    - Results available at `TokenSheriff/benchmarks`
 
@@ -100,21 +104,19 @@ Each benchmark module generates a consistent artifact structure. See link:../REA
 * **Last Run** - Timestamp of most recent benchmark
 * **WRK Performance** - WRK load testing specific score
 
-=== Quality Gates
+=== Regression Visibility
 
-Each benchmark run evaluates:
+There is no automated pass/fail quality gate — regressions surface through:
 
-* **Throughput** - Minimum operations per second
-* **Latency** - Maximum response times (P50, P90, P99)
-* **Regression** - Performance change from baseline
-* **Overall Status** - PASS/FAIL based on all gates
+* **Trend badges** - EWMA-based change detection (up/stable/down with ±2% threshold, see link:performance-scoring.adoc#_trend_calculation[Trend Calculation])
+* **Historical trends** - `trends.html` charts against previous runs
 
 == API Endpoints
 
 The generated artifacts include JSON API endpoints:
 
 * `api/latest.json` - Latest benchmark results
-* `api/status.json` - Current quality gate status
+* `api/status.json` - Run status and last-run timestamp
 * `api/benchmarks.json` - List of all benchmarks
 
 == Performance Requirements
@@ -131,12 +133,11 @@ Check that:
 - No compilation errors in benchmarking-common
 - Correct profile used (`-Pbenchmark`)
 
-=== Quality Gates Failing
+=== Unexpected Trend Direction
 
 Review:
 
-- Performance thresholds in `BenchmarkConstants`
-- Baseline comparison data availability
+- Baseline comparison data availability (`benchmark.history.dir`)
 - Resource constraints during benchmark run
 
 === Local Viewing Issues

--- a/doc/LogMessages.adoc
+++ b/doc/LogMessages.adoc
@@ -7,7 +7,7 @@
 
 == Overview
 
-This document provides a reference for all log messages used in the JWT Token Validation library.
+This document provides a reference for all log messages used across Token-Sheriff: the validation library (including the commons transport layer), the Quarkus integration module, and the client engine.
 
 === Document Navigation
 
@@ -19,7 +19,7 @@ This document provides a reference for all log messages used in the JWT Token Va
 
 === Log Message Format
 
-All messages follow the format: TokenSheriff-[identifier]: [message]
+All messages follow the format: [prefix]-[identifier]: [message], with one prefix per module: `TokenSheriff` (validation library, including the commons transport layer), `TokenSheriff_Q` (Quarkus integration), and `TokenSheriffClient` (client engine).
 
 The log message levels follow these identifier ranges:
 
@@ -49,7 +49,7 @@ For more details about security events related to these log messages, see the Se
 |TokenSheriff-009 |JWE |JWE decryption enabled with %s decryption key(s) |Logged when JWE decryption is configured on TokenValidator with the number of available decryption keys
 |===
 
-== WARN Level (100-168)
+== WARN Level (100-169)
 
 [cols="1,1,2,2", options="header"]
 |===
@@ -62,6 +62,7 @@ For more details about security events related to these log messages, see the Se
 |TokenSheriff-105 |TOKEN |Decoded part exceeds maximum size limit of %s bytes |Logged when a decoded part of the token exceeds the maximum size limit
 |TokenSheriff-106 |TOKEN |Unsupported algorithm: %s |Logged when an unsupported algorithm is encountered
 |TokenSheriff-107 |TOKEN |Token has a 'not before' claim that is more than %s seconds in the future |Logged when a token has a 'not before' claim that is further in the future than the configured clock skew tolerance
+|TokenSheriff-108 |TOKEN |JSON structure bounds exceeded: %s |Logged when a token's JSON payload exceeds the configured structural bounds (depth, array size, or field count)
 |TokenSheriff-109 |TOKEN |Token is missing required claim: %s |Logged when a token is missing a required claim
 |TokenSheriff-110 |TOKEN |Token has expired |Logged when a token has expired
 |TokenSheriff-111 |TOKEN |Token authorized party '%s' does not match expected client ID '%s' |Logged when the azp claim in the token does not match the expected client ID
@@ -121,6 +122,8 @@ For more details about security events related to these log messages, see the Se
 |TokenSheriff-166 |Audience |Access token audience validation skipped (accessTokenAudienceOptional=true). Expected audience: %s |Logged when audience validation is skipped for an access token because accessTokenAudienceOptional is enabled
 |TokenSheriff-167 |Authorized Party |azp claim missing, using client_id claim '%s' for authorized party validation (RFC 9068) |Logged when the azp claim is absent but the client_id claim (per RFC 9068) matches the expected client ID
 |TokenSheriff-168 |JWKS |SSRF egress guard blocked well-known discovery fetch: %s |Logged when the SSRF egress guard rejects the OIDC well-known discovery endpoint because its host resolves to a disallowed (loopback/link-local/site-local/ULA/metadata) address before any fetch is issued
+|TokenSheriff-168 |JWKS |Duplicate kid '%s' in JWKS: a later key overwrote an earlier one — the JWKS should carry a unique kid per key |Logged when a JWKS document contains two keys with the same key ID (note: this identifier is currently shared with the SSRF egress guard message above)
+|TokenSheriff-169 |JWKS |JWKS refresh for issuer '%s' produced no usable keys — retaining the current key set instead of retiring it |Logged when a JWKS refresh returns no usable keys and the previously loaded key set is kept
 |===
 
 == ERROR Level (200-206)
@@ -187,4 +190,42 @@ This section documents log messages specific to the Quarkus integration module (
 |===
 |ID |Component |Message |Description
 |TokenSheriff_Q-200 |VERTX |Vertx HttpServerRequest context is unavailable - no active request context found |Indicates that the Vertx HTTP server request context could not be resolved
+|===
+
+== Client Engine Messages
+
+This section documents log messages specific to the client engine (token-sheriff-client). Messages carry the `TokenSheriffClient` prefix.
+
+=== Client INFO Level (001-002)
+
+[cols="1,1,2,2", options="header"]
+|===
+|ID |Component |Message |Description
+|TokenSheriffClient-001 |DISCOVERY |Resolved OIDC provider metadata for issuer '%s' |Logged when provider metadata is successfully resolved for an issuer
+|TokenSheriffClient-002 |LOGOUT |Cleared held tokens for session '%s' as part of RP-initiated logout |Logged when held tokens for a session are cleared from the local store during RP-initiated logout (client-side store clear only; RFC 7009 revocation is performed separately)
+|===
+
+=== Client WARN Level (100-109)
+
+[cols="1,1,2,2", options="header"]
+|===
+|ID |Component |Message |Description
+|TokenSheriffClient-100 |DISCOVERY |Rejecting non-TLS issuer '%s' for discovery; enable allowInsecureHttp only for local test setups |Logged when a non-TLS issuer is rejected for discovery
+|TokenSheriffClient-101 |DISCOVERY |Discovery for issuer '%s' returned unexpected HTTP status %s |Logged when the discovery request returns a non-success HTTP status
+|TokenSheriffClient-102 |FLOW |Authorization server '%s' does not advertise PKCE 'S256'; interactive authorization_code flows will be refused |Logged when the authorization server does not advertise the PKCE S256 code-challenge method
+|TokenSheriffClient-103 |DISCOVERY |Discovery document issuer '%s' does not match configured issuer '%s' |Logged when the discovery document's issuer does not match the configured issuer
+|TokenSheriffClient-104 |TOKEN |Refresh token reuse detected; the refresh token family has been revoked |Logged when a superseded refresh token is replayed and the rotation family is revoked
+|TokenSheriffClient-105 |FLOW |Authorization response 'iss' '%s' does not match the initiating issuer '%s'; rejecting the callback (mix-up defence) |Logged when the RFC 9207 authorization-response iss claim does not match the initiating issuer
+|TokenSheriffClient-106 |DPOP |DPoP proof 'jti' reuse detected; refusing to emit a replayable proof (RFC 9449 token-replay defence) |Logged when a DPoP proof jti would be reused and the proof is refused
+|TokenSheriffClient-107 |LOGOUT |Post-logout redirect URI '%s' does not exactly match any registered URI; refusing RP-initiated logout (open-redirect defence) |Logged when a post-logout redirect URI does not exactly match a registered URI
+|TokenSheriffClient-108 |LIFECYCLE |Refresh token reuse detected for session '%s'; revoking the family at the authorization server (RFC 7009) and clearing the store |Logged when refresh-token reuse is detected on a stored session and the family is revoked
+|TokenSheriffClient-109 |TOKEN |Refreshed ID token is inconsistent with the refreshed access token (OIDC Core §12.2 'iss'/'sub'); refusing to apply the refresh |Logged when a refreshed ID token is inconsistent with the refreshed access token
+|===
+
+=== Client ERROR Level (200)
+
+[cols="1,1,2,2", options="header"]
+|===
+|ID |Component |Message |Description
+|TokenSheriffClient-200 |DISCOVERY |OIDC discovery failed for issuer '%s': %s |Logged when OIDC discovery fails for an issuer
 |===

--- a/doc/README.adoc
+++ b/doc/README.adoc
@@ -1,5 +1,9 @@
 = Documentation Hub
+:toc: left
+:toclevels: 3
+:toc-title: Table of Contents
 :sectnums:
+:source-highlighter: highlight.js
 
 This is the central navigation for TokenSheriff documentation.
 
@@ -37,7 +41,7 @@ The token validation capability — its requirements, architecture, security mod
 === Specifications
 
 * xref:validation/specification/microprofile-jwt-compatibility.adoc[MicroProfile JWT Compatibility] - MP-JWT 2.1 integration and rationale
-* xref:validation/specification/token-decryption.adoc[Token Decryption] - Future JWE support
+* xref:validation/specification/token-decryption.adoc[Token Decryption] - JWE encrypted-token support
 * xref:validation/specification/multi-idp-testing.adoc[Multi-IDP Testing] - Testing with multiple OIDC providers
 
 === FAQ
@@ -49,9 +53,10 @@ The token validation capability — its requirements, architecture, security mod
 The active OIDC capability — the server-side confidential-client engine that retrieves
 tokens, holds and refreshes them server-side, and drives the flows on top of the commons
 transport. It is the engine a Backend-For-Frontend (BFF) is built on; it is not itself a BFF.
-The `token-sheriff-client` module (and its `token-sheriff-client-quarkus` extension) now exist
-as a wired, empty skeleton (xref:oidc/05-client-module/README.adoc[Plan 05]); this document set
-still leads the functional content, which lands per xref:oidc/06-implement/README.adoc[Plan 06].
+The `token-sheriff-client` module (and its `token-sheriff-client-quarkus` extension) is
+implemented — module structure per xref:oidc/05-client-module/README.adoc[Plan 05], functional
+content delivered under xref:oidc/06-implement/README.adoc[Plan 06]; this document set remains
+the normative specification.
 
 * xref:client/README.adoc[Overview] - Capability entry point: intro, scope, reading order, document map
 * xref:client/requirements.adoc[Requirements] - `CLIENT-N`, grouped by aspect (Retrieval & flow / Token)
@@ -68,6 +73,7 @@ still leads the functional content, which lands per xref:oidc/06-implement/READM
 * xref:client/specification/retrieval-flow.adoc[Retrieval & Flow] - Auth-code + PKCE, grants, client auth, `state`/`nonce`, mix-up, PAR
 * xref:client/specification/step-up-and-logout.adoc[Step-up & Logout] - RFC 9470 step-up; RP-initiated logout
 * xref:client/specification/token-handling.adoc[Token Handling] - Server-side lifecycle delta (references the validation module)
+* xref:client/specification/test-strategy.adoc[Test Strategy] - Two-layer verification model and traceability matrix
 
 == Reference
 
@@ -80,12 +86,12 @@ still leads the functional content, which lands per xref:oidc/06-implement/READM
 ** xref:../token-sheriff-validation/doc/api-reference.adoc[API Reference]
 ** xref:../token-sheriff-validation/doc/developing.adoc[Developing]
 ** xref:../token-sheriff-validation/doc/UnitTesting.adoc[Unit Testing]
-* xref:../token-sheriff-client/README.adoc[token-sheriff-client] - Framework-agnostic OIDC/OAuth client engine _(wired, empty skeleton — Plan 05)_
+* xref:../token-sheriff-client/README.adoc[token-sheriff-client] - Framework-agnostic OIDC/OAuth client engine
 ** xref:../token-sheriff-client/doc/README.adoc[Module Documentation]
 * xref:../token-sheriff-quarkus-parent/README.adoc[token-sheriff-quarkus-parent] - Quarkus extensions
 ** xref:../token-sheriff-quarkus-parent/doc/README.adoc[Module Documentation]
 ** `token-sheriff-validation-quarkus` (+ `-deployment`) - validation extension
-** `token-sheriff-client-quarkus` (+ `-deployment`) - client extension _(wired, empty skeleton — Plan 05)_
+** `token-sheriff-client-quarkus` (+ `-deployment`) - client extension
 
 == Benchmarking
 

--- a/doc/client/README.adoc
+++ b/doc/client/README.adoc
@@ -1,4 +1,8 @@
 = Client Capability
+:toc: left
+:toclevels: 3
+:toc-title: Table of Contents
+:sectnums:
 :source-highlighter: highlight.js
 
 The *active* OIDC side of Token-Sheriff: a server-side *confidential-client engine* that
@@ -7,9 +11,9 @@ Connect flows on top of the xref:../commons/requirements.adoc[commons] transport
 engine a *Backend-For-Frontend (BFF)* is built on — *it is not itself a BFF*.
 
 The set is documented *spec-first*: the requirements, threat model and specifications below
-lead; the functional code lands protocol-by-protocol under
-xref:../oidc/06-implement/README.adoc[Plan 06]. The `token-sheriff-client` module currently
-exists as a wired, empty skeleton (xref:../oidc/05-client-module/README.adoc[Plan 05]).
+are normative. The `token-sheriff-client` module is implemented — its structure was
+established by xref:../oidc/05-client-module/README.adoc[Plan 05] and the functional code
+delivered protocol-by-protocol under xref:../oidc/06-implement/README.adoc[Plan 06].
 
 == Scope at a glance
 
@@ -64,7 +68,7 @@ no signature policy (the seam is detailed in xref:architecture.adoc[Architecture
 | The server-side lifecycle delta — validation, storage, refresh, revocation, sender-constraint preservation (`CLIENT-15`–`CLIENT-20`).
 
 | xref:specification/test-strategy.adoc[Spec — Test strategy]
-| The two-layer verification model (MockWebServer unit + real-Keycloak integration), the adversarial coverage, and the `CLIENT-N` → threat → test traceability matrix (`CLIENT-22`). Executed by xref:../oidc/06-implement/README.adoc[Plan 06].
+| The two-layer verification model (MockWebServer unit + real-Keycloak integration), the adversarial coverage, and the `CLIENT-N` → threat → test traceability matrix (`CLIENT-22`). Executed under xref:../oidc/06-implement/README.adoc[Plan 06].
 |===
 
 == See also

--- a/doc/client/architecture.adoc
+++ b/doc/client/architecture.adoc
@@ -33,16 +33,18 @@ image::../resources/diagrams/module-architecture.svg["Token-Sheriff module archi
 * The engine is *pure Java* (xref:requirements.adoc#CLIENT-21[CLIENT-21]) — no CDI /
   MicroProfile / JAX-RS inside it. It depends on `token-sheriff-validation`, which
   transitively provides the `commons` base layer.
-* The `client → validation` dependency direction is enforced by *Maven* once the module
-  exists (xref:../oidc/05-client-module/README.adoc[Plan 05]); it never reverses.
+* The `client → validation` dependency direction is enforced by *Maven* — the
+  `token-sheriff-client` module (created by
+  xref:../oidc/05-client-module/README.adoc[Plan 05]) declares the dependency; it never
+  reverses.
 * The HTTP edge (`token-sheriff-client-quarkus`, or a future RESTEasy / portal adapter) maps
   the engine's typed exceptions to `application/problem+json`
   (xref:requirements.adoc#CLIENT-20[CLIENT-20], `COMMONS-10`).
 
-NOTE: The Maven module, the `token-sheriff-client-quarkus` extension, and the BOM/reactor
-assembly are *not* created by this capability — that is
+NOTE: The Maven module (`token-sheriff-client`), the `token-sheriff-client-quarkus`
+extension, and the BOM/reactor assembly were delivered by
 xref:../oidc/05-client-module/README.adoc[Plan 05]. This document specifies the engine those
-modules will host.
+modules host.
 
 == The engine seam
 

--- a/doc/client/best-practices.adoc
+++ b/doc/client/best-practices.adoc
@@ -16,9 +16,13 @@ xref:threat-model.adoc[threat], and reflects the *most-secure current subset* pr
 direction, Browser-Based-Apps BFF guidance, FAPI 2.0 where it raises the bar), and no
 capability included merely because "the spec allows it".
 
-The checklist is organized by aspect. Transport hardening (TLS, SSRF, timeouts, JWKS
-caching) is *owned by* xref:../commons/requirements.adoc[commons] (`COMMONS-1`–`COMMONS-8`) —
-the client uses it and adds no HTTP of its own; the transport row records that boundary.
+The checklist is organized by aspect. Transport hardening *primitives* (TLS enforcement,
+timeouts, bounded reads, JWKS caching) are *owned by*
+xref:../commons/requirements.adoc[commons] (`COMMONS-1`–`COMMONS-8`); the client drives its
+*own* OIDC/OAuth back-channel HTTP on those primitives and applies an in-module egress/path
+control before each fetch (see
+xref:architecture.adoc#_owned_back_channel_http[Owned back-channel HTTP]); the transport rows
+record that boundary.
 
 == Retrieval & flow
 
@@ -124,15 +128,18 @@ the client uses it and adds no HTTP of its own; the transport row records that b
 | xref:requirements.adoc#CLIENT-19[CLIENT-19]
 |===
 
-== Transport (owned by commons — boundary note)
+== Transport (commons primitives — boundary note)
 
 [cols="3,1", options="header"]
 |===
 | Practice | Owner
 
-| Enforced TLS 1.2+, SSRF defence on advertised URLs, connect/read timeouts and response-size
-  limits, JWKS cache / rotation. *The client uses the commons transport and adds none of its
-  own HTTP.*
+| TLS 1.2+ enforcement, connect/read timeouts, response-size limits and JWKS cache / rotation
+  come from the `cui-http` transport primitives owned by commons. *The client builds its own
+  `HttpHandler`s for the OIDC/OAuth back channel* (discovery, token, userinfo, revocation,
+  PAR) and applies an in-module egress/path validation before each fetch
+  (xref:architecture.adoc#_owned_back_channel_http[Owned back-channel HTTP]); JWKS retrieval
+  stays with the commons-backed validation pipeline.
 | xref:../commons/requirements.adoc#COMMONS-1[COMMONS-1]–xref:../commons/requirements.adoc#COMMONS-8[COMMONS-8]
 
 | HTTP-surfaced client errors render as `application/problem+json` (RFC 9457) at the edge; the

--- a/doc/client/requirements.adoc
+++ b/doc/client/requirements.adoc
@@ -372,8 +372,8 @@ The engine MUST be pure Java, depending on `token-sheriff-validation` (which tra
 provides the commons base layer) — no CDI, no MicroProfile Config, no JAX-RS in the engine
 itself. Framework bindings (Quarkus, and any RESTEasy/portal adapter) sit *outside* the
 engine, so the engine is reusable across framework contexts. The `client → validation`
-dependency direction is enforced by Maven once the module exists
-(xref:../oidc/05-client-module/README.adoc[Plan 05]).
+dependency direction is enforced by Maven — the `token-sheriff-client` module (created by
+xref:../oidc/05-client-module/README.adoc[Plan 05]) declares the dependency.
 
 * Source: xref:../oidc/decision-oidc-module.adoc[Module Architecture decision] (client → validation, never the reverse).
 

--- a/doc/client/specification/retrieval-flow.adoc
+++ b/doc/client/specification/retrieval-flow.adoc
@@ -1,6 +1,7 @@
 = Client Specification — Retrieval & Flow
 :toc: left
 :toclevels: 3
+:toc-title: Table of Contents
 :sectnums:
 :source-highlighter: highlight.js
 

--- a/doc/client/specification/step-up-and-logout.adoc
+++ b/doc/client/specification/step-up-and-logout.adoc
@@ -1,6 +1,7 @@
 = Client Specification — Step-Up & RP-Initiated Logout
 :toc: left
 :toclevels: 3
+:toc-title: Table of Contents
 :sectnums:
 :source-highlighter: highlight.js
 

--- a/doc/client/specification/test-strategy.adoc
+++ b/doc/client/specification/test-strategy.adoc
@@ -1,6 +1,7 @@
 = Client Specification — Test Strategy
 :toc: left
 :toclevels: 3
+:toc-title: Table of Contents
 :sectnums:
 :source-highlighter: highlight.js
 
@@ -117,9 +118,8 @@ structure — the same layout as `token-sheriff-validation` (`@DisplayName`, `@N
 
 The OP simulators are *not re-authored*: `token-sheriff-validation` already publishes its test
 utilities as a *test-jar with classifier `generators`* (its `maven-jar-plugin` `test-jar`
-goal, xref:../../oidc/03-commons/README.adoc[Plan 03]). The client test module declares that
-test-jar dependency (a xref:../../oidc/06-implement/README.adoc[Plan 06] wiring step — the
-`token-sheriff-client` pom does not yet declare it) and reuses:
+goal, xref:../../oidc/03-commons/README.adoc[Plan 03]). The `token-sheriff-client` pom
+declares that test-jar dependency (`classifier` `generators`, `scope` `test`) and reuses:
 
 * the OP-endpoint dispatchers — `TokenDispatcher`, `UserInfoDispatcher`,
   `RevocationDispatcher`, `IntrospectionDispatcher`, `EndSessionDispatcher`, `ParDispatcher`,

--- a/doc/client/specification/token-handling.adoc
+++ b/doc/client/specification/token-handling.adoc
@@ -1,6 +1,7 @@
 = Client Specification — Token Handling
 :toc: left
 :toclevels: 3
+:toc-title: Table of Contents
 :sectnums:
 :source-highlighter: highlight.js
 

--- a/doc/client/threat-model.adoc
+++ b/doc/client/threat-model.adoc
@@ -1,6 +1,7 @@
 = Client Threat Model
 :toc: left
 :toclevels: 3
+:toc-title: Table of Contents
 :sectnums:
 :source-highlighter: highlight.js
 

--- a/doc/commons/README.adoc
+++ b/doc/commons/README.adoc
@@ -1,4 +1,8 @@
 = Commons Base Layer
+:toc: left
+:toclevels: 3
+:toc-title: Table of Contents
+:sectnums:
 :source-highlighter: highlight.js
 
 The *shared base layer* every Token-Sheriff capability sits on — the
@@ -7,7 +11,7 @@ dependency-light layer by ArchUnit rather than shipped as a separate artifact. C
 *moves bytes, raises typed errors, counts events and exposes metrics; it never interprets a
 token's trust* — that is the xref:../validation/README.adoc[validation] layer's job.
 
-Both validation and the coming xref:../client/README.adoc[client] consume it; the
+Both validation and the xref:../client/README.adoc[client] consume it; the
 re-packaging and the ArchUnit boundary are established in
 xref:../oidc/03-commons/README.adoc[Plan 03].
 
@@ -68,6 +72,6 @@ xref:architecture.adoc[Architecture]).
 
 * xref:../README.adoc[Documentation Hub]
 * xref:../validation/README.adoc[Validation] — the token-trust pipeline that ships alongside this base layer
-* xref:../client/README.adoc[Client] — the coming consumer of the extended transport
+* xref:../client/README.adoc[Client] — the consumer of the extended transport
 * xref:../oidc/decision-oidc-module.adoc[Module Architecture decision] — why commons is an enforced layer, not a separate artifact
 * xref:../oidc/03-commons/README.adoc[Plan 03] — the commons base-layer plan

--- a/doc/commons/architecture.adoc
+++ b/doc/commons/architecture.adoc
@@ -1,6 +1,7 @@
 = Commons Architecture
 :toc: left
 :toclevels: 3
+:toc-title: Table of Contents
 :sectnums:
 :source-highlighter: highlight.js
 
@@ -32,10 +33,13 @@ metrics; it never interprets a token's trust.*
 | Sub-package | Responsibility
 
 | `commons.transport`
-| All outbound IdP HTTP — discovery (`.well-known`, RFC 8414), JWKS (RFC 7517), and
-  (client-facing) token / userinfo / revocation / introspection / end-session / PAR. Owns
-  TLS enforcement, SSRF defence, timeouts, response-size limits, retry/backoff, the
-  `cui-http` client, and discovery / JWKS caching. See xref:specification/transport.adoc[transport spec].
+| The validation-side outbound IdP HTTP — discovery (`.well-known`, RFC 8414) and JWKS
+  (RFC 7517) — plus the shared transport primitives: TLS enforcement, egress policy
+  (`EgressPolicy`), timeouts, response-size limits (`BoundedBodyHandlers`), retry/backoff,
+  the `cui-http` client, and discovery / JWKS caching. The client engine builds its *own*
+  back-channel HTTP (token / userinfo / revocation / PAR) on these primitives
+  (xref:../client/architecture.adoc#_owned_back_channel_http[owned back-channel HTTP]).
+  See xref:specification/transport.adoc[transport spec].
 
 | `commons.error`
 | The typed exception hierarchy that library code throws, plus the inbound normalization of
@@ -43,7 +47,7 @@ metrics; it never interprets a token's trust.*
   HTTP edge, not here. See xref:specification/error-model.adoc[error-model spec].
 
 | `commons.events`
-| `SecurityEventCounter` and the security-event types, so validation and the future client
+| `SecurityEventCounter` and the security-event types, so validation and the client
   share one event surface. Thread-safe, no Micrometer dependency. See
   xref:specification/observability.adoc[observability spec].
 
@@ -61,8 +65,9 @@ sources — giving the same guarantee a module boundary would, with one fewer ar
   `…validation..`.
 * `…validation..` may depend on `…commons..` (the allowed direction).
 * No package cycles across the `commons` / `validation` boundary.
-* The client boundary (`client → validation`, never the reverse) is enforced by *Maven*
-  once the client module exists (xref:../oidc/05-client-module/README.adoc[Plan 05]).
+* The client boundary (`client → validation`, never the reverse) is enforced by *Maven* —
+  the `token-sheriff-client` module (created by
+  xref:../oidc/05-client-module/README.adoc[Plan 05]) declares the dependency.
 
 Because commons must not depend on validation, the security-event types in `commons.events`
 carry no link to validation's log-message registry, and the transport layer keeps its
@@ -72,7 +77,7 @@ dependencies to `cui-http` / `cui-tooling` plus commons-internal types.
 
 * `validation` → `commons` (uses transport, events, metrics, error).
 * `token-sheriff-validation-quarkus` → renders `commons.error` exceptions as RFC 9457.
-* `token-sheriff-client` (future, separate module) → `validation`, and thus `commons`
+* `token-sheriff-client` (separate module) → `validation`, and thus `commons`
   transitively.
 * `nifi-extensions` (external consumer) → `validation`; any commons-visible package move is
   recorded in xref:../oidc/01-restructure/migration-nifi-extensions.adoc[the migration guide].

--- a/doc/commons/requirements.adoc
+++ b/doc/commons/requirements.adoc
@@ -37,10 +37,12 @@ xref:threat-model.adoc[Threat Model]._
 [#COMMONS-1]
 === COMMONS-1: Outbound IdP HTTP transport
 
-Commons is the single owner of all outbound HTTP to an OpenID Provider. It provides the
-HTTP client (built on `cui-http`) used for discovery, JWKS, and — for the client
-capability — token, userinfo, revocation, introspection, end-session and PAR. No other
-package issues outbound IdP requests directly.
+Commons owns the validation-side outbound HTTP to an OpenID Provider — discovery and
+JWKS — and provides the hardened transport primitives (built on `cui-http`) it is
+performed with. The client capability builds its *own* back-channel HTTP (token, userinfo,
+revocation, PAR) on those primitives and applies its own in-module egress control
+(xref:../client/architecture.adoc#_owned_back_channel_http[owned back-channel HTTP]); it
+does not route those fetches through a commons transport service.
 
 * Source: https://www.rfc-editor.org/rfc/rfc9700[RFC 9700 §4] (single hardened HTTP surface).
 
@@ -58,9 +60,9 @@ HTTP endpoints MUST be rejected. TLS configuration is centralized (via `cui-http
 
 Any URL taken from an IdP-controlled source (`jwks_uri`, discovery endpoints, `userinfo`,
 or any endpoint advertised via discovery) MUST be constrained before it is fetched:
-scheme restricted to HTTPS, host subject to an allow-list / egress policy, and internal /
-link-local / loopback address ranges blocked. The *existing* `wellknown` and `jwks`
-fetch paths are audited to this requirement as part of their relocation into commons.
+scheme restricted to HTTPS, host subject to an allow-list / egress policy (`EgressPolicy`),
+and internal / link-local / loopback address ranges blocked. The `wellknown` and `jwks`
+fetch paths were audited to this requirement during their relocation into commons.
 
 * Source: https://owasp.org/www-community/attacks/Server_Side_Request_Forgery[OWASP SSRF], https://github.com/advisories/GHSA-7vw6-5q2f-7w5r[CVE-2026-1180], https://www.rfc-editor.org/rfc/rfc9700[RFC 9700 §4.10].
 
@@ -96,11 +98,11 @@ keys remain in validation.
 [#COMMONS-7]
 === COMMONS-7: Extended IdP endpoints (client-facing)
 
-Commons defines the transport contract for the endpoints the OIDC client capability will
-add: token (RFC 6749), userinfo (OIDC Core), revocation (RFC 7009), introspection
+Commons defines the transport contract for the endpoints the OIDC client capability
+drives: token (RFC 6749), userinfo (OIDC Core), revocation (RFC 7009), introspection
 (RFC 7662), end-session / RP-initiated logout, and PAR (RFC 9126). Each is exercised by a
 dedicated MockWebServer dispatcher in the `generators` test artifact (default + adversarial
-modes) so the contract is testable before the client engine exists.
+modes), so the contract is testable independently of the client engine.
 
 * Source: https://www.rfc-editor.org/rfc/rfc6749[RFC 6749], https://www.rfc-editor.org/rfc/rfc7009[RFC 7009], https://www.rfc-editor.org/rfc/rfc7662[RFC 7662], https://www.rfc-editor.org/rfc/rfc9126[RFC 9126], https://openid.net/specs/openid-connect-rpinitiated-1_0.html[OIDC RP-Initiated Logout 1.0].
 
@@ -119,7 +121,7 @@ _See xref:specification/error-model.adoc[Error-model specification]._
 [#COMMONS-9]
 === COMMONS-9: Typed exception hierarchy
 
-Library code (the `commons` and `validation` packages, and the future client engine — pure
+Library code (the `commons` and `validation` packages, and the client engine — pure
 Java) MUST signal failure through a typed exception hierarchy defined in `commons.error`.
 Library code MUST NOT produce HTTP problem documents — that is not its layer.
 
@@ -128,7 +130,7 @@ Library code MUST NOT produce HTTP problem documents — that is not its layer.
 [#COMMONS-10]
 === COMMONS-10: RFC 9457 rendering at every HTTP edge
 
-Every HTTP edge — `token-sheriff-validation-quarkus`, the future `token-sheriff-client-quarkus`,
+Every HTTP edge — `token-sheriff-validation-quarkus`, `token-sheriff-client-quarkus`,
 and any future non-Quarkus/RESTEasy edge (e.g. a portal adapter) — MUST map the typed
 exceptions to `application/problem+json` per RFC 9457. Existing validation rejection
 responses are retrofitted to this contract.
@@ -159,7 +161,7 @@ _See xref:specification/observability.adoc[Observability specification]._
 === COMMONS-13: Shared security-event surface
 
 `SecurityEventCounter` and the security-event types live in `commons.events` so validation
-and the future client share one event surface. The counter MUST remain thread-safe and
+and the client share one event surface. The counter MUST remain thread-safe and
 free of any Micrometer dependency; Quarkus extensions expose it as before.
 
 * Source: https://www.rfc-editor.org/rfc/rfc9700[RFC 9700 §4] (security monitoring).
@@ -169,7 +171,7 @@ free of any Micrometer dependency; Quarkus extensions expose it as before.
 
 Each security event MUST carry a category (structure / signature / semantic) usable by an
 edge to select a response. Event categories MUST NOT depend on any validation-layer type
-(the ArchUnit boundary — see xref:architecture.adoc#_archunit_boundary[Architecture]).
+(the ArchUnit boundary — see xref:architecture.adoc#archunit[Architecture]).
 
 * Source: https://www.rfc-editor.org/rfc/rfc9700[RFC 9700 §4].
 

--- a/doc/commons/specification/error-model.adoc
+++ b/doc/commons/specification/error-model.adoc
@@ -1,6 +1,7 @@
 = Commons Specification — Error Model
 :toc: left
 :toclevels: 3
+:toc-title: Table of Contents
 :sectnums:
 :source-highlighter: highlight.js
 
@@ -19,7 +20,7 @@ the inbound normalization of IdP error responses; each edge owns its RFC 9457 ma
 |===
 | Layer | Behaviour
 
-| *Libraries* — `commons` + `validation` packages, the future client engine (pure Java)
+| *Libraries* — `commons` + `validation` packages, the client engine (pure Java)
 | Throw a *typed exception hierarchy* defined in `commons.error`. They MUST NOT produce HTTP
   problem documents — that is not their layer (xref:../requirements.adoc#COMMONS-9[COMMONS-9]).
 
@@ -33,15 +34,16 @@ the inbound normalization of IdP error responses; each edge owns its RFC 9457 ma
 
 == Typed exception hierarchy (`commons.error`)
 
-A small, stable hierarchy that library code throws and edges map. The concrete shape is
-defined during re-packaging; the contract is:
+A small, stable hierarchy that library code throws and edges map:
 
-* A common base carrying a *category* (from `commons.events`, structure / signature /
-  semantic) and a *safe, caller-facing message* — never internal detail.
+* `TokenSheriffException` is the common base, carrying a *category* (from `commons.events`,
+  structure / signature / semantic) and a *safe, caller-facing message* — never internal
+  detail.
 * Transport failures (TLS rejected, SSRF blocked, timeout, oversized response, unreachable
-  endpoint) are one branch.
-* Token-validation failures (the existing `TokenValidationException`, keyed by
-  `SecurityEventCounter.EventType`) are another — retrofitted onto the shared base so the
+  endpoint) are the `TransportException` branch; inbound IdP protocol errors normalize to
+  `ClientProtocolException` (via `InboundErrorNormalizer`).
+* Token-validation failures (`TokenValidationException`, keyed by
+  `SecurityEventCounter.EventType`) are another branch on the shared base so the
   edges have one mapping surface.
 
 == RFC 9457 mapping at the edge

--- a/doc/commons/specification/observability.adoc
+++ b/doc/commons/specification/observability.adoc
@@ -1,6 +1,7 @@
 = Commons Specification — Observability
 :toc: left
 :toclevels: 3
+:toc-title: Table of Contents
 :sectnums:
 :source-highlighter: highlight.js
 
@@ -14,8 +15,8 @@ dependency, and are wired to Micrometer by each Quarkus extension.
 
 == Security events (`commons.events`)
 
-`SecurityEventCounter` and the security-event types move into `commons.events` so validation
-and the future client share one event surface (xref:../requirements.adoc#COMMONS-13[COMMONS-13]).
+`SecurityEventCounter` and the security-event types live in `commons.events` so validation
+and the client share one event surface (xref:../requirements.adoc#COMMONS-13[COMMONS-13]).
 
 * `SecurityEventCounter` — a thread-safe, highly concurrent counter keyed by event type; no
   Micrometer dependency (so the base layer stays dependency-light).

--- a/doc/commons/specification/transport.adoc
+++ b/doc/commons/specification/transport.adoc
@@ -1,6 +1,7 @@
 = Commons Specification — Transport
 :toc: left
 :toclevels: 3
+:toc-title: Table of Contents
 :sectnums:
 :source-highlighter: highlight.js
 
@@ -9,10 +10,13 @@
 _Realizes xref:../requirements.adoc#COMMONS-1[COMMONS-1]–xref:../requirements.adoc#COMMONS-8[COMMONS-8].
 See xref:../threat-model.adoc[Threat Model] and xref:../architecture.adoc[Architecture]._
 
-`commons.transport` is the single owner of all outbound HTTP to an OpenID Provider. It
-*moves bytes* — it never decides whether a token is trustworthy. It owns TLS enforcement,
-SSRF defence, timeouts, response-size limits, retry/backoff, the `cui-http` client, and
-discovery / JWKS caching.
+`commons.transport` owns the validation-side outbound HTTP to an OpenID Provider —
+discovery and JWKS — and the shared transport primitives (TLS enforcement, SSRF egress
+policy, timeouts, response-size limits, retry/backoff, the `cui-http` client, and
+discovery / JWKS caching). It *moves bytes* — it never decides whether a token is
+trustworthy. The client engine builds its *own* back-channel HTTP (token, userinfo,
+revocation, PAR) on these primitives
+(xref:../../client/architecture.adoc#_owned_back_channel_http[owned back-channel HTTP]).
 
 == Endpoints
 
@@ -31,8 +35,9 @@ discovery / JWKS caching.
 |===
 
 Discovery and JWKS are *relocated existing code* (`wellknown`, `jwks.http`); the remaining
-six are *transport contracts* the OIDC client engine (xref:../../oidc/06-implement/README.adoc[Plan 06])
-will drive. All eight are exercised by dispatchers in the `generators` test artifact.
+six are *transport contracts* the OIDC client engine
+(xref:../../oidc/06-implement/README.adoc[Plan 06]) drives with its own back-channel HTTP.
+All eight are exercised by dispatchers in the `generators` test artifact.
 
 == Security controls
 

--- a/doc/commons/threat-model.adoc
+++ b/doc/commons/threat-model.adoc
@@ -1,6 +1,7 @@
 = Commons Threat Model
 :toc: left
 :toclevels: 3
+:toc-title: Table of Contents
 :sectnums:
 :source-highlighter: highlight.js
 
@@ -21,14 +22,16 @@ Each entry cites a source, a mitigation, and the covering `COMMONS-N` requiremen
 
 The commons layer:
 
-* Issues all outbound HTTP to OpenID Providers (discovery, JWKS; client-facing:
-  token / userinfo / revocation / introspection / end-session / PAR).
+* Issues the validation-side outbound HTTP to OpenID Providers (discovery, JWKS) and
+  provides the hardened transport primitives the client engine builds its *own*
+  back-channel HTTP on
+  (xref:../client/architecture.adoc#_owned_back_channel_http[owned back-channel HTTP]).
 * Follows URLs that are partly *IdP-controlled* (advertised via discovery).
 * Normalizes inbound IdP error responses and raises typed exceptions.
 * Is rendered to end-callers by the HTTP edges as `application/problem+json`.
 
-The relocated `wellknown` and `jwks.http` code is *in scope* — its egress and TLS paths are
-audited to the requirements below as part of the move into commons.
+The relocated `wellknown` and `jwks.http` code is *in scope* — its egress and TLS paths
+were audited to the requirements below during the move into commons.
 
 == Threat catalog
 
@@ -40,9 +43,9 @@ audited to the requirements below as part of the move into commons.
 | *SSRF via `jwks_uri` / discovery / userinfo / any IdP-advertised URL.* An attacker who
   controls or spoofs IdP metadata points a URL at an internal service (cloud metadata,
   link-local, loopback) to make the server fetch it.
-| HTTPS-only scheme restriction, host allow-list / egress policy, and blocking of
-  internal / link-local / loopback ranges before any advertised URL is fetched. Audit the
-  *existing* `wellknown` / `jwks` fetch code being relocated.
+| HTTPS-only scheme restriction, host allow-list / egress policy (`EgressPolicy`), and
+  blocking of internal / link-local / loopback ranges before any advertised URL is
+  fetched. The relocated `wellknown` / `jwks` fetch code was audited to this control.
 | https://owasp.org/www-community/attacks/Server_Side_Request_Forgery[OWASP SSRF], https://github.com/advisories/GHSA-7vw6-5q2f-7w5r[CVE-2026-1180]
 | xref:requirements.adoc#COMMONS-3[COMMONS-3]
 
@@ -83,7 +86,7 @@ audited to the requirements below as part of the move into commons.
 == Adversarial test coverage
 
 Each transport threat is exercised by the `generators` test artifact's dispatchers in an
-*adversarial* mode (see xref:specification/transport.adoc#_adversarial_dispatchers[Transport
+*adversarial* mode (see xref:specification/transport.adoc#adversarial_dispatchers[Transport
 spec]):
 
 [cols="1,3", options="header"]

--- a/doc/oidc/01-restructure/README.adoc
+++ b/doc/oidc/01-restructure/README.adoc
@@ -1,6 +1,7 @@
 = Plan 01 — Restructure: Rebrand to Token-Sheriff
-:toc: macro
+:toc: left
 :toclevels: 3
+:toc-title: Table of Contents
 :sectnums:
 :source-highlighter: highlight.js
 
@@ -11,8 +12,6 @@
 | Output | First Token-Sheriff release `0.9.0` + Maven Central relocation + consumer migration
 | Version | This rename/refactor ships as *0.9.0*. `1.0.0` is reserved for when the OIDC client module is implemented and tested.
 |===
-
-toc::[]
 
 == Goal
 

--- a/doc/oidc/01-restructure/migration-nifi-extensions.adoc
+++ b/doc/oidc/01-restructure/migration-nifi-extensions.adoc
@@ -1,6 +1,7 @@
 = Migration Guide: nifi-extensions → Token-Sheriff
-:toc: macro
+:toc: left
 :toclevels: 3
+:toc-title: Table of Contents
 :sectnums:
 :source-highlighter: highlight.js
 
@@ -10,8 +11,6 @@
 | Context  | xref:README.adoc[Plan 01 — Restructure]
 | Status   | *Done — executed and merged* via https://github.com/cuioss/nifi-extensions/pull/398[nifi-extensions#398] against Token-Sheriff `0.9.0` (verified: coordinates, imports, config keys, `generators` classifier — zero functional residuals). Kept as reference for any further consumer.
 |===
-
-toc::[]
 
 == What changes
 

--- a/doc/oidc/01-restructure/phase-3-checklist.adoc
+++ b/doc/oidc/01-restructure/phase-3-checklist.adoc
@@ -1,6 +1,9 @@
 = Plan 01 — Phase 3 Execution Checklist (repo rename + external services)
-:toc: macro
+:toc: left
+:toclevels: 3
+:toc-title: Table of Contents
 :sectnums:
+:source-highlighter: highlight.js
 
 This is the committed, self-detecting checklist for Phase 3 of the Token-Sheriff
 rename. Each row carries a read-only *Detect* command (the source of truth — run
@@ -17,8 +20,6 @@ the true state, then execute the *Action* of each not-yet-done row. The repo
 rename keeps the old URL redirecting, so the primary path needs no re-clone —
 `git remote set-url` suffices (row 2).
 ====
-
-toc::[]
 
 == Checklist
 

--- a/doc/oidc/02-doc-structure/README.adoc
+++ b/doc/oidc/02-doc-structure/README.adoc
@@ -1,17 +1,16 @@
 = Plan 02 — Documentation Structure for the Commons & Client Capabilities
-:toc: macro
+:toc: left
 :toclevels: 3
+:toc-title: Table of Contents
 :sectnums:
 :source-highlighter: highlight.js
 
 [cols="1,3"]
 |===
-| Status     | *Phase 1 done* — the validation capability split shipped via https://github.com/cuioss/TokenSheriff/pull/524[#524] (2026-07). Phase 2 (client scaffolding) deferred by design until client work starts.
+| Status     | *Phase 1 done* — the validation capability split shipped via https://github.com/cuioss/TokenSheriff/pull/524[#524] (2026-07). Phase 2 (client scaffolding) was superseded: the client document set landed under xref:../04-client-spec/README.adoc[Plan 04] (`doc/client/`), and the client module docs plus global log-registry entries followed with Plans 05/06.
 | Depends on | Plan 01 — Restructure (rename); run after it to pay link churn once
 | Scope      | Reshape `doc/` so validation, Commons and the coming OIDC client are peer capabilities, with a shared cross-cutting area
 |===
-
-toc::[]
 
 == Goal
 

--- a/doc/oidc/03-commons/README.adoc
+++ b/doc/oidc/03-commons/README.adoc
@@ -1,6 +1,7 @@
 = Plan 03 — Commons: the Shared Base Layer (packages in validation, ArchUnit-enforced)
-:toc: macro
+:toc: left
 :toclevels: 3
+:toc-title: Table of Contents
 :sectnums:
 :source-highlighter: highlight.js
 
@@ -12,11 +13,9 @@
 | Outcome    | The `commons` base packages + ArchUnit rules living in `token-sheriff-validation`; its requirements/spec/threat-model under `doc/commons/` (`COMMONS-N`).
 |===
 
-toc::[]
-
 == Why a base layer (and why not a separate module)
 
-Several concerns are *base-layer*: validation and the coming client both consume them, none of them owns, and today they are scattered through validation:
+Several concerns are *base-layer*: validation and the client both consume them, none of them owns, and (at plan time) they were scattered through validation:
 
 * *IdP transport* — OIDC discovery (`wellknown`) and JWKS (`jwks.http`); the client will add token/userinfo/revocation/end-session/PAR.
 * *Error model* — every capability throws errors; the HTTP edge must render them uniformly (RFC 9457).
@@ -163,7 +162,7 @@ Requirement IDs use `COMMONS-N` (per xref:../02-doc-structure/README.adoc[Plan 0
 * [x] ArchUnit rules pass: `commons` never depends on `…validation..`; no cross-boundary cycles (`CommonsLayeringTest`)
 * [x] `SecurityEventCounter` + `EventCategory` re-packaged into `commons.events`; metric identifiers (`MetricIdentifier`) into `commons.metrics`; consumer-visible moves recorded in xref:../01-restructure/migration-nifi-extensions.adoc[the migration guide]
 * [x] *Done in xref:../05-client-module/README.adoc[Plan 05]* — `wellknown` + `jwks.http` transport → `commons.transport`. These depended deeply on `…validation.jwks..`/`…json..`/`…util..`/`JWTValidationLogMessages`; the larger transport-cluster migration (+ splitting the log registry) was folded into Plan 05 (option *b*), the first consumer of `commons.transport`. Resolution: the pure transport/JSON plumbing (`HttpWellKnownResolver`, `WellKnownConfig`(`urationConverter`), `HttpJwksLoaderConfig`, `JwksHttpContentConverter`, plus `ParserConfig`, the `Jwks`/`JwkKey`/`WellKnownResult` DTOs, `LoaderStatus`/`LoadingStatusProvider`, `JwksType`) moved to `commons.transport`; the JWKS *crypto* orchestrator (`HttpJwksLoader implements JwksLoader`, `JWKSKeyLoader`, `KeyInfo`, `jwks.parser/key`, `security`) *stayed in validation* and now depends *down* on `commons.transport` — the `HttpJwksLoader ↔ crypto` coupling was inverted, not carried along, honoring the "commons never interprets trust" seam. Six transport `LogRecord`s split into `commons.transport.TransportLogMessages` (same `TokenSheriff-` identifiers, so `doc/LogMessages.adoc` is unchanged); `WellKnownConfigurationConverter` now throws `commons.error.TransportException`.
-* [x] Libraries throw typed exceptions only (`commons.error.TokenSheriffException` hierarchy; `TokenValidationException` extends it); the `validation-quarkus` edge emits `application/problem+json` (RFC 9457) via `ProblemDetailExceptionMapper`. (`client-quarkus` edge lands with Plan 05.)
+* [x] Libraries throw typed exceptions only (`commons.error.TokenSheriffException` hierarchy; `TokenValidationException` extends it); the `validation-quarkus` edge emits `application/problem+json` (RFC 9457) via `ProblemDetailExceptionMapper`. (The `client-quarkus` edge landed with Plans 05/06 — `ClientExceptionMapper`.)
 * [x] Every `COMMONS-N` requirement and threat entry cites a source; SSRF/TLS/DoS covered for the relocated + new endpoints
 * [x] The `generators` test artifact gains dispatchers for the new endpoints (token / userinfo / revocation / introspection / end-session / PAR), with default + adversarial modes, alongside the existing `WellKnownDispatcher`/`JwksResolveDispatcher`
 * [x] `doc/commons/` requirements/spec/threat-model present; `references.adoc` resolves

--- a/doc/oidc/04-client-spec/README.adoc
+++ b/doc/oidc/04-client-spec/README.adoc
@@ -1,17 +1,16 @@
 = Plan 04 — Token Retrieval, Flows & BFF Groundwork: Requirements, Specification & Security
-:toc: macro
+:toc: left
 :toclevels: 3
+:toc-title: Table of Contents
 :sectnums:
 :source-highlighter: highlight.js
 
 [cols="1,3"]
 |===
 | Status     | *Done* — `CLIENT-1..22` requirements, specification, threat model and best practices live under `doc/client/`. Ship date + PR in the xref:../README.adoc[status roll-up].
-| Depends on | Plan 02 (doc structure) and xref:../03-commons/README.adoc[Plan 03] (the Commons transport this builds on); produces the spec the future client module is built against (spec-first)
+| Depends on | Plan 02 (doc structure) and xref:../03-commons/README.adoc[Plan 03] (the Commons transport this builds on); produced the spec the client module was built against (spec-first — delivered by Plans 05/06)
 | Focus      | Server-side *token retrieval* (token-endpoint grants incl. confidential authorization-code + PKCE), the *flow integrity* around it (`state`/`nonce`/PKCE, mix-up defence, step-up, RP-initiated logout), and the *token lifecycle* — the engine a *Backend-For-Frontend (BFF)* is built on. The *outbound IdP HTTP* it uses (discovery, JWKS, token, userinfo, …) belongs to xref:../03-commons/README.adoc[commons] and is referenced, not respecified. A *most-secure current subset*, security-led, every normative item source-referenced.
 |===
-
-toc::[]
 
 == Goal
 

--- a/doc/oidc/05-client-module/README.adoc
+++ b/doc/oidc/05-client-module/README.adoc
@@ -1,18 +1,17 @@
 = Plan 05 — Add the Client Module, Extension & Assembly (wired, empty)
-:toc: macro
+:toc: left
 :toclevels: 3
+:toc-title: Table of Contents
 :sectnums:
 :source-highlighter: highlight.js
 
 [cols="1,3"]
 |===
-| Status     | *Done* — the wired-but-empty `token-sheriff-client` engine, `token-sheriff-client-quarkus` extension/deployment, and BOM/reactor assembly exist; the `commons.transport` migration was folded in. Ship date + PR in the xref:../README.adoc[status roll-up].
+| Status     | *Done* — the wired-but-empty `token-sheriff-client` engine, `token-sheriff-client-quarkus` extension/deployment, and BOM/reactor assembly were established; the `commons.transport` migration was folded in. The skeleton has since been filled in by xref:../06-implement/README.adoc[Plan 06]. Ship date + PR in the xref:../README.adoc[status roll-up].
 | Depends on | Plan 01 (rename → `token-sheriff-*`) + Plan 03 (the `commons` base layer inside `token-sheriff-validation` it builds on). Independent of Plan 04 (structure, not content).
 | Outcome    | The three in-repo pieces — *module, extension, assembly* — fully wired, building green, with *no functional content yet*.
 | Scope      | In-repo only. `portal-authentication-oauth` (`cui-portal-core`) is the *replacement target* — a design reference (xref:../decision-oidc-module.adoc[decision], xref:../04-client-spec/README.adoc[Plan 04]), *not* a deliverable of this plan. The portal adapter and the integration tests against it are *future work beyond Plans 01–06*.
 |===
-
-toc::[]
 
 == Goal
 

--- a/doc/oidc/06-implement/README.adoc
+++ b/doc/oidc/06-implement/README.adoc
@@ -1,17 +1,16 @@
 = Plan 06 — Implement the Client (protocol by protocol)
-:toc: macro
+:toc: left
 :toclevels: 3
+:toc-title: Table of Contents
 :sectnums:
 :source-highlighter: highlight.js
 
 [cols="1,3"]
 |===
-| Status     | *Ready to execute — next plan.* Dependencies satisfied (Plans 03–05, all done — see the xref:../README.adoc[status roll-up]); execution begins with Increment 1 (client config + discovery). Not yet started.
+| Status     | *Done* — the client engine is implemented per this plan's increments: discovery, `client_credentials`, client authentication (`client_secret_*`, `private_key_jwt`, mTLS), refresh with rotation-reuse detection, authorization-code + PKCE with step-up, mix-up defence (`iss`) + PAR, userinfo, DPoP, token lifecycle + RP-initiated logout, and the adversarial attack-database hardening sweep (60 source / 51 test files in `token-sheriff-client`). See the xref:../README.adoc[status roll-up].
 | Depends on | Plan 03 (the `commons` base layer + `COMMONS-N` spec + the extended MockWebServer dispatchers), Plan 04 (`CLIENT-N` requirements + threat model + xref:../../client/specification/test-strategy.adoc[test strategy]), Plan 05 (`token-sheriff-client` module/extension/assembly)
 | Approach   | Vertical *protocol-by-protocol* increments, dependency-ordered. Each ships unit tests (MockWebServer) *and* integration tests against a *real Keycloak*. Security-driven.
 |===
-
-toc::[]
 
 == Approach: protocol per protocol
 

--- a/doc/oidc/README.adoc
+++ b/doc/oidc/README.adoc
@@ -1,5 +1,9 @@
 = OIDC Planning
+:toc: left
+:toclevels: 3
+:toc-title: Table of Contents
 :sectnums:
+:source-highlighter: highlight.js
 
 Working area for the Token-Sheriff direction: numbered, self-contained
 implementation plans plus the standing design decisions behind them.
@@ -56,8 +60,8 @@ implementation plans plus the standing design decisions behind them.
 * xref:02-doc-structure/README.adoc[Plan 02 — Documentation Structure]: *Phase 1 done*
   (2026-07, https://github.com/cuioss/TokenSheriff/pull/524[#524]) — the validation
   capability split under `doc/validation/` is executed and wired into the
-  xref:../README.adoc[Documentation Hub]. Phase 2 (client scaffolding) is deferred by
-  design until client work starts.
+  xref:../README.adoc[Documentation Hub]. Phase 2 (client scaffolding) was superseded —
+  the client document set landed under Plan 04 (`doc/client/`).
 * xref:03-commons/README.adoc[Plan 03 — Commons]: *Done*
   (2026-07-04, https://github.com/cuioss/TokenSheriff/pull/536[#536]) — the
   `de.cuioss.sheriff.token.commons.*` base layer (transport / error / events / metrics),
@@ -70,10 +74,13 @@ implementation plans plus the standing design decisions behind them.
 * xref:05-client-module/README.adoc[Plan 05 — Client Module]: *Done*
   (2026-07-05, https://github.com/cuioss/TokenSheriff/pull/538[#538]) — the wired-but-empty
   `token-sheriff-client` engine plus `token-sheriff-client-quarkus` extension/deployment
-  and BOM/reactor assembly exist; the `commons.transport` migration was folded in.
-* xref:06-implement/README.adoc[Plan 06 — Implement the Client]: *Next — not yet started.*
-  All dependencies (Plans 03–05) are satisfied; execution begins with Increment 1
-  (client config + discovery).
+  and BOM/reactor assembly were established; the `commons.transport` migration was folded in.
+  The skeleton has since been filled in by Plan 06.
+* xref:06-implement/README.adoc[Plan 06 — Implement the Client]: *Done* — the client engine
+  is implemented (discovery, authorization-code / client-credentials / refresh flows with
+  PKCE and PAR, client authentication, DPoP, token lifecycle, logout and userinfo; 60 source /
+  51 test files), and the `token-sheriff-client-quarkus` extension carries its CDI producer,
+  config mapping and exception mapper.
 
 [NOTE]
 ====

--- a/doc/oidc/decision-oidc-module.adoc
+++ b/doc/oidc/decision-oidc-module.adoc
@@ -1,6 +1,7 @@
 = Design Decision: Module Architecture — validation (with a commons base layer) + client
-:toc: macro
+:toc: left
 :toclevels: 3
+:toc-title: Table of Contents
 :sectnums:
 :source-highlighter: highlight.js
 
@@ -12,8 +13,6 @@
 | Supersedes| —
 | Related   | xref:01-restructure/README.adoc[Plan 01 — Restructure], xref:03-commons/README.adoc[Plan 03 — Commons], xref:05-client-module/README.adoc[Plan 05 — Add the Client Module], xref:../../README.md[Project README]
 |===
-
-toc::[]
 
 == Context
 
@@ -105,7 +104,7 @@ Until then, ArchUnit delivers the same layering guarantee with one fewer artifac
 
 == Still open
 
-* Session/state storage abstraction and its dependency footprint (addressed in the Plan 06 token-lifecycle increment).
+* _None._ The last open item — the session/state storage abstraction and its dependency footprint — was resolved by the Plan 06 token-lifecycle increment: the `TokenStore` abstraction with the dependency-free `InMemoryTokenStore` implementation ships in `token-sheriff-client`.
 
 == Alternatives considered
 

--- a/doc/validation/README.adoc
+++ b/doc/validation/README.adoc
@@ -1,4 +1,8 @@
 = Token Validation Capability
+:toc: left
+:toclevels: 3
+:toc-title: Table of Contents
+:sectnums:
 :source-highlighter: highlight.js
 
 The *passive* core of Token-Sheriff: a multi-issuer *JWT validation library* for resource
@@ -53,7 +57,7 @@ a consumer that needs only validation (e.g. `nifi-extensions`) pulls a single ar
 | MP-JWT 2.1 integration and rationale.
 
 | xref:specification/token-decryption.adoc[Spec — Token decryption]
-| Future JWE / encrypted-token support.
+| JWE / encrypted-token support (RFC 7516).
 
 | xref:specification/multi-idp-testing.adoc[Spec — Multi-IdP testing]
 | Testing against multiple OIDC providers.

--- a/doc/validation/architecture.adoc
+++ b/doc/validation/architecture.adoc
@@ -1,6 +1,7 @@
 = Token Validation Architecture
 :toc: left
 :toclevels: 3
+:toc-title: Table of Contents
 :sectnums:
 :source-highlighter: highlight.js
 
@@ -58,7 +59,7 @@ image::../resources/diagrams/token-content-types.svg["Token-content type hierarc
 * **TokenContent** / **BaseTokenContent** - Core interface and abstract base for JWT tokens
 * **AccessTokenContent** - OAuth2 access token with scope and role support
 * **IdTokenContent** - OpenID Connect ID token for user identity
-* **RefreshTokenContent** - Refresh token with minimal validation (implements `MinimalTokenContent`; if JWT-formatted, claims are extracted but no cryptographic signature verification or claim validation is performed)
+* **UnvalidatedRefreshToken** - Refresh token with minimal validation (implements `MinimalTokenContent`; if JWT-formatted, claims are extracted but no cryptographic signature verification or claim validation is performed)
 
 [[multi-issuer]]
 === IssuerConfig and Multi-Issuer Support
@@ -111,7 +112,7 @@ Thread-safe counter for security events during token processing. Created by `Tok
 
 === TokenValidatorMonitor
 
-High-performance, lock-free monitoring of validation pipeline metrics with microsecond precision. Measures the validation pipeline steps: `COMPLETE_VALIDATION`, `TOKEN_FORMAT_CHECK`, `TOKEN_PARSING`, `ISSUER_EXTRACTION`, `CACHE_LOOKUP`, `ISSUER_CONFIG_RESOLUTION`, `HEADER_VALIDATION`, `SIGNATURE_VALIDATION`, `TOKEN_BUILDING`, `CLAIMS_VALIDATION`, `CACHE_STORE`. Exposed as Micrometer counters in Quarkus (`sheriff.token.validation.errors`, `sheriff.token.validation.success`).
+High-performance, lock-free monitoring of validation pipeline metrics with microsecond precision. Measures the validation pipeline steps: `COMPLETE_VALIDATION`, `TOKEN_PARSING`, `ISSUER_EXTRACTION`, `CACHE_LOOKUP`, `ISSUER_CONFIG_RESOLUTION`, `HEADER_VALIDATION`, `SIGNATURE_VALIDATION`, `TOKEN_BUILDING`, `CLAIMS_VALIDATION`, `CACHE_STORE`. Exposed as Micrometer counters in Quarkus (`sheriff.token.validation.errors`, `sheriff.token.validation.success`).
 
 == Size Limits
 

--- a/doc/validation/security-reference.adoc
+++ b/doc/validation/security-reference.adoc
@@ -1,6 +1,7 @@
 = Security Reference
 :toc: left
 :toclevels: 3
+:toc-title: Table of Contents
 :sectnums:
 :source-highlighter: highlight.js
 

--- a/doc/validation/specification/microprofile-jwt-compatibility.adoc
+++ b/doc/validation/specification/microprofile-jwt-compatibility.adoc
@@ -160,7 +160,7 @@ The following capabilities have no equivalent in MP-JWT 2.1:
 * **DPoP (RFC 9449)** — Optional Demonstrating Proof-of-Possession validation
 * **Custom claim mappers** — Pluggable `ClaimMapper` interface with Keycloak-specific implementations
 * **Custom validation rules** — Pluggable `TokenValidationRule` interface for domain-specific post-validation checks (e.g., tenant-id enforcement, subject blocklists)
-* **Sealed token hierarchy** — `AccessTokenContent`, `IdTokenContent`, `RefreshTokenContent` with type-safe access patterns
+* **Sealed token hierarchy** — `AccessTokenContent`, `IdTokenContent`, `UnvalidatedRefreshToken` with type-safe access patterns
 * **Security event tracking** — `SecurityEventCounter` with categorized validation failure tracking
 * **Performance monitoring** — `TokenValidatorMonitor` with microsecond-precision pipeline measurements
 * **Token caching** — `AccessTokenCache` with TTL-based eviction
@@ -174,7 +174,7 @@ The following capabilities have no equivalent in MP-JWT 2.1:
 |MP-JWT Property |TokenSheriff Equivalent |Notes
 
 |`mp.jwt.verify.issuer`
-|`sheriff.token.issuers.<name>.expected-issuer`
+|`sheriff.token.issuers.<name>.issuer-identifier`
 |Per-issuer in TokenSheriff
 
 |`mp.jwt.verify.audiences`
@@ -186,7 +186,7 @@ The following capabilities have no equivalent in MP-JWT 2.1:
 |TokenSheriff uses OIDC discovery or direct JWKS URL
 
 |`mp.jwt.verify.publickey.algorithm`
-|`sheriff.token.issuers.<name>.allowed-signature-algorithms`
+|`sheriff.token.issuers.<name>.algorithm-preferences`
 |Per-issuer, multiple algorithms supported
 
 |`mp.jwt.verify.clock.skew`
@@ -206,12 +206,12 @@ The following capabilities have no equivalent in MP-JWT 2.1:
 |Global setting
 
 |`mp.jwt.decrypt.key.location`
-|`sheriff.token.jwe.decrypt-key-location`
-|JWE decryption key
+|`sheriff.token.jwe.decryption-key-path`
+|JWE decryption key (PKCS#8 PEM; keystore-based configuration also supported)
 
 |`mp.jwt.decrypt.key.algorithm`
-|`sheriff.token.jwe.key-management-algorithm`
-|JWE key management algorithm
+|`sheriff.token.jwe.key-management-algorithms`
+|JWE key management algorithms (list)
 |===
 
 == References

--- a/doc/validation/threat-model.adoc
+++ b/doc/validation/threat-model.adoc
@@ -1,6 +1,7 @@
 = Token Validation Threat Model
 :toc: left
 :toclevels: 3
+:toc-title: Table of Contents
 :sectnums:
 :source-highlighter: highlight.js
 
@@ -124,7 +125,7 @@ _See Requirement xref:requirements.adoc#VALIDATION-7[VALIDATION-7: Logging Requi
 
 |R2
 |Unauthorized token operations
-|Security event counting via link:../../token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/security/SecurityEventCounter.java[SecurityEventCounter]; Micrometer metrics in Quarkus
+|Security event counting via link:../../token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/commons/events/SecurityEventCounter.java[SecurityEventCounter]; Micrometer metrics in Quarkus
 |link:../../token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/security/SecurityEventCounterTest.java[SecurityEventCounterTest]
 
 |R3

--- a/token-sheriff-client/README.adoc
+++ b/token-sheriff-client/README.adoc
@@ -1,19 +1,15 @@
 = Token-Sheriff Client
 :toc: left
-:toclevels: 2
+:toclevels: 3
 :source-highlighter: highlight.js
 :toc-title: Table of Contents
 :sectnums:
 
 Framework-agnostic OIDC/OAuth *client* engine for Token-Sheriff — the outbound counterpart to
-`token-sheriff-validation`. Pure Java, no framework dependency.
-
-[NOTE]
-====
-*Status: wired, empty skeleton (Plan 05).* This module is stood up, building, and part of the
-reactor and BOM, but carries *no functional client content yet*. Flows are added in later
-increments (see xref:../doc/oidc/06-implement/README.adoc[Plan 06]).
-====
+`token-sheriff-validation`. Pure Java, no framework dependency: a server-side confidential-client
+engine that retrieves tokens, holds and refreshes them server-side, and drives the OAuth 2.0 /
+OpenID Connect flows. It is the engine a Backend-For-Frontend (BFF) is built on — it is not
+itself a BFF.
 
 == Maven Coordinates
 
@@ -25,21 +21,56 @@ increments (see xref:../doc/oidc/06-implement/README.adoc[Plan 06]).
 </dependency>
 ----
 
-== What it will do
+== Features
 
-The client engine drives the outbound OIDC/OAuth flows that complement token validation:
+Organized by package under `de.cuioss.sheriff.token.client`:
 
-* Token retrieval — https://www.rfc-editor.org/rfc/rfc6749[RFC 6749]
-* UserInfo — https://openid.net/specs/openid-connect-core-1_0.html[OIDC Core]
-* Token revocation — https://www.rfc-editor.org/rfc/rfc7009[RFC 7009]
-* Token introspection — https://www.rfc-editor.org/rfc/rfc7662[RFC 7662]
-* RP-Initiated Logout / `end_session`
-* Pushed Authorization Requests — https://www.rfc-editor.org/rfc/rfc9126[RFC 9126]
+* *Discovery* (`discovery`) — OIDC provider-metadata resolution (`DiscoveryResolver`,
+  `ProviderMetadata`) with TLS enforcement and issuer verification.
+* *Flows* (`flow`) — authorization-code flow with mandatory PKCE `S256`
+  (`AuthorizationCodeFlow`, `PkceChallenge`), client-credentials (`ClientCredentialsFlow`)
+  and refresh (`RefreshFlow`) grants, pushed authorization requests (`ParClient`, RFC 9126),
+  RFC 9207 `iss` mix-up defence (`IssValidator`), callback validation (`CallbackHandler`,
+  `CallbackParameters`), and RFC 9470 step-up authentication (`StepUpHandler`).
+* *Client authentication* (`auth`) — `client_secret_basic` / `client_secret_post`,
+  `private_key_jwt` (RFC 7523), and mTLS (RFC 8705) via `ClientAuthenticationSelector`.
+* *Sender-constraining* (`dpop`) — DPoP proof generation (`DpopProofGenerator`, RFC 9449)
+  with replay-safe `jti` handling and constraint binding.
+* *Token handling* (`token`) — every retrieved token is validated through
+  `token-sheriff-validation` (`TokenValidationBridge`, `IdTokenValidationBridge`), userinfo
+  retrieval with `sub` binding (`UserInfoClient`, `SubBindingValidator`), and refresh-token
+  rotation with reuse detection (`RefreshTokenFamily`).
+* *Lifecycle* (`lifecycle`) — server-side token storage (`TokenStore` abstraction with
+  `InMemoryTokenStore`), refresh scheduling (`RefreshScheduler`), and revocation
+  (`RevocationClient`, RFC 7009) via `TokenLifecycleManager`.
+* *Logout* (`logout`) — RP-initiated logout / `end_session` (`EndSessionFlow`) with
+  exact-match `post_logout_redirect_uri` validation (`PostLogoutRedirectValidator`).
 
 It adds *flows, not HTTP plumbing*: outbound bytes travel through the `commons` transport base
 layer (`de.cuioss.sheriff.token.commons.transport`) that ships inside `token-sheriff-validation`.
 Because it validates the tokens it retrieves, it depends on `token-sheriff-validation` and gets the
 `commons` base layer transitively.
+
+== Quick Start
+
+Configure the client once per issuer with the immutable `ClientConfiguration` value object,
+then drive the flow you need:
+
+[source,java]
+----
+ClientConfiguration config = ClientConfiguration.builder()
+    .issuer("https://issuer.example.com/realms/demo")
+    .clientId("my-confidential-client")
+    .clientSecret(secret)
+    .authMethod(ClientAuthMethod.CLIENT_SECRET_BASIC)
+    .scope("openid")
+    .build();
+----
+
+Endpoints are resolved via OIDC discovery against
+`{issuer}/.well-known/openid-configuration`. See the
+xref:../doc/client/specification/retrieval-flow.adoc[Retrieval & Flow specification] for the
+flow contracts and the xref:../doc/client/best-practices.adoc[Best Practices] checklist.
 
 == Documentation
 

--- a/token-sheriff-client/doc/README.adoc
+++ b/token-sheriff-client/doc/README.adoc
@@ -1,27 +1,34 @@
 = Token-Sheriff Client — Module Documentation
 :toc: left
-:toclevels: 2
+:toclevels: 3
 :source-highlighter: highlight.js
 :toc-title: Table of Contents
 :sectnums:
 
-Module-level documentation for `token-sheriff-client` (usage, configuration, development).
-
-[NOTE]
-====
-*Status: stub (Plan 05).* The module is a wired, empty skeleton with no functional content yet.
-Usage guides, configuration reference and developer notes land alongside the client flows in later
-increments (xref:../../doc/oidc/06-implement/README.adoc[Plan 06]).
-====
+Module-level documentation hub for `token-sheriff-client` (usage, configuration, development).
 
 == Capability documentation
 
 The conceptual *client capability* docs (requirements, architecture, threat model, specifications)
 live at the repository root under xref:../../doc/client/[`doc/client/`], as peer capabilities to
 `doc/validation/` and `doc/commons/` (see xref:../../doc/oidc/02-doc-structure/README.adoc[Plan 02]).
+They are the normative reference for the implemented engine:
 
-== Contents (to come)
+* xref:../../doc/client/architecture.adoc[Architecture] — the engine seam and its
+  commons / validation boundaries
+* xref:../../doc/client/requirements.adoc[Requirements] (`CLIENT-N`)
+* xref:../../doc/client/threat-model.adoc[Threat Model] and
+  xref:../../doc/client/best-practices.adoc[Best Practices]
+* xref:../../doc/client/specification/retrieval-flow.adoc[Retrieval & Flow],
+  xref:../../doc/client/specification/step-up-and-logout.adoc[Step-up & Logout],
+  xref:../../doc/client/specification/token-handling.adoc[Token Handling],
+  xref:../../doc/client/specification/test-strategy.adoc[Test Strategy]
 
-* `usage-guide.adoc` — obtaining and using the client engine
-* `configuration/` — client configuration reference
-* `developing.adoc` — extending the client
+== Module entry points
+
+* The module xref:../README.adoc[README] carries the feature summary (by package) and the
+  `ClientConfiguration` quick start.
+* Log messages of the engine (`TokenSheriffClient-*` identifiers) are registered in the global
+  xref:../../doc/LogMessages.adoc[Log Messages] registry.
+* The Quarkus binding is documented under
+  xref:../../token-sheriff-quarkus-parent/doc/README.adoc[token-sheriff-quarkus-parent/doc/].

--- a/token-sheriff-quarkus-parent/README.adoc
+++ b/token-sheriff-quarkus-parent/README.adoc
@@ -7,10 +7,11 @@
 :sectnums:
 
 
-A Quarkus extension for the Token-Sheriff validation library, consisting of:
+The Quarkus extensions for Token-Sheriff, consisting of:
 
 * xref:token-sheriff-validation-quarkus/README.adoc[token-sheriff-validation-quarkus] - Runtime module with CDI producers and JWT validation
 * xref:token-sheriff-validation-quarkus-deployment/README.adoc[token-sheriff-validation-quarkus-deployment] - Build-time deployment processor
+* `token-sheriff-client-quarkus` (+ `-deployment`) - Client-engine extension: CDI producer (`TokenSheriffClientProducer`), configuration mapping (`ClientRuntimeConfig`), and exception mapping (`ClientExceptionMapper`), building on the validation extension
 * xref:token-sheriff-quarkus-integration-tests/README.adoc[token-sheriff-quarkus-integration-tests] - Integration test suite
 
 == Building and Running
@@ -104,6 +105,7 @@ When no valid token is present, an empty `JsonWebToken` is injected where all me
 
 For details on the MicroProfile JWT compatibility layer, see xref:../doc/validation/specification/microprofile-jwt-compatibility.adoc[MicroProfile JWT Compatibility Specification].
 
+[#bearer-auth-declarative-security]
 ==== Declarative Security with @BearerAuth (Recommended)
 
 The `@BearerAuth` interceptor provides declarative security for JAX-RS endpoints with automatic error responses:
@@ -289,8 +291,9 @@ xref:doc/integration/health-checks.adoc[Health Checks Documentation]
 
 The project consists of the following modules:
 
-* xref:token-sheriff-validation-quarkus-deployment/README.adoc[token-sheriff-validation-quarkus-deployment] - Contains the Quarkus deployment code for the extension
-* xref:token-sheriff-validation-quarkus/README.adoc[token-sheriff-validation-quarkus] - Contains the runtime code for the extension
+* xref:token-sheriff-validation-quarkus-deployment/README.adoc[token-sheriff-validation-quarkus-deployment] - Contains the Quarkus deployment code for the validation extension
+* xref:token-sheriff-validation-quarkus/README.adoc[token-sheriff-validation-quarkus] - Contains the runtime code for the validation extension
+* `token-sheriff-client-quarkus` / `token-sheriff-client-quarkus-deployment` - Runtime and deployment code for the client-engine extension
 * xref:token-sheriff-quarkus-integration-tests/README.adoc[token-sheriff-quarkus-integration-tests] - Provides integration tests
 * link:e-2-e-playwright/[e-2-e-playwright] - End-to-end Playwright tests for Dev-UI
 * xref:doc/README.adoc[doc] - Contains additional documentation

--- a/token-sheriff-quarkus-parent/doc/README.adoc
+++ b/token-sheriff-quarkus-parent/doc/README.adoc
@@ -7,7 +7,7 @@
 
 == Overview
 
-Documentation for the Token-Sheriff Quarkus extension -- a JWT validation library integrated with Quarkus. The extension provides automatic configuration, health checks, metrics integration, and development UI components.
+Documentation for the Token-Sheriff Quarkus extensions. The validation extension provides automatic configuration, health checks, metrics integration, and development UI components; the client-engine extension (`token-sheriff-client-quarkus`) wires the OIDC/OAuth client engine into Quarkus (CDI producer, configuration mapping, exception mapping).
 
 == Quick Links
 
@@ -37,11 +37,12 @@ The Token-Sheriff Quarkus extension provides JWT validation through a modular ar
 
 * **xref:performance/jwt-validation-performance.adoc[JWT Validation Performance]** - Performance baselines and metrics
 * **xref:performance/native-optimization-guide.adoc[Native Optimization Guide]** - GraalVM build configuration
+* **xref:performance/graalvm-enterprise-optimization-options.adoc[GraalVM Enterprise Optimization Options]** - Oracle GraalVM optimization flags
 * **xref:performance/jfr-profiling-guide.adoc[JFR Profiling Guide]** - Performance analysis tools
 
 == BearerToken CDI Injection
 
-The extension provides CDI injection for validated bearer tokens via the `@BearerToken` annotation. See xref:../README.adoc#_bearertokenresult_injection_recommended[BearerTokenResult Injection] in the parent README for complete examples including scopes, roles, groups, and JAX-RS endpoint usage.
+The extension provides CDI injection for validated bearer tokens via the `@BearerToken` annotation. See xref:../README.adoc#bearer-auth-declarative-security[Declarative Security with @BearerAuth] in the parent README for complete examples including scopes, roles, groups, and JAX-RS endpoint usage.
 
 == Additional Resources
 

--- a/token-sheriff-quarkus-parent/doc/configuration/native-image-configuration.adoc
+++ b/token-sheriff-quarkus-parent/doc/configuration/native-image-configuration.adoc
@@ -27,10 +27,11 @@ The Token-Sheriff Quarkus deployment automatically registers the following class
 
 * **JWT Validation Pipeline**: `NonValidatingJwtParser`, `TokenSignatureValidator`, `TokenHeaderValidator`, `TokenClaimValidator`, `TokenBuilder`, `DecodedJwt`
 * **JWKS Loading**: `HttpJwksLoader`, `JWKSKeyLoader`, `KeyInfo`, `JwksParser`
-* **Token Content**: `AccessTokenContent`, `IdTokenContent`, `RefreshTokenContent`, `ClaimValue`
+* **Token Content**: `AccessTokenContent`, `IdTokenContent`, `UnvalidatedRefreshToken`, `ClaimValue`
 * **Security/Algorithm**: `SignatureAlgorithmPreferences`, `JwkAlgorithmPreferences`, `SecurityEventCounter`
 
-**Total Reflection Classes**: 39 classes registered automatically across 5 build steps.
+All reflection classes are registered automatically by the deployment module's build steps
+(see `TokenSheriffProcessor`) — no manual `reflect-config.json` entries are required.
 
 === Resource Configuration
 
@@ -169,7 +170,7 @@ quarkus.native.container-runtime-options=-m=64m
 
 * Native image size: 96-104MB (distroless: 104MB, JFR/UBI: 96MB)
 * Startup time: <1 second
-* Reflection classes: 39 registered
+* Reflection classes: registered automatically by `TokenSheriffProcessor`
 * Security services: All enabled for JWT support
 
 [source,bash]

--- a/token-sheriff-quarkus-parent/doc/integration/health-checks.adoc
+++ b/token-sheriff-quarkus-parent/doc/integration/health-checks.adoc
@@ -1,6 +1,6 @@
 = Health Checks
 :toc: left
-:toclevels: 2
+:toclevels: 3
 :source-highlighter: highlight.js
 :toc-title: Table of Contents
 :sectnums:

--- a/token-sheriff-quarkus-parent/token-sheriff-quarkus-integration-tests/README.adoc
+++ b/token-sheriff-quarkus-parent/token-sheriff-quarkus-integration-tests/README.adoc
@@ -223,7 +223,7 @@ Tests use `@ParameterizedTest` with `@MethodSource` to run against multiple OIDC
 * **bearer/BearerAuthSpecIT**: Bearer token producers and interceptors (Keycloak-only — requires ROLES, GROUPS, CUSTOM_SCOPES)
 * **security/DpopSpecIT**: DPoP RFC 9449 validation (parameterized over DPoP-capable providers)
 * **security/JweDecryptionSpecIT**: JWE RFC 7516 decryption (parameterized over JWE-capable providers)
-* **client/***: Client-engine specs against a real Keycloak — discovery (`DiscoverySpecIT`), `client_credentials` (`ClientCredentialsSpecIT`), client authentication (`ClientAuthSpecIT`), refresh with rotation (`RefreshSpecIT`), authorization-code + PKCE (`AuthCodePkceSpecIT`), mix-up defence (`MixUpSpecIT`), PAR (`ParSpecIT`), userinfo (`UserInfoSpecIT`), DPoP-bound tokens (`DpopBoundSpecIT`), revocation (`RevocationSpecIT`), RP-initiated logout (`LogoutSpecIT`), step-up (`StepUpSpecIT`), and the full-flow E2E (`FullFlowE2EIT`)
+* `client/**`: Client-engine specs against a real Keycloak — discovery (`DiscoverySpecIT`), `client_credentials` (`ClientCredentialsSpecIT`), client authentication (`ClientAuthSpecIT`), refresh with rotation (`RefreshSpecIT`), authorization-code + PKCE (`AuthCodePkceSpecIT`), mix-up defence (`MixUpSpecIT`), PAR (`ParSpecIT`), userinfo (`UserInfoSpecIT`), DPoP-bound tokens (`DpopBoundSpecIT`), revocation (`RevocationSpecIT`), RP-initiated logout (`LogoutSpecIT`), step-up (`StepUpSpecIT`), and the full-flow E2E (`FullFlowE2EIT`)
 * **health/HealthCheckIntegrationIT**: Health endpoint validation
 * **health/HealthCheckResponsivenessIT**: Health endpoint responsiveness testing
 * **api/ApiValidationSpecIT**: API input validation (provider-independent)

--- a/token-sheriff-quarkus-parent/token-sheriff-quarkus-integration-tests/README.adoc
+++ b/token-sheriff-quarkus-parent/token-sheriff-quarkus-integration-tests/README.adoc
@@ -8,7 +8,7 @@
 
 == Overview
 
-Integration tests for the Token-Sheriff Quarkus extension with native container testing, HTTPS support, health checks, and metrics validation.
+Integration tests for the Token-Sheriff Quarkus extensions with native container testing, HTTPS support, health checks, and metrics validation. Covers both the validation extension (token validation, bearer auth, DPoP, JWE) and the client engine (discovery, flows, logout) against a real Keycloak.
 
 == Port Configuration
 
@@ -176,10 +176,15 @@ token-sheriff-quarkus-integration-tests/
 │           └── integration-realm.json
 ├── src/test/java/de/cuioss/sheriff/token/integration/
 │   ├── BaseIntegrationTest.java
+│   ├── TestConstants.java
 │   ├── TestRealm.java
 │   ├── TestProviders.java
 │   ├── token/TokenValidationSpecIT.java
 │   ├── bearer/BearerAuthSpecIT.java
+│   ├── client/{DiscoverySpecIT,ClientCredentialsSpecIT,ClientAuthSpecIT,RefreshSpecIT,
+│   │           AuthCodePkceSpecIT,MixUpSpecIT,ParSpecIT,UserInfoSpecIT,DpopBoundSpecIT,
+│   │           RevocationSpecIT,LogoutSpecIT,StepUpSpecIT,FullFlowE2EIT,
+│   │           FormPostSupport,KeycloakUrlSupport}.java
 │   ├── security/{DpopSpecIT,JweDecryptionSpecIT,DpopProofHelper}.java
 │   ├── health/{HealthCheckIntegrationIT,HealthCheckResponsivenessIT}.java
 │   └── api/{ApiValidationSpecIT,TokenRequestSpecIT}.java
@@ -187,6 +192,8 @@ token-sheriff-quarkus-integration-tests/
     ├── start-integration-container.sh
     ├── stop-integration-container.sh
     ├── build-native-if-needed.sh
+    ├── dump-app-logs.sh
+    ├── dump-keycloak-logs.sh
     └── verify-environment.sh
 ----
 
@@ -216,6 +223,7 @@ Tests use `@ParameterizedTest` with `@MethodSource` to run against multiple OIDC
 * **bearer/BearerAuthSpecIT**: Bearer token producers and interceptors (Keycloak-only — requires ROLES, GROUPS, CUSTOM_SCOPES)
 * **security/DpopSpecIT**: DPoP RFC 9449 validation (parameterized over DPoP-capable providers)
 * **security/JweDecryptionSpecIT**: JWE RFC 7516 decryption (parameterized over JWE-capable providers)
+* **client/***: Client-engine specs against a real Keycloak — discovery (`DiscoverySpecIT`), `client_credentials` (`ClientCredentialsSpecIT`), client authentication (`ClientAuthSpecIT`), refresh with rotation (`RefreshSpecIT`), authorization-code + PKCE (`AuthCodePkceSpecIT`), mix-up defence (`MixUpSpecIT`), PAR (`ParSpecIT`), userinfo (`UserInfoSpecIT`), DPoP-bound tokens (`DpopBoundSpecIT`), revocation (`RevocationSpecIT`), RP-initiated logout (`LogoutSpecIT`), step-up (`StepUpSpecIT`), and the full-flow E2E (`FullFlowE2EIT`)
 * **health/HealthCheckIntegrationIT**: Health endpoint validation
 * **health/HealthCheckResponsivenessIT**: Health endpoint responsiveness testing
 * **api/ApiValidationSpecIT**: API input validation (provider-independent)

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus-deployment/README.adoc
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus-deployment/README.adoc
@@ -96,8 +96,8 @@ Automatically registers classes for reflection across 5 build steps (36 classes 
 **Configuration Classes (Methods Only):**
 
 * `de.cuioss.sheriff.token.validation.IssuerConfig` - Issuer configuration
-* `de.cuioss.sheriff.token.validation.ParserConfig` - Parser settings
-* `de.cuioss.sheriff.token.validation.jwks.http.HttpJwksLoaderConfig` - JWKS loader configuration
+* `de.cuioss.sheriff.token.commons.transport.ParserConfig` - Parser settings
+* `de.cuioss.sheriff.token.commons.transport.HttpJwksLoaderConfig` - JWKS loader configuration
 
 **Runtime Initialization:**
 

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/README.adoc
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/README.adoc
@@ -109,7 +109,7 @@ Runtime service for DevUI integration:
 [source, yaml]
 ----
 sheriff:
-  oauth:
+  token:
     issuers:
       my-issuer:
         issuer-identifier: "https://auth.example.com"
@@ -124,7 +124,7 @@ sheriff:
 [source, yaml]
 ----
 sheriff:
-  oauth:
+  token:
     issuers:
       issuer-one:
         issuer-identifier: "https://auth1.example.com"

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/main/resources/META-INF/quarkus-config-doc.adoc
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/main/resources/META-INF/quarkus-config-doc.adoc
@@ -115,9 +115,9 @@ belongs to this Resource Server.
 |===
 |Property |Type |Default |Description
 |`sheriff.token.jwe.decryption-key-path` |String |— |Path to a PKCS#8 PEM file with the decryption private key
-|`sheriff.token.jwe.decryption-key-id` |String |— |Key id (`kid`) associated with the PEM key
+|`sheriff.token.jwe.decryption-key-id` |String |— |Key ID (`kid`) associated with the PEM key
 |`sheriff.token.jwe.decryption-keys.<kid>` |String |— |Additional per-`kid` PEM key paths (rotation)
-|`sheriff.token.jwe.default-key-id` |String |— |Default key id when multiple keys are configured
+|`sheriff.token.jwe.default-key-id` |String |— |Default key ID when multiple keys are configured
 |`sheriff.token.jwe.keystore-path` |String |— |Keystore-based key configuration (alternative to PEM)
 |`sheriff.token.jwe.keystore-password` |String |— |Keystore password
 |`sheriff.token.jwe.key-alias` |String |— |Keystore key alias

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/main/resources/META-INF/quarkus-config-doc.adoc
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/main/resources/META-INF/quarkus-config-doc.adoc
@@ -1,4 +1,6 @@
 = Token-Sheriff Quarkus Extension Configuration Reference
+:toc: left
+:toclevels: 3
 :toc-title: Table of Contents
 :sectnums:
 :source-highlighter: highlight.js
@@ -29,6 +31,10 @@ Properties under `sheriff.token.issuers.<name>.*` — one block per issuer.
 |`algorithm-preferences` |String (csv) |— |Allowed signature algorithms (default: all supported)
 |`claim-sub-optional` |boolean |`false` |Allow missing `sub` claim
 |`expected-token-type` |String |— (disabled) |Expected `typ` header value. Set to `at+jwt` for RFC 9068-compliant IdPs. Most IdPs (Keycloak, Zitadel, Dex) do *not* set `at+jwt` — verify before enabling.
+|`audience-validation-disabled` |boolean |`false` |Disable audience validation for this issuer
+|`access-token-audience-optional` |boolean |`false` |Allow access tokens without an `aud` claim
+|`clock-skew-seconds` |int |`60` |Clock skew tolerance for `exp` / `nbf` validation
+|`max-token-age-seconds` |int |— (disabled) |Max token age based on `iat`; rejects when `now - iat > max-token-age-seconds + clock-skew-seconds`
 |===
 
 === JWKS Source (mutually exclusive)
@@ -52,6 +58,9 @@ Properties under `sheriff.token.issuers.<name>.*` — one block per issuer.
 |`jwks.http.read-timeout-seconds` |int |`10` |HTTP read timeout
 |`jwks.http.key-rotation-grace-period-seconds` |int |`300` |Grace period for retired keys during rotation
 |`jwks.http.max-retired-key-sets` |int |`3` |Max retained retired key sets
+|`jwks.http.allow-insecure-http` |boolean |`false` |Permit plain-HTTP JWKS endpoints (testing only)
+|`jwks.http.allow-loopback-egress` |boolean |`false` |Permit loopback resolutions in the SSRF egress guard (local development / MockWebServer)
+|`jwks.http.allowed-egress-hosts` |String (csv) |— |Explicit host allow-list bypassing the egress address-range checks
 |===
 
 === DPoP (RFC 9449)
@@ -86,6 +95,36 @@ without enabling DPoP fails at application startup to prevent silently disabled 
 |Property |Type |Default |Description
 |`sheriff.token.cache.access-token.max-size` |int |`1000` |Max cached tokens (0 = disabled)
 |`sheriff.token.cache.access-token.eviction-interval-seconds` |long |`10` |Eviction run interval
+|===
+
+== Token Extraction
+
+[cols="2,1,1,3", options="header"]
+|===
+|Property |Type |Default |Description
+|`sheriff.token.token.header` |String |`Authorization` |Token source: `Authorization` (Bearer header) or `Cookie`
+|`sheriff.token.token.cookie-name` |String |`Bearer` |Cookie name when `sheriff.token.token.header=Cookie`
+|===
+
+== JWE Decryption
+
+Configured at the `TokenValidator` level (not per-issuer) — the decryption private key
+belongs to this Resource Server.
+
+[cols="2,1,1,3", options="header"]
+|===
+|Property |Type |Default |Description
+|`sheriff.token.jwe.decryption-key-path` |String |— |Path to a PKCS#8 PEM file with the decryption private key
+|`sheriff.token.jwe.decryption-key-id` |String |— |Key id (`kid`) associated with the PEM key
+|`sheriff.token.jwe.decryption-keys.<kid>` |String |— |Additional per-`kid` PEM key paths (rotation)
+|`sheriff.token.jwe.default-key-id` |String |— |Default key id when multiple keys are configured
+|`sheriff.token.jwe.keystore-path` |String |— |Keystore-based key configuration (alternative to PEM)
+|`sheriff.token.jwe.keystore-password` |String |— |Keystore password
+|`sheriff.token.jwe.key-alias` |String |— |Keystore key alias
+|`sheriff.token.jwe.key-password` |String |— |Key password (defaults to keystore password)
+|`sheriff.token.jwe.key-management-algorithms` |String (csv) |all supported |Allowed key management algorithms (RSA-OAEP, RSA-OAEP-256, ECDH-ES)
+|`sheriff.token.jwe.content-encryption-algorithms` |String (csv) |all supported |Allowed content encryption algorithms (A128GCM, A256GCM, A128CBC-HS256, A256CBC-HS512)
+|`sheriff.token.jwe.max-encrypted-token-size` |int |`32768` |Max JWE token size (bytes)
 |===
 
 == Health Checks

--- a/token-sheriff-validation/README.adoc
+++ b/token-sheriff-validation/README.adoc
@@ -1,6 +1,6 @@
 = Token-Sheriff Core
 :toc: left
-:toclevels: 2
+:toclevels: 3
 :source-highlighter: highlight.js
 :toc-title: Table of Contents
 :sectnums:
@@ -49,8 +49,11 @@ try {
 * **Type-Safe Tokens**: Strongly typed Access, ID, and Refresh tokens
 * **Security Pipeline**: Structure, signature, and semantic validation
 * **Flexible Key Management**: Static keys, JWKS endpoints, OpenID Connect
+* **JWE Decryption**: Encrypted-token (RFC 7516) support via `JweDecryptionConfig`
+* **DPoP Validation**: Sender-constrained tokens (RFC 9449)
 * **Built-in Caching**: Performance-optimized token validation
 * **Custom Claim Mapping**: Extensible claim processing
+* **Commons Base Layer**: The artifact also carries the `de.cuioss.sheriff.token.commons.*` transport / error / events / metrics layer (ArchUnit-enforced), consumed by validation and the client engine
 
 == Documentation
 

--- a/token-sheriff-validation/doc/UnitTesting.adoc
+++ b/token-sheriff-validation/doc/UnitTesting.adoc
@@ -20,7 +20,7 @@ See xref:../README.adoc#test-artifact[Test Artifact Dependencies] in the main mo
 === Contents
 
 * `de.cuioss.sheriff.token.validation.test` - Core test utilities
-* `de.cuioss.sheriff.token.validation.test.dispatcher` - MockWebServer dispatchers (`WellKnownDispatcher`, `JwksResolveDispatcher`)
+* `de.cuioss.sheriff.token.validation.test.dispatcher` - MockWebServer dispatchers: discovery/JWKS (`WellKnownDispatcher`, `JwksResolveDispatcher`, `EnhancedJwksResolveDispatcher`, `MultiIssuerJwksDispatcher`) and the OP-endpoint dispatchers (`TokenDispatcher`, `UserInfoDispatcher`, `RevocationDispatcher`, `IntrospectionDispatcher`, `EndSessionDispatcher`, `ParDispatcher`), plus the shared `AdversarialResponses` payloads
 * `de.cuioss.sheriff.token.validation.test.generator` - Token and claim generators
 * `de.cuioss.sheriff.token.validation.test.junit` - JUnit 5 extensions and annotations (`@TestTokenSource`)
 

--- a/token-sheriff-validation/doc/api-reference.adoc
+++ b/token-sheriff-validation/doc/api-reference.adoc
@@ -15,11 +15,11 @@ The main entry point for token validation.
 [source,java]
 ----
 public class TokenValidator implements Closeable {
-    public static Builder builder() { ... }
+    public static TokenValidatorBuilder builder() { ... }
 
     public AccessTokenContent createAccessToken(AccessTokenRequest request);
     public IdTokenContent createIdToken(IdTokenRequest request);
-    public RefreshTokenContent createRefreshToken(RefreshTokenRequest request);
+    public UnvalidatedRefreshToken createRefreshToken(RefreshTokenRequest request);
 ----
 
 === AccessTokenContent
@@ -58,7 +58,7 @@ public class AccessTokenContent extends BaseTokenContent {
 [source,java]
 ----
 public class IssuerConfig implements LoadingStatusProvider {
-    public static Builder builder() { ... }
+    public static IssuerConfigBuilder builder() { ... }
 
     public static class IssuerConfigBuilder {
         public IssuerConfigBuilder enabled(boolean enabled);

--- a/token-sheriff-validation/doc/configuration/multi-issuer-setup.adoc
+++ b/token-sheriff-validation/doc/configuration/multi-issuer-setup.adoc
@@ -107,7 +107,7 @@ public class DynamicTokenValidator {
     private volatile TokenValidator validator;
 
     public void reloadIssuers() {
-        TokenValidator.Builder builder = TokenValidator.builder();
+        TokenValidator.TokenValidatorBuilder builder = TokenValidator.builder();
         List<IssuerConfig> issuers = loadIssuersFromDatabase();
         for (IssuerConfig issuer : issuers) {
             builder.issuerConfig(issuer);

--- a/token-sheriff-validation/doc/configuration/openid-discovery.adoc
+++ b/token-sheriff-validation/doc/configuration/openid-discovery.adoc
@@ -106,7 +106,7 @@ public class OpenIDConnectValidator {
 public class MultiProviderDiscovery {
 
     public static TokenValidator createMultiProvider() {
-        TokenValidator.Builder builder = TokenValidator.builder();
+        TokenValidator.TokenValidatorBuilder builder = TokenValidator.builder();
 
         addProviderFromDiscovery(builder, "https://accounts.google.com", "google-client-id");
         addProviderFromDiscovery(builder, "https://login.microsoftonline.com/common/v2.0", "microsoft-client-id");
@@ -116,7 +116,7 @@ public class MultiProviderDiscovery {
     }
 
     private static void addProviderFromDiscovery(
-            TokenValidator.Builder builder, String issuerUrl, String clientId) {
+            TokenValidator.TokenValidatorBuilder builder, String issuerUrl, String clientId) {
         try {
             IssuerConfig issuerConfig = IssuerConfig.builder()
                 .expectedAudience(clientId)

--- a/token-sheriff-validation/doc/developing.adoc
+++ b/token-sheriff-validation/doc/developing.adoc
@@ -40,7 +40,6 @@ metrics.ifPresent(stats -> {
 Pipeline steps (in execution order):
 
 * `COMPLETE_VALIDATION` - End-to-end validation time
-* `TOKEN_FORMAT_CHECK` - Pre-pipeline string validation (empty/blank/size checks)
 * `TOKEN_PARSING` - Base64URL decoding and JSON structure parsing
 * `ISSUER_EXTRACTION` - Extract and validate issuer (iss) claim
 * `CACHE_LOOKUP` - Check cache before expensive operations (access tokens only)
@@ -50,14 +49,6 @@ Pipeline steps (in execution order):
 * `TOKEN_BUILDING` - Build typed token object from validated JWT
 * `CLAIMS_VALIDATION` - Token claims validation (exp, nbf, aud, iss)
 * `CACHE_STORE` - Store validated token in cache (access tokens only)
-
-Cross-cutting concerns:
-
-* `JWKS_OPERATIONS` - Key loading and caching operations (within signature validation)
-* `JWE_DECRYPTION` - JWE token decryption (within token parsing for 5-part JWE tokens)
-* `RETRY_ATTEMPT` - Individual HTTP retry attempt timing
-* `RETRY_COMPLETE` - Complete retry cycle with all attempts and delays
-* `RETRY_DELAY` - Exponential backoff delay timing between retries
 
 === Design Principles
 
@@ -157,7 +148,7 @@ See xref:UnitTesting.adoc[Unit Testing Guide] for test utilities via the `genera
 * Configure appropriate JWKS refresh intervals (300-3600 seconds)
 * Consider using the built-in access token cache
 
-Some operations (`TOKEN_FORMAT_CHECK`, `ISSUER_EXTRACTION`, `JWKS_OPERATIONS` with cached keys) execute in sub-microsecond time and may appear as zero when exported to milliseconds. This is expected behavior.
+Some operations (`ISSUER_EXTRACTION`, `CACHE_LOOKUP` with cached keys) execute in sub-microsecond time and may appear as zero when exported to milliseconds. This is expected behavior.
 
 == Memory Management
 


### PR DESCRIPTION
## Summary

Full accuracy review of the project's AsciiDoc documentation and the root `README.md`, correcting every reviewed document so it reflects the codebase's actual current status. Docs-only plan: no production/test code changes, no build/verify pass.

The review was driven by a confirmed staleness finding: `token-sheriff-client/README.adoc` and `token-sheriff-client/doc/README.adoc` both carried a "Status: stub / wired, empty skeleton (Plan 05)" note, and the root `README.md` module table repeated the same stale claim for `token-sheriff-client` / `token-sheriff-client-quarkus`. The architecture inventory shows 60 source files and 51 test files under `token-sheriff-client` (auth, flow, dpop, lifecycle, logout, token packages) — the module is functionally implemented, not an empty skeleton. That correction, plus every other staleness issue found during the per-module pass, is applied across 61 changed files spanning 12 deliverables / 11 modules.

The existing landing-page (`README.adoc`) / doc-hub (`doc/README.adoc`) structural pattern used across modules (`token-sheriff-client`, `token-sheriff-quarkus-parent`) is intentional and is preserved as-is; only content accuracy was corrected.

## Changes

- `README.md` — corrected the module-status table (removed the stale "empty skeleton" claims).
- `doc/README.adoc`, `doc/LogMessages.adoc` — top-level doc hub and log-message reference refreshed.
- `doc/client/**` (9 files: README, architecture, best-practices, requirements, threat-model, and 4 specification pages) — client module docs refreshed, including the stub/skeleton status correction.
- `doc/commons/**` (7 files: README, architecture, requirements, threat-model, and 3 specification pages) — commons module docs refreshed.
- `doc/oidc/**` (10 files: README plus the 6 plan-history sub-pages `01-restructure` .. `06-implement`, the restructure migration/checklist notes, and the OIDC-module decision record) — historical/plan-status docs corrected to reflect the completed state.
- `doc/validation/**` (5 files: README, architecture, security-reference, threat-model, MicroProfile-JWT-compatibility spec) — validation module docs refreshed.
- `token-sheriff-client/README.adoc`, `token-sheriff-client/doc/README.adoc` — stale "stub / empty skeleton" status replaced with the module's actual implemented state.
- `token-sheriff-quarkus-parent/**` (8 files: parent README + doc hub, native-image-configuration, health-checks, and the 3 sub-module READMEs for `token-sheriff-quarkus-integration-tests`, `token-sheriff-validation-quarkus-deployment`, `token-sheriff-validation-quarkus`, plus the generated quarkus-config-doc reference) — Quarkus integration docs refreshed.
- `token-sheriff-validation/**` (6 files: README, UnitTesting, api-reference, developing, and 2 configuration pages) — validation library docs refreshed.
- `benchmarking/**` (11 files: top-level and benchmark-core READMEs, benchmarking-common README + LogMessages, and 7 architecture/workflow/profiling/metrics/scoring docs under `benchmarking/doc/`) — benchmarking suite docs refreshed.

## Known Issue Found During Review (Out of Scope for This Docs-Only Plan)

While cross-referencing log-message identifiers documented in `doc/LogMessages.adoc`, an identifier collision was found: `TokenSheriff-168` is used by both `TransportLogMessages.SSRF_EGRESS_BLOCKED_DISCOVERY` and `JWTValidationLogMessages.DUPLICATE_JWKS_KID`. This is a production-code fix and is out of scope for this docs-only plan — flagging it here for a follow-up fix.

## Test Plan

- [ ] N/A — docs-only plan; no production/test code changes, no build/verify pass required (per plan scope).

## Related Issues

None.
