### PR TITLE
feat(client): add optional per-client SSLContext to the OIDC client engine transport

### DIFF
--- a/doc/client/requirements.adoc
+++ b/doc/client/requirements.adoc
@@ -226,6 +226,25 @@ TLS enforcement owned by commons (`COMMONS-2`).
 
 * Source: https://www.rfc-editor.org/rfc/rfc9700#section-4.3[RFC 9700 §4.3] (credentials in URLs), https://www.rfc-editor.org/rfc/rfc9207[RFC 9207], https://www.rfc-editor.org/rfc/rfc6749#section-5.1[RFC 6749 §5.1] (token response).
 
+[#CLIENT-23]
+=== CLIENT-23: Optional per-client outbound TLS trust
+
+The engine MUST accept an *optional per-client outbound `SSLContext`* on its client
+configuration and MUST apply it to *every* discovery and back-channel call that client issues
+(discovery, token, userinfo, revocation, PAR). This is the supported way to trust a private-CA
+or self-signed authorization server: the trust is scoped to the one client instead of being
+forced onto the whole JVM through a process-global `javax.net.ssl.trustStore` override, so two
+clients in the same process may trust two different authorization servers. When no context is
+configured the commons transport default applies unchanged, and the TLS floor
+(<<CLIENT-14>>, `COMMONS-2`) still governs the connection — a supplied context selects *trust
+material*, it does not relax the protocol policy. This mirrors the validation-side analogue
+`HttpJwksLoaderConfig.sslContext()`, so both sides of the product configure private-CA trust the
+same way. The low-level TLS context primitive itself remains owned by commons (see
+<<_aspect_separation_and_what_is_referenced_not_duplicated>>); this requirement is only the
+client-side seam that hands the caller's context to that primitive.
+
+* Source: xref:../commons/requirements.adoc[commons] (`COMMONS-2`, `cui-http` `HttpHandler.sslContext()`), https://www.rfc-editor.org/rfc/rfc9700#section-2.6[RFC 9700 §2.6] (TLS on every outbound request).
+
 == Token requirements
 
 _The server-side lifecycle delta on top of the validation module — storage, refresh,
@@ -412,6 +431,7 @@ sourced xref:best-practices.adoc[best-practices] checklist, and realized in a sp
 | CLIENT-12 | T-STEPUP | xref:specification/step-up-and-logout.adoc[step-up-and-logout]
 | CLIENT-13 | T-LOGOUT | step-up-and-logout
 | CLIENT-14 | T-URL-LEAK, T-TLS-TOKEN (delegated) | retrieval-flow
+| CLIENT-23 | T-TLS-TOKEN (per-client trust material for the delegated TLS primitive) | retrieval-flow
 | CLIENT-15 | T-AUD-CONFUSION | xref:specification/token-handling.adoc[token-handling]
 | CLIENT-16 | T-IDTOKEN-INTEGRITY | token-handling
 | CLIENT-17 | T-REFRESH-THEFT, T-LOGOUT | token-handling

--- a/doc/client/requirements.adoc
+++ b/doc/client/requirements.adoc
@@ -243,6 +243,16 @@ same way. The low-level TLS context primitive itself remains owned by commons (s
 <<_aspect_separation_and_what_is_referenced_not_duplicated>>); this requirement is only the
 client-side seam that hands the caller's context to that primitive.
 
+A supplied context is applied verbatim, so it MUST perform full certificate-chain validation —
+a trust-all `TrustManager` disables server authentication for every credential-bearing
+back-channel request. The seam narrows trust to a known CA; it does not weaken verification.
+
+The scope is the client engine's own calls. JWKS retrieval for token *validation* runs through
+the validation module's `HttpJwksLoaderConfig`, which carries an independent `sslContext()` this
+requirement does not feed. Against a private-CA authorization server both MUST be configured;
+otherwise token retrieval succeeds and validation then fails the JWKS fetch, and the natural
+workaround is exactly the process-global truststore override this requirement exists to avoid.
+
 * Source: xref:../commons/requirements.adoc[commons] (`COMMONS-2`, `cui-http` `HttpHandler.sslContext()`), https://www.rfc-editor.org/rfc/rfc9700#section-2.6[RFC 9700 §2.6] (TLS on every outbound request).
 
 == Token requirements

--- a/doc/client/specification/test-strategy.adoc
+++ b/doc/client/specification/test-strategy.adoc
@@ -424,6 +424,11 @@ an isolated-component or server-capability test alone does not qualify the row a
 | xref:../requirements.adoc#CLIENT-22[CLIENT-22] | (cross-cutting)
 | Concurrent flows; *every* threat → a fail-closed adversarial unit test
 | The full `*IT` suite across providers | all
+
+| xref:../requirements.adoc#CLIENT-23[CLIENT-23] | (transport trust seam)
+| The configured `SSLContext` reaches *every* endpoint handler `BackChannelHttp` produces; absent
+  one, the JVM default truststore is used; a rejected context still surfaces as `TransportException`
+| — (needs a private-CA / self-signed IdP fixture; not in the current provider set) | all
 |===
 
 == Per-increment definition of done (test view)

--- a/token-sheriff-client/README.adoc
+++ b/token-sheriff-client/README.adoc
@@ -26,7 +26,9 @@ itself a BFF.
 Organized by package under `de.cuioss.sheriff.token.client`:
 
 * *Discovery* (`discovery`) — OIDC provider-metadata resolution (`DiscoveryResolver`,
-  `ProviderMetadata`) with TLS enforcement and issuer verification.
+  `ProviderMetadata`) with TLS enforcement and issuer verification, over an optional
+  per-client TLS trust seam (`ClientConfiguration.sslContext`) shared by every discovery and
+  back-channel call.
 * *Flows* (`flow`) — authorization-code flow with mandatory PKCE `S256`
   (`AuthorizationCodeFlow`, `PkceChallenge`), client-credentials (`ClientCredentialsFlow`)
   and refresh (`RefreshFlow`) grants, pushed authorization requests (`ParClient`, RFC 9126),
@@ -64,8 +66,15 @@ ClientConfiguration config = ClientConfiguration.builder()
     .clientSecret(secret)
     .authMethod(ClientAuthMethod.CLIENT_SECRET_BASIC)
     .scope("openid")
+    .sslContext(sslContext) // <1>
     .build();
 ----
+<1> Optional. Supply an `SSLContext` when the authorization server presents a private-CA or
+self-signed certificate: the trust is scoped to this one client, so no process-global
+`javax.net.ssl.trustStore` override is needed. Omit it — the default — and the JVM / cui-http
+default truststore applies. When present, the context is used for every discovery and
+back-channel call this client makes (`CLIENT-23`); it selects trust material only and does not
+relax the TLS protocol floor.
 
 Endpoints are resolved via OIDC discovery against
 `{issuer}/.well-known/openid-configuration`. See the

--- a/token-sheriff-client/README.adoc
+++ b/token-sheriff-client/README.adoc
@@ -75,6 +75,16 @@ self-signed certificate: the trust is scoped to this one client, so no process-g
 default truststore applies. When present, the context is used for every discovery and
 back-channel call this client makes (`CLIENT-23`); it selects trust material only and does not
 relax the TLS protocol floor.
++
+WARNING: The supplied `SSLContext` MUST perform full certificate-chain validation. It is taken
+verbatim — a trust-all `TrustManager` silently disables server authentication for every
+credential-bearing back-channel request. This knob narrows trust to a known CA; it is not a way
+to skip verification.
++
+NOTE: The scope is this client engine only. JWKS retrieval for token *validation* runs through
+`HttpJwksLoaderConfig`, which carries its own independent `sslContext()`. Against a private-CA
+authorization server, configure both — otherwise token retrieval succeeds and validation then
+fails the JWKS fetch with a PKIX error.
 
 Endpoints are resolved via OIDC discovery against
 `{issuer}/.well-known/openid-configuration`. See the

