### PR TITLE
chore(build): adopt cui-java-parent 1.5.2, drop local pre-commit override

### DIFF
--- a/.plan/project-architecture/token-sheriff-client/enriched.json
+++ b/.plan/project-architecture/token-sheriff-client/enriched.json
@@ -1,5 +1,7 @@
 {
-  "best_practices": [],
+  "best_practices": [
+    "Javadoc {@link} references deliberately target Lombok-backed private fields (e.g. ClientConfiguration#allowInsecureHttp, ClientAuthMethod#strength) instead of generated accessors \u2014 Lombok getters are invisible to javadoc without delombok; the field-link form validates clean under -Xdoclint:all. Decline review-bot suggestions to switch to accessor links"
+  ],
   "insights": [],
   "internal_dependencies": [
     "token-sheriff-validation"

--- a/.plan/project-architecture/token-sheriff-validation-quarkus-deployment-npm/enriched.json
+++ b/.plan/project-architecture/token-sheriff-validation-quarkus-deployment-npm/enriched.json
@@ -1,5 +1,7 @@
 {
-  "best_practices": [],
+  "best_practices": [
+    "License scanners (Sourcery/trivy) cannot identify the OSI-approved BlueOak-1.0.0 license used by several transitive npm packages (chownr, tar, yallist, isexe, ...) \u2014 such license-ID-gap notices on package-lock.json are an accepted, non-actionable finding class; do not chase them as security/legal risks"
+  ],
   "insights": [],
   "internal_dependencies": [
     "token-sheriff-validation-quarkus-deployment-maven"

--- a/benchmarking/benchmarking-common/src/test/java/de/cuioss/benchmarking/common/test/TestResourceLoader.java
+++ b/benchmarking/benchmarking-common/src/test/java/de/cuioss/benchmarking/common/test/TestResourceLoader.java
@@ -107,7 +107,7 @@ public final class TestResourceLoader {
      */
     public static Path writeTestFile(Path tempDir, String fileName, String content) throws IOException {
         Path filePath = tempDir.resolve(fileName);
-        Files.writeString(filePath, content, StandardCharsets.UTF_8);
+        Files.writeString(filePath, content);
         return filePath;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.cuioss</groupId>
         <artifactId>cui-java-parent</artifactId>
-        <version>1.5.1</version>
+        <version>1.5.2</version>
         <relativePath />
     </parent>
     <groupId>de.cuioss.sheriff.token</groupId>
@@ -46,76 +46,5 @@
         <frontend.node.version>v22.22.0</frontend.node.version>
         <frontend.npm.version>10.9.2</frontend.npm.version>
     </properties>
-
-    <profiles>
-        <profile>
-            <!-- Overrides the pre-commit profile inherited from cui-java-parent: redeclares the
-                 OpenRewrite activeRecipes list WITHOUT org.openrewrite.java.migrate.util.JavaUtilAPIs.
-                 Its UseMapOf sub-recipe produces broken output in this codebase:
-                 1. Rewrites LinkedHashMap/HashMap put-chains to `new HashMap<>(Map.of(...))` without
-                    adding the java.util.HashMap import (compile failures in BadgeGenerator,
-                    GitHubPagesGenerator, LibraryMetricsExporter).
-                 2. Map.of() rejects null values that the original put() chains tolerated
-                    (NullPointerException in ReportDataGenerator.convertMetadata and
-                    TokenSheriffDevUIRuntimeService.getConfiguration, which puts explicit nulls).
-                 3. Silently replaces LinkedHashMap with HashMap, discarding deliberate insertion
-                    ordering of generated report/JSON output.
-                 Remove this override once the recipe defect is fixed upstream. -->
-            <id>pre-commit</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.openrewrite.maven</groupId>
-                        <artifactId>rewrite-maven-plugin</artifactId>
-                        <configuration>
-                            <activeRecipes combine.self="override">
-                                <!-- Code formatting - MUST run first to normalize whitespace -->
-                                <recipe>org.openrewrite.java.format.AutoFormat</recipe>
-                                <recipe>org.openrewrite.java.format.NormalizeLineBreaks</recipe>
-                                <recipe>org.openrewrite.java.format.RemoveTrailingWhitespace</recipe>
-
-                                <!-- CUI-specific formatting and standards - run after base formatting -->
-                                <recipe>de.cuioss.rewrite.format.AnnotationNewlineFormat</recipe>
-                                <recipe>de.cuioss.rewrite.logging.CuiLoggerStandardsRecipe</recipe>
-                                <recipe>de.cuioss.rewrite.logging.CuiLogRecordPatternRecipe</recipe>
-                                <recipe>de.cuioss.rewrite.logging.InvalidExceptionUsageRecipe</recipe>
-
-                                <!-- Java 21 migration and modernization -->
-                                <recipe>org.openrewrite.java.migrate.UpgradeToJava21</recipe>
-
-                                <!-- Not included in UpgradeToJava21.
-                                     NOTE: org.openrewrite.java.migrate.util.JavaUtilAPIs is deliberately
-                                     NOT active here (see profile comment above). -->
-                                <recipe>org.openrewrite.java.migrate.RemoveSecurityManager</recipe>
-
-                                <!-- Code organization -->
-                                <recipe>org.openrewrite.java.OrderImports</recipe>
-                                <recipe>org.openrewrite.java.RemoveUnusedImports</recipe>
-                                <recipe>org.openrewrite.java.ShortenFullyQualifiedTypeReferences</recipe>
-
-                                <!-- Testing improvements -->
-                                <recipe>org.openrewrite.java.testing.junit5.JUnit5BestPractices</recipe>
-                                <recipe>org.openrewrite.java.testing.junit5.RemoveTryCatchFailBlocks</recipe>
-
-                                <!-- Static analysis improvements -->
-                                <recipe>org.openrewrite.staticanalysis.EqualsAvoidsNull</recipe>
-                                <recipe>org.openrewrite.staticanalysis.NoPrimitiveWrappersForToStringOrCompareTo</recipe>
-                                <recipe>org.openrewrite.staticanalysis.SimplifyBooleanExpression</recipe>
-                                <recipe>org.openrewrite.staticanalysis.UnnecessaryParentheses</recipe>
-                            </activeRecipes>
-                            <!-- Appended to the parent's exclusions (target/**): the OpenRewrite YAML
-                                 parser cannot parse e-2-e-playwright/docker-compose.yml (valid compose
-                                 syntax; the healthcheck shell redirection trips the parser) and emits a
-                                 "There were problems parsing" warning on every run. No active recipe
-                                 targets compose files, so excluding them loses nothing. -->
-                            <exclusions combine.children="append">
-                                <exclusion>**/docker-compose.yml</exclusion>
-                            </exclusions>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 
 </project>


### PR DESCRIPTION
## What

Adopt **cui-java-parent 1.5.2** and remove the local `-Ppre-commit` profile override that PR #577 added as a temporary workaround. Both upstream OpenRewrite defects the override guarded against are now fixed and released:

- **UseMapOf / JavaUtilAPIs** (broken `HashMap` rewrite: missing import, `Map.of` null-intolerance, dropped ordering) — excluded in the parent's pre-commit profile (cuioss-parent-pom#1323, released in 1.5.2).
- **InvalidExceptionUsageRecipe** inline catch-marker churn (broke SonarCloud new-code coverage) — fixed in cui-open-rewrite 1.3.1 (cui-open-rewrite#107, resolves cui-open-rewrite#105); the marker is now emitted on its own line above the `catch`.

## Changes

- `pom.xml`: bump `cui-java-parent` 1.5.1 → 1.5.2; delete the local `pre-commit` profile override (`activeRecipes` redeclaration + `**/docker-compose.yml` exclusion), now redundant.
- Incidental modernization the parent recipe set applies to a pre-existing file (`Files.writeString` redundant UTF-8 charset in `TestResourceLoader`).
- Refresh two architecture descriptors (`enriched.json`).

## Verification

Full `verify -Ppre-commit` (parent 1.5.2, no local override):

- Green build.
- **0** UseMapOf / HashMap breakage — the map fix works upstream.
- No `TokenLifecycleManager` catch-marker churn — the marker fix works upstream.
- **Idempotent**: run → commit → rerun produced zero working-tree diff.

## Notes

- The revocation-path coverage test and the `license-checker-rseidelsohn` pin added in #577 are independent improvements and are intentionally retained.
- Removing the local `**/docker-compose.yml` exclusion reintroduces a single non-failing OpenRewrite "problems parsing" warning for `e-2-e-playwright/docker-compose.yml`; excluding compose files belongs upstream in the parent profile, not as a per-repo override.
