### PR TITLE
fix(it): make docker-compose cleanup resilient to missing daemon/plugin

### DIFF
--- a/token-sheriff-quarkus-parent/token-sheriff-quarkus-integration-tests/scripts/lib-docker-compose.sh
+++ b/token-sheriff-quarkus-parent/token-sheriff-quarkus-integration-tests/scripts/lib-docker-compose.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Shared helpers for resolving the Docker Compose command and probing the daemon.
+# Source this file: `source "$(dirname "$0")/lib-docker-compose.sh"`
+#
+# Rationale: not every host wires the Compose v2 plugin into the docker CLI
+# (`docker compose`). Rancher Desktop, for example, ships the standalone
+# `docker-compose` binary instead. Hardcoding `docker compose` makes it fail
+# with "unknown shorthand flag: 'f'" because docker parses `-f` as a top-level
+# option. Resolve whichever form is actually available.
+
+# Prints the working compose invocation (either "docker compose" or
+# "docker-compose"), or nothing if neither is available. Returns non-zero when
+# no compose command exists.
+resolve_compose_cmd() {
+    if docker compose version >/dev/null 2>&1; then
+        echo "docker compose"
+        return 0
+    fi
+    if command -v docker-compose >/dev/null 2>&1; then
+        echo "docker-compose"
+        return 0
+    fi
+    return 1
+}
+
+# Returns 0 when the Docker daemon is reachable, non-zero otherwise.
+docker_daemon_up() {
+    docker info >/dev/null 2>&1
+}

--- a/token-sheriff-quarkus-parent/token-sheriff-quarkus-integration-tests/scripts/start-integration-container.sh
+++ b/token-sheriff-quarkus-parent/token-sheriff-quarkus-integration-tests/scripts/start-integration-container.sh
@@ -7,9 +7,23 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 ROOT_DIR="$(dirname "$(dirname "$PROJECT_DIR")")"
 
+# shellcheck source=lib-docker-compose.sh
+source "${SCRIPT_DIR}/lib-docker-compose.sh"
+
 echo "Starting JWT Integration Tests with Docker Compose"
 echo "Project directory: ${PROJECT_DIR}"
 echo "Root directory: ${ROOT_DIR}"
+
+# Resolve the compose command (docker compose plugin vs standalone docker-compose)
+COMPOSE_BASE="$(resolve_compose_cmd || true)"
+if [[ -z "$COMPOSE_BASE" ]]; then
+    echo "Error: Docker Compose not available (neither 'docker compose' nor 'docker-compose')"
+    exit 1
+fi
+if ! docker_daemon_up; then
+    echo "Error: Docker daemon not running — start Docker/Rancher Desktop first"
+    exit 1
+fi
 
 cd "${PROJECT_DIR}"
 
@@ -76,9 +90,9 @@ echo "Quarkus logs will be written to: ${LOG_TARGET_DIR}/quarkus.log"
 if [[ -n "$COMPOSE_OVERRIDE" ]]; then
     mkdir -p "${PROJECT_DIR}/target/jfr-output"
     echo "Using compose overlay: $COMPOSE_OVERRIDE"
-    (cd "${PROJECT_DIR}" && docker compose -f "$COMPOSE_FILE" -f "$COMPOSE_OVERRIDE" up -d)
+    (cd "${PROJECT_DIR}" && $COMPOSE_BASE -f "$COMPOSE_FILE" -f "$COMPOSE_OVERRIDE" up -d)
 else
-    (cd "${PROJECT_DIR}" && docker compose -f "$COMPOSE_FILE" up -d)
+    (cd "${PROJECT_DIR}" && $COMPOSE_BASE -f "$COMPOSE_FILE" up -d)
 fi
 
 # Wait for Keycloak to be ready first
@@ -136,7 +150,7 @@ if [[ "$COMPOSE_PROFILES" == *"multi-idp"* ]]; then
     echo "Running Zitadel setup script..."
     # Copy PAT from Docker container to host-accessible location
     # Retry because Zitadel may still be writing the PAT file after health check passes
-    PAT_CONTAINER=$(docker compose ps -q zitadel)
+    PAT_CONTAINER=$($COMPOSE_BASE ps -q zitadel)
     mkdir -p /tmp/zitadel-admin-pat
     for i in {1..10}; do
         if docker cp "${PAT_CONTAINER}:/machinekey/zitadel-admin-sa.pat" /tmp/zitadel-admin-pat/ 2>/dev/null; then