--- a/token-sheriff-client/pom.xml
+++ b/token-sheriff-client/pom.xml
@@ -198,6 +198,21 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- Exclude the DSL-JSON annotation processor's generated converters from coverage measurement.
+                 The processor emits _<Type>_DslJsonConverter classes straight into target/classes with no
+                 counterpart under src/main/java, so their branches measure the DSL-JSON code generator rather
+                 than project code. The pattern is anchored to the processor's fixed _<Type>_DslJsonConverter
+                 naming so it cannot silently swallow hand-written classes. The configuration sits at plugin
+                 level so it applies to both the report and check goals inherited from the cuioss parent. -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>**/_*_DslJsonConverter*.class</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/config/ClientConfiguration.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/config/ClientConfiguration.java
@@ -144,6 +144,23 @@ public class ClientConfiguration {
      * {@link SSLContext} has identity semantics and no useful string form, mirroring how
      * {@code HttpJwksLoaderConfig} excludes its {@code HttpHandler}. Two configurations that differ only
      * in their {@code sslContext} therefore remain equal.
+     * <p>
+     * <strong>Reload consequence of that exclusion:</strong> a configuration diff cannot see a trust
+     * rotation. Rebuilding this configuration with a new {@code SSLContext} and otherwise identical
+     * values compares {@code equal} to the previous one, so the common
+     * {@code if (!newConfig.equals(current)) rebuild()} reload idiom will not rebuild and the engine
+     * keeps validating against the retired trust anchor until the process restarts. Trigger the rebuild
+     * on the rotation event itself rather than on a configuration diff.
+     * <p>
+     * <strong>The supplied context MUST perform full certificate-chain validation.</strong> It is
+     * applied verbatim — a trust-all {@code TrustManager} silently disables server authentication for
+     * every credential-bearing back-channel request. This field narrows trust to a known CA; it is not
+     * a mechanism for skipping verification.
+     * <p>
+     * <strong>Scope:</strong> this covers the calls the client engine issues (discovery, token,
+     * userinfo, revocation, PAR). JWKS retrieval for token validation runs through
+     * {@code HttpJwksLoaderConfig} and carries its own independent {@code sslContext()}, which must be
+     * configured alongside this one against a private-CA authorization server.
      */
     @Nullable
     @ToString.Exclude

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/config/ClientConfiguration.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/config/ClientConfiguration.java
@@ -16,12 +16,14 @@
 package de.cuioss.sheriff.token.client.config;
 
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.Singular;
 import lombok.ToString;
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
 
+import javax.net.ssl.SSLContext;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
@@ -129,6 +131,26 @@ public class ClientConfiguration {
     int readTimeoutSeconds = DEFAULT_READ_TIMEOUT_SECONDS;
 
     /**
+     * The per-client outbound TLS trust material, applied to every discovery and back-channel call this
+     * client issues, or {@code null} to use the cui-http / JVM default truststore (the behaviour when the
+     * field is not configured).
+     * <p>
+     * This is the client-side analogue of {@code HttpJwksLoaderConfig.sslContext()} on the validation
+     * side, and it is the supported way to trust a private-CA or self-signed authorization server: the
+     * trust is scoped to this one client instead of being forced onto the whole JVM through a
+     * process-global {@code javax.net.ssl.trustStore} override.
+     * <p>
+     * Excluded from {@code toString()} and from the generated {@code equals}/{@code hashCode} — an
+     * {@link SSLContext} has identity semantics and no useful string form, mirroring how
+     * {@code HttpJwksLoaderConfig} excludes its {@code HttpHandler}. Two configurations that differ only
+     * in their {@code sslContext} therefore remain equal.
+     */
+    @Nullable
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    SSLContext sslContext;
+
+    /**
      * All-args constructor invoked by the Lombok-generated builder. It validates the configuration at
      * construction so a malformed client can never be built and later fail obscurely on the wire:
      * {@code issuer} and {@code clientId} must be non-blank, {@code issuer} must be a well-formed
@@ -146,7 +168,8 @@ public class ClientConfiguration {
     @SuppressWarnings("java:S107")
     ClientConfiguration(@NonNull String issuer, @NonNull String clientId, @Nullable String clientSecret,
             @NonNull ClientAuthMethod authMethod, List<String> scopes, @Nullable String redirectUri,
-            boolean allowInsecureHttp, int connectTimeoutSeconds, int readTimeoutSeconds) {
+            boolean allowInsecureHttp, int connectTimeoutSeconds, int readTimeoutSeconds,
+            @Nullable SSLContext sslContext) {
         this.issuer = requireNonBlank(issuer, "issuer");
         validateIssuerUrl(this.issuer);
         this.clientId = requireNonBlank(clientId, "clientId");
@@ -157,6 +180,8 @@ public class ClientConfiguration {
         this.allowInsecureHttp = allowInsecureHttp;
         this.connectTimeoutSeconds = requirePositive(connectTimeoutSeconds, "connectTimeoutSeconds");
         this.readTimeoutSeconds = requirePositive(readTimeoutSeconds, "readTimeoutSeconds");
+        // No validation: null means "use the cui-http / JVM default truststore", the unconfigured default.
+        this.sslContext = sslContext;
     }
 
     /**

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/StepUpChallengeParser.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/StepUpChallengeParser.java
@@ -71,7 +71,12 @@ public class StepUpChallengeParser {
         if (!INSUFFICIENT_USER_AUTHENTICATION.equals(params.get("error"))) {
             return Optional.empty();
         }
-        String acrValues = params.get("acr_values");
+        // Blank-normalise acr_values exactly as parseMaxAge already does for max_age: a whitespace-only
+        // value constrains nothing, so treating it as present would make the challenge actionable while
+        // leaving StepUpResultVerifier with no constraint to check — verify() would then return normally
+        // having verified nothing, and a caller reading that as proof of elevation would grant a
+        // privileged operation on an unelevated authentication. Fail closed instead (CLIENT-12 / H1).
+        String acrValues = blankToNull(params.get("acr_values"));
         Integer maxAge = parseMaxAge(params.get("max_age"));
         if (acrValues == null && maxAge == null) {
             LOGGER.debug("Ignoring step-up challenge without acr_values or max_age");
@@ -139,6 +144,10 @@ public class StepUpChallengeParser {
         }
         parts.add(current.toString());
         return parts;
+    }
+
+    private static @Nullable String blankToNull(@Nullable String value) {
+        return value == null || value.isBlank() ? null : value;
     }
 
     private static @Nullable Integer parseMaxAge(@Nullable String value) {

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/StepUpResultVerifier.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/StepUpResultVerifier.java
@@ -70,7 +70,13 @@ public class StepUpResultVerifier {
                 .filter(value -> !value.isBlank())
                 .collect(Collectors.toSet());
         if (required.isEmpty()) {
-            return;
+            // Fail closed (H1): the challenge asked for an acr constraint, but it parses to no actual
+            // value — so there is nothing to check. Returning normally here would report "verified" to a
+            // caller that reads a normal return as proof of elevation, granting a privileged operation on
+            // an unelevated authentication. A constraint we cannot evaluate is a rejection, not a pass.
+            throw new ClientProtocolException(
+                    "step-up challenge carries an 'acr_values' constraint that names no value; "
+                            + "the required step-up cannot be verified");
         }
         ClaimValue acrClaim = idToken.getClaims().get(CLAIM_ACR);
         String actualAcr = acrClaim == null ? null : acrClaim.getOriginalString();

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/internal/BackChannelHttp.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/internal/BackChannelHttp.java
@@ -29,8 +29,10 @@ import javax.net.ssl.SSLContext;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpResponse;
+import java.util.Locale;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * Shared back-channel transport control for the OIDC/OAuth endpoint clients.
@@ -77,7 +79,7 @@ public final class BackChannelHttp {
     private final ClientConfiguration configuration;
     private final HttpSecurityValidator egressValidator;
     private final int maxContentSize;
-    private final AtomicReference<HttpClient> sharedClient = new AtomicReference<>();
+    private final ConcurrentMap<String, HttpClient> sharedClients = new ConcurrentHashMap<>();
 
     /**
      * @param configuration  the client configuration carrying the TLS policy and timeout knobs; must
@@ -145,25 +147,29 @@ public final class BackChannelHttp {
 
     /**
      * Returns the shared {@link HttpClient} for this helper instance, building it once (lazily,
-     * thread-safely) from the given already-validated handler and reusing it for every subsequent
-     * request. All endpoints for one authorization server share the same TLS trust, so a single client
-     * is correct for every back-channel call.
+     * thread-safely) per endpoint scheme and reusing it for every subsequent request to that scheme.
+     * <p>
+     * The client is keyed by scheme rather than being a single instance because
+     * {@link HttpClient} bakes its TLS material in at construction: cui-http's {@code HttpHandler}
+     * installs the {@link SSLContext} and the TLS 1.2/1.3 {@code SSLParameters} pinning only on its
+     * HTTPS path. A single cached client seeded by whichever handler happened to be built first
+     * would therefore let a cleartext endpoint — reachable only when
+     * {@link ClientConfiguration#allowInsecureHttp} is set — seed a client carrying no trust
+     * material, which a later {@code https://} endpoint would then silently reuse. That would drop
+     * the configured per-client trust anchor and widen validation back to the JVM default CA set,
+     * breaking the CLIENT-23 guarantee that the configured {@link SSLContext} applies to
+     * <em>every</em> call. Keying by scheme keeps connection pooling while making that
+     * cross-scheme bleed structurally impossible.
      *
      * @param handler an already-validated handler whose SSL context and connect timeout seed the client
-     * @return the shared, reused {@link HttpClient}
+     * @return the shared, reused {@link HttpClient} for this handler's scheme
      */
     public HttpClient sharedClient(HttpHandler handler) {
-        HttpClient client = sharedClient.get();
-        if (client == null) {
-            synchronized (this) {
-                client = sharedClient.get();
-                if (client == null) {
-                    client = handler.createHttpClient();
-                    sharedClient.set(client);
-                }
-            }
-        }
-        return client;
+        Objects.requireNonNull(handler, "handler must not be null");
+        String scheme = handler.getUri().getScheme();
+        return sharedClients.computeIfAbsent(
+                scheme == null ? "" : scheme.toLowerCase(Locale.ROOT),
+                unusedKey -> handler.createHttpClient());
     }
 
     /**

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/internal/BackChannelHttp.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/internal/BackChannelHttp.java
@@ -25,6 +25,7 @@ import de.cuioss.sheriff.token.client.config.ClientConfiguration;
 import de.cuioss.sheriff.token.commons.error.TransportException;
 import de.cuioss.tools.logging.CuiLogger;
 
+import javax.net.ssl.SSLContext;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpResponse;
@@ -50,6 +51,11 @@ import java.util.concurrent.atomic.AtomicReference;
  *   <li><strong>Scheme / TLS control:</strong> a non-TLS ({@code http://}) endpoint is refused unless
  *       {@link ClientConfiguration#allowInsecureHttp} is set, via the {@link HttpHandler} builder's
  *       own TLS enforcement.</li>
+ *   <li><strong>Per-client TLS trust:</strong> the {@link ClientConfiguration#getSslContext() configured
+ *       SSLContext}, when present, is applied to every endpoint handler this helper produces — so all
+ *       five endpoint clients sharing one {@code ClientConfiguration} trust the same authorization
+ *       server, without a process-global {@code javax.net.ssl.trustStore} override. When absent, the
+ *       cui-http / JVM default truststore is used.</li>
  *   <li><strong>Consistent transport typing (M9):</strong> a malformed or non-TLS endpoint surfaces as
  *       the declared {@link TransportException}, never a raw {@link IllegalArgumentException} leaking
  *       from {@code HttpHandler.build()}.</li>
@@ -100,12 +106,16 @@ public final class BackChannelHttp {
         Objects.requireNonNull(endpointUrl, "endpointUrl must not be null");
         applyEgressControl(endpointUrl, failureContext);
         try {
-            return HttpHandler.builder()
+            HttpHandler.HttpHandlerBuilder builder = HttpHandler.builder()
                     .url(endpointUrl)
                     .connectionTimeoutSeconds(configuration.getConnectTimeoutSeconds())
                     .readTimeoutSeconds(configuration.getReadTimeoutSeconds())
-                    .allowInsecureHttp(configuration.isAllowInsecureHttp())
-                    .build();
+                    .allowInsecureHttp(configuration.isAllowInsecureHttp());
+            SSLContext sslContext = configuration.getSslContext();
+            if (sslContext != null) {
+                builder.sslContext(sslContext);
+            }
+            return builder.build();
         } catch (IllegalArgumentException e) {
             // M9: a non-TLS / malformed endpoint must surface as the declared transport failure, not a
             // raw IllegalArgumentException leaking from the handler builder.

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/config/ClientConfigurationTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/config/ClientConfigurationTest.java
@@ -21,11 +21,15 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import javax.net.ssl.SSLContext;
+
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -222,6 +226,88 @@ class ClientConfigurationTest {
                         "the excluded field is not even named in the string representation"),
                 () -> assertTrue(rendered.contains(clientId),
                         "non-secret fields remain visible for diagnostics"));
+    }
+
+    @Nested
+    @DisplayName("Per-client TLS trust (sslContext)")
+    class SslContextTest {
+
+        @Test
+        @DisplayName("Should leave the SSL context absent when the builder never sets one")
+        void shouldDefaultToAbsentSslContext() {
+            var config = minimalBuilder().build();
+
+            assertNull(config.getSslContext(),
+                    "an unconfigured sslContext means 'use the cui-http / JVM default truststore'");
+        }
+
+        @Test
+        @DisplayName("Should return the supplied SSL context identically — trust material is never copied")
+        void shouldReturnSuppliedSslContextIdentically() {
+            var supplied = defaultSslContext();
+
+            var config = minimalBuilder().sslContext(supplied).build();
+
+            assertSame(supplied, config.getSslContext(),
+                    "the caller's trust material must reach the transport unchanged");
+        }
+
+        @Test
+        @DisplayName("Should exclude the SSL context from toString so a dump cannot expose the trust material")
+        void shouldExcludeSslContextFromToString() {
+            var supplied = defaultSslContext();
+            var config = minimalBuilder().sslContext(supplied).build();
+
+            String rendered = config.toString();
+
+            assertAll("sslContext never appears in the string representation",
+                    () -> assertFalse(rendered.contains(supplied.toString()),
+                            "the SSLContext's own string form must not be rendered"),
+                    () -> assertFalse(rendered.contains("sslContext"),
+                            "the excluded field is not even named in the string representation"));
+        }
+
+        @Test
+        @DisplayName("Should keep two configurations equal when they differ only in their SSL context")
+        void shouldIgnoreSslContextForEquality() {
+            var issuer = issuer();
+            var clientId = Generators.nonBlankStrings().next();
+            var withDefaultTrust = ClientConfiguration.builder()
+                    .issuer(issuer).clientId(clientId).authMethod(ClientAuthMethod.CLIENT_SECRET_BASIC)
+                    .sslContext(defaultSslContext()).build();
+            var withPrivateTrust = ClientConfiguration.builder()
+                    .issuer(issuer).clientId(clientId).authMethod(ClientAuthMethod.CLIENT_SECRET_BASIC)
+                    .sslContext(freshSslContext()).build();
+            var withoutTrust = ClientConfiguration.builder()
+                    .issuer(issuer).clientId(clientId).authMethod(ClientAuthMethod.CLIENT_SECRET_BASIC).build();
+
+            // An SSLContext has identity semantics and no value form, so it is deliberately excluded
+            // from the generated equals/hashCode — configurations stay comparable by their value fields.
+            assertAll("sslContext is excluded from value equality by design",
+                    () -> assertEquals(withDefaultTrust, withPrivateTrust),
+                    () -> assertEquals(withDefaultTrust.hashCode(), withPrivateTrust.hashCode()),
+                    () -> assertEquals(withDefaultTrust, withoutTrust),
+                    () -> assertEquals(withDefaultTrust.hashCode(), withoutTrust.hashCode()));
+        }
+
+        private ClientConfiguration.ClientConfigurationBuilder minimalBuilder() {
+            return ClientConfiguration.builder()
+                    .issuer(issuer())
+                    .clientId(Generators.nonBlankStrings().next())
+                    .authMethod(ClientAuthMethod.CLIENT_SECRET_BASIC);
+        }
+    }
+
+    static SSLContext defaultSslContext() {
+        return assertDoesNotThrow(SSLContext::getDefault);
+    }
+
+    static SSLContext freshSslContext() {
+        return assertDoesNotThrow(() -> {
+            var context = SSLContext.getInstance("TLSv1.3");
+            context.init(null, null, null);
+            return context;
+        });
     }
 
     @Nested

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/config/ClientConfigurationTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/config/ClientConfigurationTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import javax.net.ssl.SSLContext;
-
 import java.util.ArrayList;
 
 import static org.junit.jupiter.api.Assertions.assertAll;

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/config/ClientConfigurationTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/config/ClientConfigurationTest.java
@@ -23,6 +23,8 @@ import org.junit.jupiter.api.Test;
 
 import javax.net.ssl.SSLContext;
 
+import java.util.ArrayList;
+
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -334,6 +336,100 @@ class ClientConfigurationTest {
                             ClientAuthMethod.fromMetadataValue("tls_client_auth").orElseThrow()),
                     () -> assertTrue(ClientAuthMethod.fromMetadataValue("none").isEmpty()),
                     () -> assertTrue(ClientAuthMethod.fromMetadataValue(null).isEmpty()));
+        }
+    }
+
+    @Nested
+    @DisplayName("Construction-time issuer and scope validation (L14)")
+    class IssuerAndScopeValidation {
+
+        private ClientConfiguration.ClientConfigurationBuilder builderWithIssuer(String issuerValue) {
+            return ClientConfiguration.builder()
+                    .issuer(issuerValue)
+                    .clientId(Generators.nonBlankStrings().next())
+                    .authMethod(ClientAuthMethod.CLIENT_SECRET_BASIC)
+                    .clientSecret(Generators.nonBlankStrings().next());
+        }
+
+        @Test
+        @DisplayName("Should reject a blank issuer or client id — a present-but-empty value is not a value")
+        void shouldRejectBlankIssuerAndClientId() {
+            var blankIssuer = builderWithIssuer("   ");
+            var blankClientId = ClientConfiguration.builder()
+                    .issuer(issuer()).clientId("  ")
+                    .authMethod(ClientAuthMethod.CLIENT_SECRET_BASIC);
+
+            assertAll("blank required fields",
+                    () -> assertThrows(IllegalArgumentException.class, blankIssuer::build,
+                            "a whitespace-only issuer must be rejected at construction"),
+                    () -> assertThrows(IllegalArgumentException.class, blankClientId::build,
+                            "a whitespace-only client id must be rejected at construction"));
+        }
+
+        @Test
+        @DisplayName("Should reject a relative issuer that carries no scheme at all")
+        void shouldRejectRelativeIssuer() {
+            var relative = builderWithIssuer("issuer.example.com/auth");
+
+            assertThrows(IllegalArgumentException.class, relative::build,
+                    "a relative reference cannot identify an authorization server");
+        }
+
+        @Test
+        @DisplayName("Should reject an absolute issuer URI that carries no host")
+        void shouldRejectIssuerWithoutHost() {
+            var hostless = builderWithIssuer("urn:example:issuer");
+
+            assertThrows(IllegalArgumentException.class, hostless::build,
+                    "an absolute URI without a host cannot be dereferenced for discovery");
+        }
+
+        @Test
+        @DisplayName("Should reject an issuer whose scheme is neither http nor https")
+        void shouldRejectNonHttpIssuerScheme() {
+            var ftp = builderWithIssuer("ftp://issuer.example.com");
+
+            assertThrows(IllegalArgumentException.class, ftp::build,
+                    "only http(s) issuers can be resolved over the discovery transport");
+        }
+
+        @Test
+        @DisplayName("Should reject a malformed issuer URL that cannot be parsed at all")
+        void shouldRejectUnparseableIssuer() {
+            var malformed = builderWithIssuer("https://issuer.example.com/ a path");
+
+            assertThrows(IllegalArgumentException.class, malformed::build,
+                    "an unparseable issuer must fail at construction, not later on the wire");
+        }
+
+        @Test
+        @DisplayName("Should accept an http issuer so a cleartext local test setup stays configurable")
+        void shouldAcceptHttpIssuer() {
+            var config = builderWithIssuer("http://localhost:8080/auth").allowInsecureHttp(true).build();
+
+            assertEquals("http://localhost:8080/auth", config.getIssuer(),
+                    "a plaintext http issuer remains constructible for local test setups");
+        }
+
+        @Test
+        @DisplayName("Should reject a blank scope entry that would otherwise serialise into the scope parameter")
+        void shouldRejectBlankScopeEntry() {
+            var blankScope = builderWithIssuer(issuer()).scope("openid").scope("   ");
+
+            assertThrows(IllegalArgumentException.class, blankScope::build,
+                    "a blank scope would serialise as stray whitespace in the scope parameter");
+        }
+
+        @Test
+        @DisplayName("Should reject a null scope entry that would otherwise serialise as the literal \"null\"")
+        void shouldRejectNullScopeEntry() {
+            var scopes = new ArrayList<String>();
+            scopes.add("openid");
+            scopes.add(null);
+            var nullScope = builderWithIssuer(issuer()).scopes(scopes);
+
+            assertThrows(IllegalArgumentException.class, nullScope::build,
+                    "a null scope would serialise as the literal \"null\" in the scope parameter");
         }
     }
 }

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/discovery/ProviderMetadataTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/discovery/ProviderMetadataTest.java
@@ -129,4 +129,24 @@ class ProviderMetadataTest {
                 () -> assertFalse(empty.getRevocationEndpoint().isPresent()),
                 () -> assertFalse(empty.getIntrospectionEndpoint().isPresent()));
     }
+
+    @Test
+    @DisplayName("Should treat an advertised-but-empty capability as unsupported rather than supported")
+    void shouldTreatEmptyAdvertisedCapabilityAsUnsupported() {
+        // A discovery document may carry the key with an empty value; presence of the key alone must
+        // not be read as a usable capability, or the flow would target an empty endpoint URL.
+        var blankEndpoints = new ProviderMetadata();
+        blankEndpoints.pushedAuthorizationRequestEndpoint = "   ";
+        blankEndpoints.endSessionEndpoint = "";
+        var emptyDpop = new ProviderMetadata();
+        emptyDpop.dpopSigningAlgValuesSupported = List.of();
+
+        assertAll("advertised-but-empty capabilities",
+                () -> assertFalse(blankEndpoints.supportsPushedAuthorizationRequests(),
+                        "a blank PAR endpoint is not a usable PAR capability"),
+                () -> assertFalse(blankEndpoints.supportsEndSession(),
+                        "an empty end-session endpoint is not a usable logout capability"),
+                () -> assertFalse(emptyDpop.supportsDpop(),
+                        "an empty dpop_signing_alg_values_supported advertises no usable algorithm"));
+    }
 }

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/StepUpChallengeParserTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/StepUpChallengeParserTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.token.client.flow;
+
+import de.cuioss.sheriff.token.client.flow.StepUpChallengeParser.StepUpChallenge;
+import de.cuioss.test.generator.Generators;
+import de.cuioss.test.generator.junit.EnableGeneratorController;
+import de.cuioss.test.juli.junit5.EnableTestLogger;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Exercises the RFC 9110 {@code auth-param} grammar {@link StepUpChallengeParser} implements when it
+ * reads an RFC 9470 step-up challenge off a {@code WWW-Authenticate} header: top-level comma
+ * splitting that respects quoted-strings, backslash unescaping inside a {@code quoted-string},
+ * unquoted {@code token} values, and the fail-safe handling of malformed segments.
+ * <p>
+ * The header literals are deliberately hand-written rather than generated — the grammar under test is
+ * about the exact placement of quotes, commas and backslashes, so the structural characters are the
+ * specification. Only the semantically free {@code acr} token values are generated.
+ */
+@EnableTestLogger
+@EnableGeneratorController
+@DisplayName("StepUpChallengeParser auth-param grammar")
+class StepUpChallengeParserTest {
+
+    private static final String CHALLENGE_PREFIX = "Bearer error=\"insufficient_user_authentication\"";
+
+    private final StepUpChallengeParser parser = new StepUpChallengeParser();
+
+    private static String acrToken() {
+        return "urn:acr:" + Generators.letterStrings(3, 10).next();
+    }
+
+    private StepUpChallenge parseRequired(String header) {
+        Optional<StepUpChallenge> challenge = parser.parse(header);
+        assertTrue(challenge.isPresent(), "header must yield an actionable challenge: " + header);
+        return challenge.get();
+    }
+
+    @Nested
+    @DisplayName("Quoted-string values")
+    class QuotedStringValues {
+
+        @Test
+        @DisplayName("Should keep a comma inside a quoted acr_values with its own parameter rather than splitting on it")
+        void shouldNotSplitOnCommaInsideQuotes() {
+            var first = acrToken();
+            var second = acrToken();
+            String header = CHALLENGE_PREFIX + ", acr_values=\"" + first + "," + second + "\"";
+
+            var challenge = parseRequired(header);
+
+            assertEquals(Optional.of(first + "," + second), challenge.getAcrValues(),
+                    "a comma inside the quoted-string belongs to the value, not to the auth-param list");
+        }
+
+        @Test
+        @DisplayName("Should unescape a backslash-escaped quote inside a quoted acr_values (RFC 9110 §5.6.4)")
+        void shouldUnescapeEscapedQuote() {
+            var acr = acrToken();
+            String header = CHALLENGE_PREFIX + ", acr_values=\"\\\"" + acr + "\\\"\"";
+
+            var challenge = parseRequired(header);
+
+            assertEquals(Optional.of("\"" + acr + "\""), challenge.getAcrValues(),
+                    "an escaped quote must be unescaped into the value and must not close the quoted-string");
+        }
+
+        @Test
+        @DisplayName("Should unescape a backslash-escaped backslash inside a quoted acr_values")
+        void shouldUnescapeEscapedBackslash() {
+            var acr = acrToken();
+            String header = CHALLENGE_PREFIX + ", acr_values=\"" + acr + "\\\\\"";
+
+            var challenge = parseRequired(header);
+
+            assertEquals(Optional.of(acr + "\\"), challenge.getAcrValues(),
+                    "a doubled backslash must collapse to a single literal backslash");
+        }
+
+        @Test
+        @DisplayName("Should leave an unterminated quoted acr_values verbatim instead of stripping a lone quote")
+        void shouldLeaveUnterminatedQuoteVerbatim() {
+            var acr = acrToken();
+            String header = CHALLENGE_PREFIX + ", acr_values=\"" + acr;
+
+            var challenge = parseRequired(header);
+
+            assertEquals(Optional.of("\"" + acr), challenge.getAcrValues(),
+                    "a value that never closes its quote is not a quoted-string and stays verbatim");
+        }
+    }
+
+    @Nested
+    @DisplayName("Unquoted token values and malformed segments")
+    class UnquotedAndMalformed {
+
+        @Test
+        @DisplayName("Should accept unquoted token values for both acr_values and max_age")
+        void shouldAcceptUnquotedTokenValues() {
+            var acr = acrToken();
+            String header = CHALLENGE_PREFIX + ", acr_values=" + acr + ", max_age=5";
+
+            var challenge = parseRequired(header);
+
+            assertAll("unquoted auth-param values",
+                    () -> assertEquals(Optional.of(acr), challenge.getAcrValues(),
+                            "an unquoted token value is taken as-is"),
+                    () -> assertEquals(Optional.of(5), challenge.getMaxAge(),
+                            "a single-character max_age is too short to be a quoted-string and stays verbatim"));
+        }
+
+        @Test
+        @DisplayName("Should not treat a backslash outside a quoted-string as an escape")
+        void shouldNotEscapeOutsideQuotes() {
+            var acr = acrToken();
+            String header = CHALLENGE_PREFIX + ", acr_values=" + acr + "\\, max_age=60";
+
+            var challenge = parseRequired(header);
+
+            assertAll("backslash outside quotes",
+                    () -> assertEquals(Optional.of(acr + "\\"), challenge.getAcrValues(),
+                            "the trailing backslash stays in the value and does not swallow the separator"),
+                    () -> assertEquals(Optional.of(60), challenge.getMaxAge(),
+                            "the comma after an unquoted backslash still separates the next auth-param"));
+        }
+
+        @Test
+        @DisplayName("Should skip a segment carrying no '=' rather than rejecting the whole challenge")
+        void shouldSkipSegmentWithoutEquals() {
+            var acr = acrToken();
+            String header = CHALLENGE_PREFIX + ", acr_values=\"" + acr + "\", realm";
+
+            var challenge = parseRequired(header);
+
+            assertEquals(Optional.of(acr), challenge.getAcrValues(),
+                    "a valueless segment is ignored and the well-formed parameters still apply");
+        }
+
+        @Test
+        @DisplayName("Should skip a segment whose name is empty rather than binding an empty auth-param name")
+        void shouldSkipSegmentWithEmptyName() {
+            var acr = acrToken();
+            String header = CHALLENGE_PREFIX + ", =orphan, acr_values=\"" + acr + "\"";
+
+            var challenge = parseRequired(header);
+
+            assertEquals(Optional.of(acr), challenge.getAcrValues(),
+                    "a segment starting with '=' carries no auth-param name and is ignored");
+        }
+    }
+
+    @Nested
+    @DisplayName("max_age handling")
+    class MaxAgeHandling {
+
+        @Test
+        @DisplayName("Should drop an empty quoted max_age while keeping the acr_values constraint")
+        void shouldDropEmptyMaxAge() {
+            var acr = acrToken();
+            String header = CHALLENGE_PREFIX + ", acr_values=\"" + acr + "\", max_age=\"\"";
+
+            var challenge = parseRequired(header);
+
+            assertAll("empty max_age",
+                    () -> assertTrue(challenge.getMaxAge().isEmpty(),
+                            "an empty max_age constrains nothing and is dropped"),
+                    () -> assertEquals(Optional.of(acr), challenge.getAcrValues(),
+                            "dropping max_age must not discard the acr_values constraint"));
+        }
+
+        @Test
+        @DisplayName("Should ignore a challenge whose only constraint is an empty max_age")
+        void shouldIgnoreChallengeWithOnlyEmptyMaxAge() {
+            String header = CHALLENGE_PREFIX + ", max_age=\"  \"";
+
+            assertTrue(parser.parse(header).isEmpty(),
+                    "a challenge left with no constraint at all is not actionable");
+        }
+    }
+}

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/StepUpChallengeParserTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/StepUpChallengeParserTest.java
@@ -198,5 +198,30 @@ class StepUpChallengeParserTest {
             assertTrue(parser.parse(header).isEmpty(),
                     "a challenge left with no constraint at all is not actionable");
         }
+
+        @Test
+        @DisplayName("Should ignore a challenge whose only constraint is a blank acr_values (H1)")
+        void shouldIgnoreChallengeWithOnlyBlankAcrValues() {
+            String header = CHALLENGE_PREFIX + ", acr_values=\"   \"";
+
+            assertTrue(parser.parse(header).isEmpty(),
+                    "a blank acr_values names no value, so the challenge constrains nothing and must not "
+                            + "be actionable — an actionable-but-unverifiable challenge is the fail-open "
+                            + "shape H1 forbids");
+        }
+
+        @Test
+        @DisplayName("Should drop a blank acr_values while keeping the max_age constraint")
+        void shouldDropBlankAcrValuesKeepingMaxAge() {
+            String header = CHALLENGE_PREFIX + ", acr_values=\"  \", max_age=\"300\"";
+
+            var challenge = parseRequired(header);
+
+            assertAll("blank acr_values",
+                    () -> assertTrue(challenge.getAcrValues().isEmpty(),
+                            "a blank acr_values constrains nothing and is dropped"),
+                    () -> assertEquals(Optional.of(300), challenge.getMaxAge(),
+                            "dropping acr_values must not discard the max_age constraint"));
+        }
     }
 }

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/StepUpHandlerTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/StepUpHandlerTest.java
@@ -285,13 +285,15 @@ class StepUpHandlerTest {
         }
 
         @Test
