### PR TITLE
chore(steward): land steward-maintained artifacts

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -121,6 +121,10 @@
         "default:lessons-capture": {
           "lane": "minimal"
         },
+        "default:finalize-step-preference-emitter": {
+          "preference_min_recurrence": 2,
+          "lane": "minimal"
+        },
         "default:adr-propose": {
           "lane": "off"
         },
@@ -134,10 +138,6 @@
           "use_merge_queue": true,
           "admin_merge_on_stuck_state": false,
           "pre_merge_comment_barrier": "fail_into_loopback",
-          "lane": "minimal"
-        },
-        "default:finalize-step-preference-emitter": {
-          "preference_min_recurrence": 2,
           "lane": "minimal"
         },
         "default:record-metrics": {
@@ -156,6 +156,9 @@
         "post-run-review": "level-4"
       }
     }
+  },
+  "orchestrator": {
+    "auto_emit": false
   },
   "build": {
     "queue": {
@@ -303,6 +306,6 @@
       "plugin_cache_keep_days": 3
     },
     "provisioned_version": "0.1.1212",
-    "config_seed_fingerprint": "9a1bd104"
+    "config_seed_fingerprint": "4e859c03"
   }
 }

--- a/.plan/project-architecture/benchmark-core/enriched.json
+++ b/.plan/project-architecture/benchmark-core/enriched.json
@@ -40,7 +40,11 @@
           "description": "Core Java patterns including modern features and performance optimization",
           "skill": "pm-dev-java:java-core"
         },
-        "pm-dev-java-cui:cui-logging"
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "marshalld build-server consumption client (submit/wait/ping/preflight) \u2014 build-dispatch routes builds through the daemon when the project is registered, else falls back in-process",
+          "skill": "plan-marshall:build-server-client"
+        }
       ]
     },
     "module_testing": {
@@ -65,7 +69,11 @@
           "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
           "skill": "pm-dev-java:junit-core"
         },
-        "pm-dev-java-cui:cui-logging"
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "marshalld build-server consumption client (submit/wait/ping/preflight) \u2014 test-run dispatch routes through the daemon when the project is registered, else falls back in-process",
+          "skill": "plan-marshall:build-server-client"
+        }
       ]
     },
     "quality": {
@@ -99,6 +107,6 @@
       ]
     }
   },
-  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals",
+  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals; Repopulate skills_by_profile after phase-4 Q-Gate finding f9f1e9: documentation module lacked the implementation profile key declared by pm-documents",
   "tips": []
 }

--- a/.plan/project-architecture/benchmark-integration-wrk/enriched.json
+++ b/.plan/project-architecture/benchmark-integration-wrk/enriched.json
@@ -30,7 +30,11 @@
           "description": "Core Java patterns including modern features and performance optimization",
           "skill": "pm-dev-java:java-core"
         },
-        "pm-dev-java-cui:cui-logging"
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "marshalld build-server consumption client (submit/wait/ping/preflight) \u2014 build-dispatch routes builds through the daemon when the project is registered, else falls back in-process",
+          "skill": "plan-marshall:build-server-client"
+        }
       ]
     },
     "module_testing": {
@@ -55,7 +59,11 @@
           "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
           "skill": "pm-dev-java:junit-core"
         },
-        "pm-dev-java-cui:cui-logging"
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "marshalld build-server consumption client (submit/wait/ping/preflight) \u2014 test-run dispatch routes through the daemon when the project is registered, else falls back in-process",
+          "skill": "plan-marshall:build-server-client"
+        }
       ]
     },
     "quality": {
@@ -89,6 +97,6 @@
       ]
     }
   },
-  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals",
+  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals; Repopulate skills_by_profile after phase-4 Q-Gate finding f9f1e9: documentation module lacked the implementation profile key declared by pm-documents",
   "tips": []
 }