@@ -229,7 +243,7 @@ if [[ "$COMPOSE_PROFILES" == *"multi-idp"* ]]; then
 fi
 
 # Extract native startup time from logs
-NATIVE_STARTUP=$(docker compose logs token-sheriff-integration-tests 2>/dev/null | grep "started in" | sed -n 's/.*started in \([0-9.]*\)s.*/\1/p' | tail -1)
+NATIVE_STARTUP=$($COMPOSE_BASE logs token-sheriff-integration-tests 2>/dev/null | grep "started in" | sed -n 's/.*started in \([0-9.]*\)s.*/\1/p' | tail -1)
 if [ ! -z "$NATIVE_STARTUP" ]; then
     echo "Native app startup: ${NATIVE_STARTUP}s (application only)"
 fi

--- a/token-sheriff-quarkus-parent/token-sheriff-quarkus-integration-tests/scripts/stop-integration-container.sh
+++ b/token-sheriff-quarkus-parent/token-sheriff-quarkus-integration-tests/scripts/stop-integration-container.sh
@@ -6,16 +6,33 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 
+# shellcheck source=lib-docker-compose.sh
+source "${SCRIPT_DIR}/lib-docker-compose.sh"
+
 echo "Stopping JWT Integration Tests Docker containers"
 
 cd "${PROJECT_DIR}"
+
+# This runs at Maven's pre-clean phase as a best-effort cleanup. If Docker isn't
+# available or the daemon isn't running there is nothing to stop, so exit
+# cleanly rather than failing `clean install`.
+COMPOSE_BASE="$(resolve_compose_cmd || true)"
+if [[ -z "$COMPOSE_BASE" ]]; then
+    echo "Docker Compose not available — nothing to stop, skipping cleanup."
+    exit 0
+fi
+if ! docker_daemon_up; then
+    echo "Docker daemon not running — nothing to stop, skipping cleanup."
+    exit 0
+fi
 
 # Use the docker-compose.yml file (only file available)
 COMPOSE_FILE="docker-compose.yml"
 MODE="native"
 
 # Build compose command with optional overlay (using array for safe argument handling)
-COMPOSE_CMD=("docker" "compose" "-f" "$COMPOSE_FILE")
+read -ra COMPOSE_CMD <<< "$COMPOSE_BASE"
+COMPOSE_CMD+=("-f" "$COMPOSE_FILE")
 if [[ -n "$COMPOSE_OVERRIDE" ]]; then
     echo "Using compose overlay: $COMPOSE_OVERRIDE"
     COMPOSE_CMD+=("-f" "$COMPOSE_OVERRIDE")


### PR DESCRIPTION
## Problem

`clean install` fails at the `token-sheriff-quarkus-integration-tests` module's `pre-clean` phase. The best-effort cleanup script `stop-integration-container.sh` hardcodes `docker compose`, which fails when:

- the Docker daemon isn't running, or
- the Compose v2 plugin isn't wired into the docker CLI (e.g. Rancher Desktop ships the standalone `docker-compose` binary).

In that case docker parses `-f` as a top-level flag → `unknown shorthand flag: 'f'` → exit **125**, which is outside the `pre-clean` `successCodes` (0,1), so the whole build fails even though this cleanup is meant to be non-fatal.

## Fix

- New `scripts/lib-docker-compose.sh` shared helper: `resolve_compose_cmd()` (prefers `docker compose`, falls back to `docker-compose`) and `docker_daemon_up()`.
- `stop-integration-container.sh`: exits 0 cleanly when Compose is unavailable or the daemon is down (nothing to stop), otherwise uses the resolved command.
- `start-integration-container.sh`: fixes the identical latent hardcoded-`docker compose` bug and fails fast with a clear message if Compose/daemon is missing.

`benchmark-integration-wrk` reuses these IT scripts, so it's covered too. The `e-2-e-playwright` stop script was already build-safe.

## Verification

- Reproduced original failure: exit 125.
- After fix, `stop-integration-container.sh --clean` with daemon down → exit 0.
- `bash -n` passes on all three scripts.
- `mvnw pre-clean -pl .../token-sheriff-quarkus-integration-tests` → exit 0 (the previously failing step).
- `mvnw pre-clean -pl .../e-2-e-playwright` → exit 0 (confirmed unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)