### PR TITLE
chore(ci): opt in to the PR-Agent third reviewer

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -1,0 +1,36 @@
+# Third automated PR reviewer (PR-Agent on Google Gemini), beside CodeRabbit and Sourcery.
+#
+# All review tuning is central in cuioss/pr-agent-settings (.pr_agent.toml) — nothing is
+# configured here. The org skip rules (dependabot[bot], cuioss-release-bot[bot], the
+# skip-bot-review label, fork PRs) are enforced by the reusable workflow's job-level `if:`
+# guard, because PR-Agent's own ignore_pr_* settings are inert in GitHub Action mode.
+#
+# See https://github.com/cuioss/pr-agent-settings/blob/main/README.adoc
+
+name: PR Agent Review
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+  # On-demand commands (/review, /ask, /improve, /help). Also how a re-review is requested
+  # after pushing fixes — there is deliberately no automatic re-review on every push.
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  # Required: mints the OIDC token Workload Identity Federation exchanges for the short-lived
+  # GCP credentials the reviewer uses to reach Gemini on Vertex AI.
+  id-token: write
+
+jobs:
+  review:
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-pr-agent-review.yml@ab447694b019d30edc56f2ff7c5100ba731ca590 # v0.15.3
+    # Map only what the reviewer needs. `secrets: inherit` would hand it every secret this
+    # repo can see (GPG keys, Sonatype credentials, SONAR_TOKEN, …) for no reason; these two
+    # are the whole requirement, because Vertex AI is reached keylessly.
+    secrets:
+      REVIEW_APP_ID: ${{ secrets.REVIEW_APP_ID }}
+      REVIEW_APP_PRIVATE_KEY: ${{ secrets.REVIEW_APP_PRIVATE_KEY }}

--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -102,7 +102,7 @@
           "re_review_on_timeout": "ask",
           "review_rate_window_await": false,
           "review_rate_window_timeout_seconds": 3600,
-          "enabled_bots": "coderabbit,sourcery,gemini",
+          "enabled_bots": "coderabbit,sourcery,pr-agent",
           "review_completion_poll_timeout_seconds": 600,
           "lane": "ask"
         },


### PR DESCRIPTION
Joins plan-marshall and API-Sheriff on the org's **third** automated reviewer: open-source [PR-Agent](https://github.com/The-PR-Agent/pr-agent) running Gemini on **Vertex AI**, beside CodeRabbit and Sourcery. Nothing is replaced.

Two changes:

**1. The caller workflow** (`.github/workflows/pr-agent.yml`), pinned at v0.15.3. Nothing is configured locally — review tuning is central in [cuioss/pr-agent-settings](https://github.com/cuioss/pr-agent-settings), and the org skip rules (`dependabot[bot]`, `cuioss-release-bot[bot]`, the `skip-bot-review` label, fork PRs) live in the reusable workflow's job-level `if:` guard, because PR-Agent's own `ignore_pr_*` settings are inert in GitHub Action mode.

- `id-token: write` is required — it mints the OIDC token Workload Identity Federation exchanges for short-lived GCP credentials. No Google credential is stored anywhere.
- Only `REVIEW_APP_ID` / `REVIEW_APP_PRIVATE_KEY` are mapped, not `secrets: inherit`.
- Only `/review` runs automatically; `/describe` and `/improve` are off. `/review` as a comment is the on-demand and re-review trigger.

**2. `enabled_bots` → `coderabbit,sourcery,pr-agent`** so the finalize pipeline ingests the reviewer's findings as `pr-comment` findings under `bot_kind: pr-agent`. Gemini is dropped in the same edit: its consumer tier was retired 2026-07-17, so that entry only made finalize wait for a bot that can never post. Net bot count is unchanged, so the wait budget doesn't grow.

## What this PR is also good for

The reviewer's **publish path has never executed** — both earlier pilot diffs were clean, so no review comment has ever been posted. This PR carries a slightly larger diff, so it may produce the first real one. If it does, the things to confirm are: the comment is authored by `cuioss-review-bot[bot]`, headed `## PR Reviewer Guide 🔍`, and its findings complement CodeRabbit/Sourcery rather than restating them.

If it posts nothing, that is also a valid outcome (a clean review is deliberately not published) — the job still reports green off the reviewer's structured output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated pull request review workflows for new and reopened pull requests, ready-for-review events, and supported review commands.
  * Enabled PR-Agent as an automated review option in the finalization process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->