--- a/.plan/project-architecture/benchmarking-common/enriched.json
+++ b/.plan/project-architecture/benchmarking-common/enriched.json
@@ -42,7 +42,11 @@
           "description": "Core Java patterns including modern features and performance optimization",
           "skill": "pm-dev-java:java-core"
         },
-        "pm-dev-java-cui:cui-logging"
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "marshalld build-server consumption client (submit/wait/ping/preflight) \u2014 build-dispatch routes builds through the daemon when the project is registered, else falls back in-process",
+          "skill": "plan-marshall:build-server-client"
+        }
       ]
     },
     "module_testing": {
@@ -67,7 +71,11 @@
           "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
           "skill": "pm-dev-java:junit-core"
         },
-        "pm-dev-java-cui:cui-logging"
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "marshalld build-server consumption client (submit/wait/ping/preflight) \u2014 test-run dispatch routes through the daemon when the project is registered, else falls back in-process",
+          "skill": "plan-marshall:build-server-client"
+        }
       ]
     },
     "quality": {
@@ -101,6 +109,6 @@
       ]
     }
   },
-  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals",
+  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals; Repopulate skills_by_profile after phase-4 Q-Gate finding f9f1e9: documentation module lacked the implementation profile key declared by pm-documents",
   "tips": []
 }

--- a/.plan/project-architecture/benchmarking/enriched.json
+++ b/.plan/project-architecture/benchmarking/enriched.json
@@ -28,7 +28,11 @@
           "description": "Core Java patterns including modern features and performance optimization",
           "skill": "pm-dev-java:java-core"
         },
-        "pm-dev-java-cui:cui-logging"
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "marshalld build-server consumption client (submit/wait/ping/preflight) \u2014 build-dispatch routes builds through the daemon when the project is registered, else falls back in-process",
+          "skill": "plan-marshall:build-server-client"
+        }
       ]
     },
     "module_testing": {
@@ -53,7 +57,11 @@
           "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
           "skill": "pm-dev-java:junit-core"
         },
-        "pm-dev-java-cui:cui-logging"
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "marshalld build-server consumption client (submit/wait/ping/preflight) \u2014 test-run dispatch routes through the daemon when the project is registered, else falls back in-process",
+          "skill": "plan-marshall:build-server-client"
+        }
       ]
     },
     "quality": {
@@ -87,6 +95,6 @@
       ]
     }
   },
-  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals",
+  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals; Repopulate skills_by_profile after phase-4 Q-Gate finding f9f1e9: documentation module lacked the implementation profile key declared by pm-documents",
   "tips": []
 }

--- a/.plan/project-architecture/documentation/enriched.json
+++ b/.plan/project-architecture/documentation/enriched.json
@@ -29,8 +29,28 @@
           "skill": "pm-documents:ref-svg-diagrams"
         }
       ]
+    },
+    "implementation": {
+      "defaults": [
+        {
+          "description": "AsciiDoc formatting, validation, link verification, and template creation",
+          "skill": "pm-documents:ref-asciidoc"
+        },
+        {
+          "description": "Content quality, tone analysis, organization standards, and review orchestration",
+          "skill": "pm-documents:ref-documentation"
+        },
+        {
+          "description": "Narrative styles for technical documentation \u2014 tone, voice, and arc for the engineering-narrative style",
+          "skill": "pm-documents:ref-narrative-styles"
+        },
+        {
+          "description": "SVG diagram authoring standards \u2014 visual language, theme handling, AsciiDoc embedding, per-diagram-type patterns",
+          "skill": "pm-documents:ref-svg-diagrams"
+        }
+      ]
     }
   },
-  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals",
+  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals; Repopulate skills_by_profile after phase-4 Q-Gate finding f9f1e9: documentation module lacked the implementation profile key declared by pm-documents",
   "tips": []
 }

--- a/.plan/project-architecture/e-2-e-playwright-maven/enriched.json
+++ b/.plan/project-architecture/e-2-e-playwright-maven/enriched.json
@@ -26,7 +26,11 @@
           "description": "Core Java patterns including modern features and performance optimization",
           "skill": "pm-dev-java:java-core"
         },