-        @DisplayName("Should treat a whitespace-only acr_values challenge as constraining nothing")
-        void shouldAcceptWhenAcrValuesConstrainNothing() {
+        @DisplayName("Should reject a whitespace-only acr_values challenge rather than verify nothing (H1)")
+        void shouldRejectWhenAcrValuesConstrainNothing() {
             var challenge = new StepUpChallenge("   ", null);
             var idToken = idToken(WEAK_ACR, Instant.now().getEpochSecond());
 
-            assertDoesNotThrow(() -> stepUpHandler.verifyResult(challenge, idToken),
-                    "a challenge listing no actual acr value cannot be violated by any acr");
+            assertThrows(ClientProtocolException.class,
+                    () -> stepUpHandler.verifyResult(challenge, idToken),
+                    "a constraint that names no acr value cannot be evaluated, so it must fail closed — "
+                            + "returning normally would report a weak authentication as an elevated one");
         }
 
         @Test

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/StepUpHandlerTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/flow/StepUpHandlerTest.java
@@ -32,12 +32,15 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -235,6 +238,22 @@ class StepUpHandlerTest {
             return holder.asIdTokenContent();
         }
 
+        private IdTokenContent idTokenWithout(String claimName) {
+            TestTokenHolder holder = TestTokenGenerators.idTokens().next();
+            holder.withClaim("acr", ClaimValue.forPlainString(ACR));
+            holder.withClaim("auth_time",
+                    ClaimValue.forPlainString(Long.toString(Instant.now().getEpochSecond())));
+            holder.withoutClaim(claimName);
+            return holder.asIdTokenContent();
+        }
+
+        private IdTokenContent idTokenWithAuthTime(ClaimValue authTime) {
+            TestTokenHolder holder = TestTokenGenerators.idTokens().next();
+            holder.withClaim("acr", ClaimValue.forPlainString(ACR));
+            holder.withClaim("auth_time", authTime);
+            return holder.asIdTokenContent();
+        }
+
         @Test
         @DisplayName("Should accept a step-up satisfying both the required acr and max_age")
         void shouldAcceptSatisfiedStepUp() {
@@ -263,6 +282,82 @@ class StepUpHandlerTest {
 
             assertThrows(ClientProtocolException.class, () -> stepUpHandler.verifyResult(challenge, idToken),
                     "an authentication older than max_age must be rejected as stale");
+        }
+
+        @Test
+        @DisplayName("Should treat a whitespace-only acr_values challenge as constraining nothing")
+        void shouldAcceptWhenAcrValuesConstrainNothing() {
+            var challenge = new StepUpChallenge("   ", null);
+            var idToken = idToken(WEAK_ACR, Instant.now().getEpochSecond());
+
+            assertDoesNotThrow(() -> stepUpHandler.verifyResult(challenge, idToken),
+                    "a challenge listing no actual acr value cannot be violated by any acr");
+        }
+
+        @Test
+        @DisplayName("Should reject a step-up whose ID token carries no acr claim at all (H1)")
+        void shouldRejectMissingAcrClaim() {
+            var challenge = new StepUpChallenge(ACR, null);
+            var idToken = idTokenWithout("acr");
+
+            assertThrows(ClientProtocolException.class, () -> stepUpHandler.verifyResult(challenge, idToken),
+                    "an absent acr claim proves nothing about the authentication strength");
+        }
+
+        @Test
+        @DisplayName("Should reject a step-up whose acr claim is blank (H1)")
+        void shouldRejectBlankAcrClaim() {
+            var challenge = new StepUpChallenge(ACR, null);
+            var idToken = idToken("   ", Instant.now().getEpochSecond());
+
+            assertThrows(ClientProtocolException.class, () -> stepUpHandler.verifyResult(challenge, idToken),
+                    "a blank acr claim proves nothing about the authentication strength");
+        }
+
+        @Test
+        @DisplayName("Should reject a step-up whose ID token carries no auth_time claim (H2)")
+        void shouldRejectMissingAuthTimeClaim() {
+            var challenge = new StepUpChallenge(null, 300);
+            var idToken = idTokenWithout("auth_time");
+
+            assertThrows(ClientProtocolException.class, () -> stepUpHandler.verifyResult(challenge, idToken),
+                    "freshness cannot be verified without an auth_time claim");
+        }
+
+        @Test
+        @DisplayName("Should reject a step-up whose auth_time is blank (H2)")
+        void shouldRejectBlankAuthTime() {
+            var challenge = new StepUpChallenge(null, 300);
+            var idToken = idTokenWithAuthTime(ClaimValue.forPlainString("   "));
+
+            assertThrows(ClientProtocolException.class, () -> stepUpHandler.verifyResult(challenge, idToken),
+                    "an empty auth_time cannot establish freshness");
+        }
+
+        @Test
+        @DisplayName("Should reject a step-up whose auth_time is not a numeric date (H2)")
+        void shouldRejectNonNumericAuthTime() {
+            var challenge = new StepUpChallenge(null, 300);
+            var idToken = idTokenWithAuthTime(ClaimValue.forPlainString("yesterday"));
+
+            var exception = assertThrows(ClientProtocolException.class,
+                    () -> stepUpHandler.verifyResult(challenge, idToken),
+                    "a non-numeric auth_time cannot establish freshness");
+
+            assertInstanceOf(NumberFormatException.class, exception.getCause(),
+                    "the parse failure is preserved as the cause");
+        }
+
+        @Test
+        @DisplayName("Should accept a typed DATETIME auth_time without falling back to string parsing")
+        void shouldAcceptTypedDateTimeAuthTime() {
+            var authTime = OffsetDateTime.now(ZoneOffset.UTC).minusSeconds(30);
+            var challenge = new StepUpChallenge(null, 300);
+            var idToken = idTokenWithAuthTime(
+                    ClaimValue.forDateTime("not-a-number", authTime));
+
+            assertDoesNotThrow(() -> stepUpHandler.verifyResult(challenge, idToken),
+                    "a typed auth_time is read from the parsed value, never from its original string");
         }
     }
 }

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/internal/BackChannelHttpTlsTrustTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/internal/BackChannelHttpTlsTrustTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.token.client.internal;
+
+import de.cuioss.sheriff.token.client.config.ClientAuthMethod;
+import de.cuioss.sheriff.token.client.config.ClientConfiguration;
+import de.cuioss.sheriff.token.commons.error.TransportException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.SSLContext;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Verifies that the per-client TLS trust configured on {@link ClientConfiguration} reaches the
+ * outbound transport at the {@link BackChannelHttp#validatedHandler(String, String)} seam, and that
+ * adding the trust hand-off did not regress the consistent-transport-typing guarantee (M9).
+ */
+@DisplayName("BackChannelHttp per-client TLS trust")
+class BackChannelHttpTlsTrustTest {
+
+    private static final int MAX_CONTENT_SIZE = 8192;
+    private static final String ISSUER = "https://as.example.com";
+    private static final String TOKEN_ENDPOINT = ISSUER + "/token";
+    private static final String USERINFO_ENDPOINT = ISSUER + "/userinfo";
+    private static final String FAILURE_CONTEXT = "token endpoint request failed";
+
+    @Test
+    @DisplayName("Should forward the configured SSL context to the handler it builds")
+    void shouldForwardConfiguredSslContextToHandler() {
+        var configured = freshSslContext();
+        var backChannel = backChannelWith(configured);
+
+        var handler = backChannel.validatedHandler(TOKEN_ENDPOINT, FAILURE_CONTEXT);
+
+        assertSame(configured, handler.getSslContext(),
+                "the caller's trust material must be handed to the handler unchanged");
+    }
+
+    @Test
+    @DisplayName("Should apply the same SSL context to every endpoint handler the helper produces")
+    void shouldApplySameSslContextToEveryEndpointHandler() {
+        var configured = freshSslContext();
+        var backChannel = backChannelWith(configured);
+
+        var tokenHandler = backChannel.validatedHandler(TOKEN_ENDPOINT, FAILURE_CONTEXT);
+        var userinfoHandler = backChannel.validatedHandler(USERINFO_ENDPOINT, FAILURE_CONTEXT);
+
+        assertAll("all endpoints of one authorization server share the same trust",
+                () -> assertSame(configured, tokenHandler.getSslContext()),
+                () -> assertSame(configured, userinfoHandler.getSslContext()));
+    }
+
+    @Test
+    @DisplayName("Should fall back to the cui-http default trust when no SSL context is configured")
+    void shouldFallBackToDefaultTrustWhenUnconfigured() {
+        var unrelated = freshSslContext();
+        var backChannel = backChannelWithoutTrust();
+
+        var handler = backChannel.validatedHandler(TOKEN_ENDPOINT, FAILURE_CONTEXT);
+
+        assertAll("an unconfigured client still gets a working, secure handler",
+                () -> assertNotNull(handler.getSslContext(),
+                        "cui-http creates a secure context when the client configures none"),
+                () -> assertNotSame(unrelated, handler.getSslContext()),
+                () -> assertNotNull(backChannel.sharedClient(handler),
+                        "the handler must still yield a usable shared HttpClient"));
+    }
+
+    @Test
+    @DisplayName("Should still surface a non-TLS endpoint as TransportException with an SSL context configured (M9)")
+    void shouldKeepTransportTypingForNonTlsEndpoint() {
+        var backChannel = backChannelWith(freshSslContext());
+
+        assertThrows(TransportException.class,
+                () -> backChannel.validatedHandler("http://as.example.com/token", FAILURE_CONTEXT),
+                "cleartext must be refused as the declared transport failure, not a raw IllegalArgumentException");
+    }
+
+    @Test
+    @DisplayName("Should still surface an unsupported scheme as TransportException with an SSL context configured (M9)")
+    void shouldKeepTransportTypingForUnsupportedScheme() {
+        var backChannel = backChannelWith(freshSslContext());
+
+        assertThrows(TransportException.class,
+                () -> backChannel.validatedHandler("ftp://as.example.com/token", FAILURE_CONTEXT),
+                "a non-HTTP scheme must be refused as the declared transport failure");
+    }
+
+    private static BackChannelHttp backChannelWith(SSLContext sslContext) {
+        return new BackChannelHttp(configurationBuilder().sslContext(sslContext).build(), MAX_CONTENT_SIZE);
+    }
+
+    private static BackChannelHttp backChannelWithoutTrust() {
+        return new BackChannelHttp(configurationBuilder().build(), MAX_CONTENT_SIZE);
+    }
+
+    private static ClientConfiguration.ClientConfigurationBuilder configurationBuilder() {
+        return ClientConfiguration.builder()
+                .issuer(ISSUER)
+                .clientId("test-client")
+                .authMethod(ClientAuthMethod.CLIENT_SECRET_BASIC);
+    }
+
+    private static SSLContext freshSslContext() {
+        return assertDoesNotThrow(() -> {
+            var context = SSLContext.getInstance("TLSv1.3");
+            context.init(null, null, null);
+            return context;
+        });
+    }
+}

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/internal/BackChannelHttpTlsTrustTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/internal/BackChannelHttpTlsTrustTest.java
@@ -106,6 +106,37 @@ class BackChannelHttpTlsTrustTest {
                 "a non-HTTP scheme must be refused as the declared transport failure");
     }
 
