### PR TITLE
chore(steward): land steward-maintained artifacts

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -166,12 +166,32 @@
     "map": {
       "java": [
         {
+          "glob": "*.sh",
+          "role": "config",
+          "build_class": "verify"
+        },
+        {
           "glob": "*/src/main/*.java",
           "role": "production",
           "build_class": "compile"
         },
         {
+          "glob": "*/src/main/resources/*",
+          "role": "production",
+          "build_class": "compile"
+        },
+        {
           "glob": "*/src/test/*.java",
+          "role": "test",
+          "build_class": "module-tests"
+        },
+        {
+          "glob": "*/src/test/*IT.java",
+          "role": "test",
+          "build_class": "verify"
+        },
+        {
+          "glob": "*/src/test/resources/*",
           "role": "test",
           "build_class": "module-tests"
         },
@@ -213,7 +233,8 @@
       "chore/"
     ],
     "pr_strategy": "compact",
-    "pr_compact_max_changed_files": 150
+    "pr_compact_max_changed_files": 150,
+    "merge_queue_managed_externally": false
   },
   "providers": [
     {
@@ -277,9 +298,11 @@
       "logs_days": 1,
       "archived_plans_days": 5,
       "lessons_superseded_days": 0,
-      "temp_on_maintenance": true
+      "temp_on_maintenance": true,
+      "plugin_cache_keep_versions": 5,
+      "plugin_cache_keep_days": 3
     },
-    "provisioned_version": "0.1.1116",
-    "config_seed_fingerprint": "37df1a33"
+    "provisioned_version": "0.1.1212",
+    "config_seed_fingerprint": "9a1bd104"
   }
 }


### PR DESCRIPTION
## Summary

Post-plugin-update reconciliation of `.plan/marshal.json` produced by
`/marshall-steward upgrade` (plan-marshall `0.1.1212`).

- Executor regenerated (140 scripts discovered; the previous executor was stamped
  `0.1.1156`, whose cache dir had been pruned, so it could no longer proxy)
- Plugin-cache retention sweep pruned 10 superseded `0.1.1192` version dirs
- `sync-defaults` back-filled `project.merge_queue_managed_externally`,
  `system.retention.plugin_cache_keep_versions`, `system.retention.plugin_cache_keep_days`
- `build.map` re-seeded from the live-tree derivation: the `java` domain gains
  `*.sh`, `*/src/main/resources/*`, `*/src/test/*IT.java`, `*/src/test/resources/*`
- `system.provisioned_version` re-stamped to `0.1.1212`
- `steps-sort`: already in canonical frontmatter order (no reorder)

Only `.plan/marshal.json` changed. This is steward-maintained configuration.

## Review

Labelled `skip-bot-review` — deterministic config reconcile, no code change.
Note the label fully suppresses only CodeRabbit; Sourcery/Gemini are not
label-suppressible in this repo.

## Test plan

- Executor preflight reports `executor_action: fresh` / `marshal_status: fresh`,
  all versions `0.1.1212`
- No production or test code touched