-        "pm-dev-java-cui:cui-logging"
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "marshalld build-server consumption client (submit/wait/ping/preflight) \u2014 build-dispatch routes builds through the daemon when the project is registered, else falls back in-process",
+          "skill": "plan-marshall:build-server-client"
+        }
       ]
     },
     "module_testing": {
@@ -51,7 +55,11 @@
           "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
           "skill": "pm-dev-java:junit-core"
         },
-        "pm-dev-java-cui:cui-logging"
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "marshalld build-server consumption client (submit/wait/ping/preflight) \u2014 test-run dispatch routes through the daemon when the project is registered, else falls back in-process",
+          "skill": "plan-marshall:build-server-client"
+        }
       ]
     },
     "quality": {
@@ -85,6 +93,6 @@
       ]
     }
   },
-  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals",
+  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals; Repopulate skills_by_profile after phase-4 Q-Gate finding f9f1e9: documentation module lacked the implementation profile key declared by pm-documents",
   "tips": []
 }

--- a/.plan/project-architecture/e-2-e-playwright-npm/enriched.json
+++ b/.plan/project-architecture/e-2-e-playwright-npm/enriched.json
@@ -27,6 +27,10 @@
         {
           "description": "Core JavaScript development standards covering ES modules, modern patterns, web component patterns, DOM trust boundaries / XSS prevention, and code quality",
           "skill": "pm-dev-frontend:javascript"
+        },
+        {
+          "description": "marshalld build-server consumption client (submit/wait/ping/preflight) \u2014 build-dispatch routes builds through the daemon when the project is registered, else falls back in-process",
+          "skill": "plan-marshall:build-server-client"
         }
       ]
     },
@@ -51,6 +55,10 @@
         {
           "description": "JavaScript unit testing with Jest, DOM testing, mocking, async patterns",
           "skill": "pm-dev-frontend:jest-testing"
+        },
+        {
+          "description": "marshalld build-server consumption client (submit/wait/ping/preflight) \u2014 test-run dispatch routes through the daemon when the project is registered, else falls back in-process",
+          "skill": "plan-marshall:build-server-client"
         }
       ]
     },
@@ -83,6 +91,6 @@
       ]
     }
   },
-  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals",
+  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals; Repopulate skills_by_profile after phase-4 Q-Gate finding f9f1e9: documentation module lacked the implementation profile key declared by pm-documents",
   "tips": []
 }

--- a/.plan/project-architecture/token-sheriff-bom/enriched.json
+++ b/.plan/project-architecture/token-sheriff-bom/enriched.json
@@ -24,7 +24,11 @@
           "description": "Core Java patterns including modern features and performance optimization",
           "skill": "pm-dev-java:java-core"
         },
-        "pm-dev-java-cui:cui-logging"
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "marshalld build-server consumption client (submit/wait/ping/preflight) \u2014 build-dispatch routes builds through the daemon when the project is registered, else falls back in-process",
+          "skill": "plan-marshall:build-server-client"
+        }
       ]
     },
     "module_testing": {
@@ -49,7 +53,11 @@
           "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
           "skill": "pm-dev-java:junit-core"
         },
-        "pm-dev-java-cui:cui-logging"
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "marshalld build-server consumption client (submit/wait/ping/preflight) \u2014 test-run dispatch routes through the daemon when the project is registered, else falls back in-process",
+          "skill": "plan-marshall:build-server-client"
+        }
       ]
     },
     "quality": {
@@ -83,6 +91,6 @@
       ]
     }
   },
-  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals",
+  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals; Repopulate skills_by_profile after phase-4 Q-Gate finding f9f1e9: documentation module lacked the implementation profile key declared by pm-documents",
   "tips": []
 }