+    @Test
+    @DisplayName("Should not let a cleartext endpoint seed the client a TLS endpoint reuses (CLIENT-23)")
+    void shouldNotShareClientAcrossSchemes() {
+        // An insecure-http-permitting client with pinned trust material: the only configuration in
+        // which validatedHandler can legitimately produce handlers of two different schemes.
+        var configured = freshSslContext();
+        var backChannel = new BackChannelHttp(configurationBuilder()
+                .sslContext(configured)
+                .allowInsecureHttp(true)
+                .build(), MAX_CONTENT_SIZE);
+
+        // The cleartext endpoint is reached FIRST, so it is the one that would seed a single shared
+        // client. cui-http's HTTP path installs no SSLContext and no TLS-version pinning, so a client
+        // seeded from it carries no trust material at all.
+        var cleartextHandler = backChannel.validatedHandler("http://as.example.com/token", FAILURE_CONTEXT);
+        var cleartextClient = backChannel.sharedClient(cleartextHandler);
+
+        var tlsHandler = backChannel.validatedHandler(USERINFO_ENDPOINT, FAILURE_CONTEXT);
+        var tlsClient = backChannel.sharedClient(tlsHandler);
+
+        assertAll("the TLS endpoint must not inherit the cleartext endpoint's trust-free client",
+                () -> assertNotSame(cleartextClient, tlsClient,
+                        "a cleartext-seeded client must never be reused for a TLS endpoint — doing so drops the "
+                                + "configured trust anchor and widens validation back to the JVM default CA set"),
+                () -> assertSame(configured, tlsHandler.getSslContext(),
+                        "the TLS handler must still carry the configured trust material"),
+                () -> assertSame(tlsClient, backChannel.sharedClient(
+                        backChannel.validatedHandler(TOKEN_ENDPOINT, FAILURE_CONTEXT)),
+                        "two TLS endpoints on one configuration must still share a pooled client"));
+    }
+
     private static BackChannelHttp backChannelWith(SSLContext sslContext) {
         return new BackChannelHttp(configurationBuilder().sslContext(sslContext).build(), MAX_CONTENT_SIZE);
     }

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/lifecycle/StoredTokenTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/lifecycle/StoredTokenTest.java
@@ -158,9 +158,10 @@ class StoredTokenTest {
         void shouldRefuseDowngradeToBearer() {
             var binding = ConstraintBinding.dpop(token());
             var constrained = new StoredToken(token(), token(), token(), binding, Instant.now());
+            var newAccessToken = token();
 
             var exception = assertThrows(IllegalStateException.class,
-                    () -> constrained.refreshed(token(), null, null, null),
+                    () -> constrained.refreshed(newAccessToken, null, null, null),
                     "a sender-constrained bundle must not silently degrade to a bearer token");
 
             assertTrue(exception.getMessage().contains("cnf"),
@@ -173,9 +174,10 @@ class StoredTokenTest {
             var binding = ConstraintBinding.dpop(token());
             var otherBinding = ConstraintBinding.dpop(token());
             var constrained = new StoredToken(token(), token(), token(), binding, Instant.now());
+            var newAccessToken = token();
 
             assertThrows(IllegalStateException.class,
-                    () -> constrained.refreshed(token(), null, null, otherBinding),
+                    () -> constrained.refreshed(newAccessToken, null, null, otherBinding),
                     "a re-binding to a different key must fail closed");
         }
 

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/lifecycle/StoredTokenTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/lifecycle/StoredTokenTest.java
@@ -64,6 +64,17 @@ class StoredTokenTest {
                             () -> new StoredToken("   ", null, null, null, null),
                             "a whitespace-only access token is not a usable credential"));
         }
+
+        @Test
+        @DisplayName("Should reject a null access token via the separate requireNonNull guard")
+        void shouldRejectNullAccessToken() {
+            // Distinct from the blank cases above: the compact constructor guards null with
+            // Objects.requireNonNull (NullPointerException) before the isBlank check that raises
+            // IllegalArgumentException, so the two contracts need separate coverage.
+            assertThrows(NullPointerException.class,
+                    () -> new StoredToken(null, null, null, null, null),
+                    "a null access token is not a usable credential");
+        }
     }
 
     @Nested

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/lifecycle/StoredTokenTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/lifecycle/StoredTokenTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.token.client.lifecycle;
+
+import de.cuioss.sheriff.token.client.dpop.ConstraintBinding;
+import de.cuioss.test.generator.Generators;
+import de.cuioss.test.generator.junit.EnableGeneratorController;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Value-object level tests for {@link StoredToken}: construction guards, the {@link
+ * StoredToken#isExpired(Instant)} freshness predicate the refresh scheduler drives, and the
+ * carry-forward rules {@link StoredToken#refreshed} applies to the refresh and ID tokens.
+ */
+@EnableGeneratorController
+@DisplayName("StoredToken value object")
+class StoredTokenTest {
+
+    private static String token() {
+        return Generators.letterStrings(20, 40).next();
+    }
+
+    private static StoredToken bearerToken(Instant expiresAt) {
+        return new StoredToken(token(), token(), token(), null, expiresAt);
+    }
+
+    @Nested
+    @DisplayName("Construction guards")
+    class ConstructionGuards {
+
+        @Test
+        @DisplayName("Should reject a blank access token so an unusable bundle can never be stored")
+        void shouldRejectBlankAccessToken() {
+            assertAll("blank access tokens",
+                    () -> assertThrows(IllegalArgumentException.class,
+                            () -> new StoredToken("", null, null, null, null),
+                            "an empty access token is not a usable credential"),
+                    () -> assertThrows(IllegalArgumentException.class,
+                            () -> new StoredToken("   ", null, null, null, null),
+                            "a whitespace-only access token is not a usable credential"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Expiry predicate")
+    class ExpiryPredicate {
+
+        @Test
+        @DisplayName("Should never report expiry when the access-token expiry is unknown")
+        void shouldNeverExpireWithoutExpiry() {
+            var stored = bearerToken(null);
+
+            assertFalse(stored.isExpired(Instant.now()),
+                    "a bundle with an unknown expiry must not be treated as expired");
+        }
+
+        @Test
+        @DisplayName("Should report the token still valid strictly before its expiry instant")
+        void shouldNotBeExpiredBeforeExpiry() {
+            var expiresAt = Instant.now().plus(Duration.ofMinutes(5));
+            var stored = bearerToken(expiresAt);
+
+            assertFalse(stored.isExpired(expiresAt.minusSeconds(1)),
+                    "the token is still valid up to, but not including, its expiry instant");
+        }
+
+        @Test
+        @DisplayName("Should report the token expired at and after its expiry instant (inclusive boundary)")
+        void shouldBeExpiredAtAndAfterExpiry() {
+            var expiresAt = Instant.now().plus(Duration.ofMinutes(5));
+            var stored = bearerToken(expiresAt);
+
+            assertAll("inclusive expiry boundary",
+                    () -> assertTrue(stored.isExpired(expiresAt),
+                            "the expiry instant itself already counts as expired"),
+                    () -> assertTrue(stored.isExpired(expiresAt.plusSeconds(1)),
+                            "any instant after the expiry counts as expired"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Refresh carry-forward")
+    class RefreshCarryForward {
+
+        @Test
+        @DisplayName("Should keep the current refresh and ID token when the AS returned neither on refresh")
+        void shouldKeepCurrentRefreshAndIdToken() {
+            var stored = bearerToken(Instant.now());
+            var newAccessToken = token();
+
+            var refreshed = stored.refreshed(newAccessToken, null, null, null);
+
+            assertAll("carry-forward on an omitting refresh",
+                    () -> assertEquals(newAccessToken, refreshed.accessToken(),
+                            "the refreshed access token replaces the previous one"),
+                    () -> assertEquals(stored.refreshToken(), refreshed.refreshToken(),
+                            "an omitted refresh token keeps the stored one"),
+                    () -> assertEquals(stored.idToken(), refreshed.idToken(),
+                            "an omitted ID token keeps the stored one (OIDC Core §12.2)"),
+                    () -> assertNull(refreshed.expiresAt(),
+                            "an unknown refreshed expiry is recorded as unknown"));
+        }
+
+        @Test
+        @DisplayName("Should adopt the refreshed refresh and ID token when the AS returned both")
+        void shouldAdoptReturnedRefreshAndIdToken() {
+            var stored = bearerToken(Instant.now());
+            var newRefreshToken = token();
+            var newIdToken = token();
+
+            var refreshed = stored.refreshed(token(), newRefreshToken, null, null, newIdToken);
+
+            assertAll("adoption of returned material",
+                    () -> assertEquals(newRefreshToken, refreshed.refreshToken(),
+                            "a returned refresh token replaces the stored one (rotation)"),
+                    () -> assertEquals(newIdToken, refreshed.idToken(),
+                            "a returned ID token replaces the stored one"));
+        }
+
+        @Test
+        @DisplayName("Should refuse to refresh a sender-constrained bundle onto a plain bearer token (CLIENT-18)")
+        void shouldRefuseDowngradeToBearer() {
+            var binding = ConstraintBinding.dpop(token());
+            var constrained = new StoredToken(token(), token(), token(), binding, Instant.now());
+
+            var exception = assertThrows(IllegalStateException.class,
+                    () -> constrained.refreshed(token(), null, null, null),
+                    "a sender-constrained bundle must not silently degrade to a bearer token");
+
+            assertTrue(exception.getMessage().contains("cnf"),
+                    "the failure must name the stale cnf binding it refused to preserve");
+        }
+
+        @Test
+        @DisplayName("Should refuse to refresh a sender-constrained bundle onto a differently bound token")
+        void shouldRefuseRebindingToAnotherKey() {
+            var binding = ConstraintBinding.dpop(token());
+            var otherBinding = ConstraintBinding.dpop(token());
+            var constrained = new StoredToken(token(), token(), token(), binding, Instant.now());
+
+            assertThrows(IllegalStateException.class,
+                    () -> constrained.refreshed(token(), null, null, otherBinding),
+                    "a re-binding to a different key must fail closed");
+        }
+
+        @Test
+        @DisplayName("Should carry the sender constraint forward when the refreshed token confirms the same key")
+        void shouldCarryConstraintForwardOnMatchingBinding() {
+            var binding = ConstraintBinding.dpop(token());
+            var constrained = new StoredToken(token(), token(), token(), binding, Instant.now());
+
+            var refreshed = constrained.refreshed(token(), null, null, binding);
+
+            assertEquals(binding, refreshed.constraintBinding(),
+                    "a refreshed token confirming the same key keeps the sender constraint");
+        }
+    }
+}

--- a/token-sheriff-validation/pom.xml
+++ b/token-sheriff-validation/pom.xml
@@ -234,6 +234,21 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- Exclude the DSL-JSON annotation processor's generated converters from coverage measurement.
+                 The processor emits _<Type>_DslJsonConverter classes straight into target/classes with no
+                 counterpart under src/main/java, so their branches measure the DSL-JSON code generator rather
+                 than project code. The pattern is anchored to the processor's fixed _<Type>_DslJsonConverter
+                 naming so it cannot silently swallow hand-written classes. The configuration sits at plugin
+                 level so it applies to both the report and check goals inherited from the cuioss parent. -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>**/_*_DslJsonConverter*.class</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
## Summary

Adds an optional per-client `SSLContext` to the OIDC confidential-client engine's outbound transport, so a consumer can trust a private-CA / self-signed authorization server without a process-global `javax.net.ssl.trustStore` override. This is the client-side analogue of `HttpJwksLoaderConfig.sslContext()` on the validation side.

## Changes

- `ClientConfiguration` (`token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/config/ClientConfiguration.java`) gains an optional `@Nullable @ToString.Exclude @EqualsAndHashCode.Exclude SSLContext`, threaded through the package-private all-args constructor. `null` means "use the cui-http / JVM default truststore".
- `BackChannelHttp` (`token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/internal/BackChannelHttp.java`) forwards the configured `SSLContext` to the `HttpHandler` builder only when non-null, inside the existing try block so a rejected context still surfaces as the declared `TransportException`. Applies to every endpoint handler the helper produces.
- New tests: `BackChannelHttpTlsTrustTest` (propagation, same context across endpoints, default-trust fallback, two consistent-transport-typing guards) plus `ClientConfigurationTest` additions (absent by default, returned identically, excluded from `toString`, excluded from equality).
- Docs: `CLIENT-23` in `doc/client/requirements.adoc` with its `test-strategy.adoc` traceability row, and a `.sslContext(sslContext)` line in `token-sheriff-client/README.adoc`.

### Secondary work (operator-approved, out of the original scope): JaCoCo coverage fix

Pre-existing debt on `main`, not introduced by this branch. The DSL-JSON annotation processor emits `_<Type>_DslJsonConverter` classes into `target/classes` with no `src/` counterpart, and they accounted for 154 of 373 missed branches in `token-sheriff-validation` and 377 of 495 in `token-sheriff-client` — so `verify -Pcoverage` failed `jacoco:check` in both modules before this fix.

- `token-sheriff-client/pom.xml` and `token-sheriff-validation/pom.xml` now carry a plugin-level exclude of `**/_*_DslJsonConverter*.class`. The 0.80 thresholds are unchanged.
- The exclusion alone left `token-sheriff-client` at 0.7862 branch coverage, 8 covered branches short of 0.80, so genuine tests were added for real decision paths: `StepUpChallengeParserTest` (RFC 9110 auth-param grammar edge cases), `StoredTokenTest` (`isExpired` boundary incl. the previously 0/4-branch case, `CLIENT-18` bearer-downgrade and re-binding refusals), plus additions to `ClientConfigurationTest` (issuer/scope validation), `StepUpHandlerTest` (acr/auth_time claim handling), and `ProviderMetadataTest` (advertised-but-empty endpoints).
- Final coverage: `token-sheriff-client` INSTRUCTION 0.9330 / BRANCH 0.8587; `token-sheriff-validation` INSTRUCTION 0.9225 / BRANCH 0.8289.

## Test Plan

- [x] Whole-tree `verify -Ppre-commit` green (725s)
- [x] `verify -Pcoverage -pl token-sheriff-client -am` green with `jacoco:check` passing for both `token-sheriff-client` and `token-sheriff-validation`
- [x] All tests passing

## Related Issues

Closes #597


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional per-client TLS trust configuration for discovery and back-channel requests.
  - TLS settings support full certificate-chain validation and fall back to the default truststore when unspecified.
  - Documented configuration examples and clarified separate TLS settings for token validation.

- **Bug Fixes**
  - Step-up authentication now fails closed when required constraints are blank, missing, or invalid.
  - Empty provider capabilities are correctly treated as unsupported.
  - Improved token refresh handling for expiry and sender-constrained tokens.

- **Documentation**
  - Added requirement and test-traceability coverage for per-client TLS configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->