--- a/.plan/project-architecture/token-sheriff-client-quarkus-deployment/enriched.json
+++ b/.plan/project-architecture/token-sheriff-client-quarkus-deployment/enriched.json
@@ -30,7 +30,11 @@
           "description": "Core Java patterns including modern features and performance optimization",
           "skill": "pm-dev-java:java-core"
         },
-        "pm-dev-java-cui:cui-logging"
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "marshalld build-server consumption client (submit/wait/ping/preflight) \u2014 build-dispatch routes builds through the daemon when the project is registered, else falls back in-process",
+          "skill": "plan-marshall:build-server-client"
+        }
       ]
     },
     "module_testing": {
@@ -55,7 +59,11 @@
           "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
           "skill": "pm-dev-java:junit-core"
         },
-        "pm-dev-java-cui:cui-logging"
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "marshalld build-server consumption client (submit/wait/ping/preflight) \u2014 test-run dispatch routes through the daemon when the project is registered, else falls back in-process",
+          "skill": "plan-marshall:build-server-client"
+        }
       ]
     },
     "quality": {
@@ -89,6 +97,6 @@
       ]
     }
   },
-  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals",
+  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals; Repopulate skills_by_profile after phase-4 Q-Gate finding f9f1e9: documentation module lacked the implementation profile key declared by pm-documents",
   "tips": []
 }

--- a/.plan/project-architecture/token-sheriff-client-quarkus/enriched.json
+++ b/.plan/project-architecture/token-sheriff-client-quarkus/enriched.json
@@ -31,7 +31,11 @@
           "description": "Core Java patterns including modern features and performance optimization",
           "skill": "pm-dev-java:java-core"
         },
-        "pm-dev-java-cui:cui-logging"
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "marshalld build-server consumption client (submit/wait/ping/preflight) \u2014 build-dispatch routes builds through the daemon when the project is registered, else falls back in-process",
+          "skill": "plan-marshall:build-server-client"
+        }
       ]
     },
     "module_testing": {
@@ -56,7 +60,11 @@
           "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
           "skill": "pm-dev-java:junit-core"
         },
-        "pm-dev-java-cui:cui-logging"
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "marshalld build-server consumption client (submit/wait/ping/preflight) \u2014 test-run dispatch routes through the daemon when the project is registered, else falls back in-process",
+          "skill": "plan-marshall:build-server-client"
+        }
       ]
     },
     "quality": {
@@ -90,6 +98,6 @@
       ]
     }
   },
-  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals",
+  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals; Repopulate skills_by_profile after phase-4 Q-Gate finding f9f1e9: documentation module lacked the implementation profile key declared by pm-documents",
   "tips": []
 }

--- a/.plan/project-architecture/token-sheriff-client/enriched.json
+++ b/.plan/project-architecture/token-sheriff-client/enriched.json
@@ -36,7 +36,11 @@
           "description": "Core Java patterns including modern features and performance optimization",
           "skill": "pm-dev-java:java-core"
         },
-        "pm-dev-java-cui:cui-logging"
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "marshalld build-server consumption client (submit/wait/ping/preflight) \u2014 build-dispatch routes builds through the daemon when the project is registered, else falls back in-process",
+          "skill": "plan-marshall:build-server-client"
+        }
       ]
     },
     "module_testing": {
@@ -61,7 +65,11 @@
           "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
           "skill": "pm-dev-java:junit-core"
         },
-        "pm-dev-java-cui:cui-logging"
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "marshalld build-server consumption client (submit/wait/ping/preflight) \u2014 test-run dispatch routes through the daemon when the project is registered, else falls back in-process",
+          "skill": "plan-marshall:build-server-client"
+        }
       ]
     },
     "quality": {
@@ -95,6 +103,6 @@
       ]
     }
   },
-  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals",
+  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals; Repopulate skills_by_profile after phase-4 Q-Gate finding f9f1e9: documentation module lacked the implementation profile key declared by pm-documents",
   "tips": []
 }

--- a/.plan/project-architecture/token-sheriff-parent/enriched.json
+++ b/.plan/project-architecture/token-sheriff-parent/enriched.json
@@ -24,7 +24,11 @@
           "description": "Core Java patterns including modern features and performance optimization",
           "skill": "pm-dev-java:java-core"
         },
-        "pm-dev-java-cui:cui-logging"
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "marshalld build-server consumption client (submit/wait/ping/preflight) \u2014 build-dispatch routes builds through the daemon when the project is registered, else falls back in-process",
+          "skill": "plan-marshall:build-server-client"
+        }
       ]
     },
     "module_testing": {
@@ -49,7 +53,11 @@
           "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
           "skill": "pm-dev-java:junit-core"
         },
-        "pm-dev-java-cui:cui-logging"
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "marshalld build-server consumption client (submit/wait/ping/preflight) \u2014 test-run dispatch routes through the daemon when the project is registered, else falls back in-process",
+          "skill": "plan-marshall:build-server-client"
+        }
       ]
     },
     "quality": {
@@ -83,6 +91,6 @@
       ]
     }
   },
-  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals",
+  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals; Repopulate skills_by_profile after phase-4 Q-Gate finding f9f1e9: documentation module lacked the implementation profile key declared by pm-documents",
   "tips": []
 }

--- a/.plan/project-architecture/token-sheriff-quarkus-integration-tests/enriched.json
+++ b/.plan/project-architecture/token-sheriff-quarkus-integration-tests/enriched.json
@@ -36,7 +36,11 @@
           "description": "Core Java patterns including modern features and performance optimization",
           "skill": "pm-dev-java:java-core"
         },
-        "pm-dev-java-cui:cui-logging"
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "marshalld build-server consumption client (submit/wait/ping/preflight) \u2014 build-dispatch routes builds through the daemon when the project is registered, else falls back in-process",
+          "skill": "plan-marshall:build-server-client"
+        }
       ]
     },
     "module_testing": {
@@ -61,7 +65,11 @@
           "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
           "skill": "pm-dev-java:junit-core"
         },
-        "pm-dev-java-cui:cui-logging"
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "marshalld build-server consumption client (submit/wait/ping/preflight) \u2014 test-run dispatch routes through the daemon when the project is registered, else falls back in-process",
+          "skill": "plan-marshall:build-server-client"
+        }
       ]
     },
     "quality": {
@@ -95,6 +103,6 @@
       ]
     }
   },
-  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals",
+  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals; Repopulate skills_by_profile after phase-4 Q-Gate finding f9f1e9: documentation module lacked the implementation profile key declared by pm-documents",
   "tips": []
 }

--- a/.plan/project-architecture/token-sheriff-quarkus-parent/enriched.json
+++ b/.plan/project-architecture/token-sheriff-quarkus-parent/enriched.json
@@ -31,7 +31,11 @@
           "description": "Core Java patterns including modern features and performance optimization",
           "skill": "pm-dev-java:java-core"
         },
-        "pm-dev-java-cui:cui-logging"
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "marshalld build-server consumption client (submit/wait/ping/preflight) \u2014 build-dispatch routes builds through the daemon when the project is registered, else falls back in-process",
+          "skill": "plan-marshall:build-server-client"
+        }
       ]
     },
     "module_testing": {
@@ -56,7 +60,11 @@
           "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
           "skill": "pm-dev-java:junit-core"
         },
-        "pm-dev-java-cui:cui-logging"
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "marshalld build-server consumption client (submit/wait/ping/preflight) \u2014 test-run dispatch routes through the daemon when the project is registered, else falls back in-process",
+          "skill": "plan-marshall:build-server-client"
+        }
       ]
     },
     "quality": {
@@ -90,7 +98,7 @@
       ]
     }
   },
-  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals",
+  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals; Repopulate skills_by_profile after phase-4 Q-Gate finding f9f1e9: documentation module lacked the implementation profile key declared by pm-documents",
   "tips": [
     "Review bots (e.g. gemini-code-assist) may file factually wrong existence claims about Quarkus artifacts relocated in Quarkus 3.37+ (quarkus-junit and QuarkusExtensionTest DO exist at 3.37.2 post-relocation). During PR-comment triage, verify any 'artifact/class does not exist' bot claim against the actual dependency tree (mvn dependency:tree / resolved classpath) before accepting it \u2014 11 such findings were pure triage noise on one run."
   ]

--- a/.plan/project-architecture/token-sheriff-validation-quarkus-deployment-maven/enriched.json
+++ b/.plan/project-architecture/token-sheriff-validation-quarkus-deployment-maven/enriched.json
@@ -30,7 +30,11 @@
           "description": "Core Java patterns including modern features and performance optimization",
           "skill": "pm-dev-java:java-core"
         },
-        "pm-dev-java-cui:cui-logging"
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "marshalld build-server consumption client (submit/wait/ping/preflight) \u2014 build-dispatch routes builds through the daemon when the project is registered, else falls back in-process",
+          "skill": "plan-marshall:build-server-client"
+        }
       ]
     },
     "module_testing": {
@@ -55,7 +59,11 @@
           "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
           "skill": "pm-dev-java:junit-core"
         },
-        "pm-dev-java-cui:cui-logging"
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "marshalld build-server consumption client (submit/wait/ping/preflight) \u2014 test-run dispatch routes through the daemon when the project is registered, else falls back in-process",
+          "skill": "plan-marshall:build-server-client"
+        }
       ]
     },
     "quality": {
@@ -89,6 +97,6 @@
       ]
     }
   },
-  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals",
+  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals; Repopulate skills_by_profile after phase-4 Q-Gate finding f9f1e9: documentation module lacked the implementation profile key declared by pm-documents",
   "tips": []
 }

--- a/.plan/project-architecture/token-sheriff-validation-quarkus-deployment-npm/enriched.json
+++ b/.plan/project-architecture/token-sheriff-validation-quarkus-deployment-npm/enriched.json
@@ -27,6 +27,10 @@
         {
           "description": "Core JavaScript development standards covering ES modules, modern patterns, web component patterns, DOM trust boundaries / XSS prevention, and code quality",
           "skill": "pm-dev-frontend:javascript"
+        },
+        {
+          "description": "marshalld build-server consumption client (submit/wait/ping/preflight) \u2014 build-dispatch routes builds through the daemon when the project is registered, else falls back in-process",
+          "skill": "plan-marshall:build-server-client"
         }
       ]
     },
@@ -51,6 +55,10 @@
         {
           "description": "JavaScript unit testing with Jest, DOM testing, mocking, async patterns",
           "skill": "pm-dev-frontend:jest-testing"
+        },
+        {
+          "description": "marshalld build-server consumption client (submit/wait/ping/preflight) \u2014 test-run dispatch routes through the daemon when the project is registered, else falls back in-process",
+          "skill": "plan-marshall:build-server-client"
         }
       ]
     },
@@ -83,6 +91,6 @@
       ]
     }
   },
-  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals",
+  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals; Repopulate skills_by_profile after phase-4 Q-Gate finding f9f1e9: documentation module lacked the implementation profile key declared by pm-documents",
   "tips": []
 }

--- a/.plan/project-architecture/token-sheriff-validation-quarkus/enriched.json
+++ b/.plan/project-architecture/token-sheriff-validation-quarkus/enriched.json
@@ -43,7 +43,11 @@
           "description": "Core Java patterns including modern features and performance optimization",
           "skill": "pm-dev-java:java-core"
         },
-        "pm-dev-java-cui:cui-logging"
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "marshalld build-server consumption client (submit/wait/ping/preflight) \u2014 build-dispatch routes builds through the daemon when the project is registered, else falls back in-process",
+          "skill": "plan-marshall:build-server-client"
+        }
       ]
     },
     "module_testing": {
@@ -68,7 +72,11 @@
           "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
           "skill": "pm-dev-java:junit-core"
         },
-        "pm-dev-java-cui:cui-logging"
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "marshalld build-server consumption client (submit/wait/ping/preflight) \u2014 test-run dispatch routes through the daemon when the project is registered, else falls back in-process",
+          "skill": "plan-marshall:build-server-client"
+        }
       ]
     },
     "quality": {
@@ -102,6 +110,6 @@
       ]
     }
   },
-  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals",
+  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals; Repopulate skills_by_profile after phase-4 Q-Gate finding f9f1e9: documentation module lacked the implementation profile key declared by pm-documents",
   "tips": []
 }

--- a/.plan/project-architecture/token-sheriff-validation/enriched.json
+++ b/.plan/project-architecture/token-sheriff-validation/enriched.json
@@ -44,7 +44,11 @@
           "description": "Core Java patterns including modern features and performance optimization",
           "skill": "pm-dev-java:java-core"
         },
-        "pm-dev-java-cui:cui-logging"
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "marshalld build-server consumption client (submit/wait/ping/preflight) \u2014 build-dispatch routes builds through the daemon when the project is registered, else falls back in-process",
+          "skill": "plan-marshall:build-server-client"
+        }
       ]
     },
     "module_testing": {
@@ -69,7 +73,11 @@
           "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
           "skill": "pm-dev-java:junit-core"
         },
-        "pm-dev-java-cui:cui-logging"
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "marshalld build-server consumption client (submit/wait/ping/preflight) \u2014 test-run dispatch routes through the daemon when the project is registered, else falls back in-process",
+          "skill": "plan-marshall:build-server-client"
+        }
       ]
     },
     "quality": {
@@ -103,6 +111,6 @@
       ]
     }
   },
-  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals",
+  "skills_by_profile_reasoning": "wizard re-run: batch-populate skills_by_profile from extension signals; Repopulate skills_by_profile after phase-4 Q-Gate finding f9f1e9: documentation module lacked the implementation profile key declared by pm-documents",
   "tips": []
 }


### PR DESCRIPTION
## Summary

Post-change reconciliation produced by `/marshall-steward upgrade` (consumer
project, plan-marshall `0.1.1212`).

- **`.plan/marshal.json`** — `sync-defaults` back-filled `orchestrator` and
  `orchestrator.auto_emit`; `steps-sort` re-sorted `phase-6-finalize.steps` into
  frontmatter order (`finalize-step-preference-emitter` ahead of `adr-propose`,
  `record-metrics` after `branch-cleanup`).
- **`.plan/project-architecture/*/enriched.json`** (18 modules) — refreshed
  enriched architecture module data.

## Upgrade stages

| Stage | Result |
|-------|--------|
| 1 — regenerate-targets | cache freshness `fresh` (`0.1.1212`); executor regenerated (140 scripts); retention sweep pruned 60 superseded version dirs across 10 bundles, kept 90 |
| 2 — reconcile-config | `sync-defaults` +2 keys; `steps-sort` reordered; `build.map` `in_sync: true` (no re-seed) |
| 3 — verify | executor preflight: executor `0.1.1212`, marshal `0.1.1212`, `marshal_status: fresh` |
| 4 — land | this PR |

Additionally cleared stale `.orphaned_at` markers on the installed `0.1.1212`
cache dirs. Those markers had caused the generated executor to split its script
mappings across `0.1.1194` (121 paths) and `0.1.1212` (63 paths) despite being
stamped `MARSHALL_VERSION = 0.1.1212`. After clearing and regenerating, all 217
mappings resolve to `0.1.1212`.

## Review

Labelled `skip-bot-review` — deterministic config reconcile plus regenerated
architecture data, no code change. Note the label fully suppresses only
CodeRabbit; Sourcery and Gemini are not label-suppressible in this repo.

## Test plan

- Executor preflight reports all versions `0.1.1212`, `marshal_status: fresh`
- No production or test code touched
