### PR TITLE
fix: drop unsupported semver cooldown keys from github-actions and docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,11 +19,11 @@ updates:
     directory: /
     schedule:
       interval: daily
+    # Only `default-days`: the `semver-*-days` keys are rejected for the
+    # github-actions ecosystem, and one rejected key invalidates the whole file,
+    # which disables version updates for the entire repo.
     cooldown:
       default-days: 3
-      semver-major-days: 7
-      semver-minor-days: 3
-      semver-patch-days: 1
 
   - package-ecosystem: docker
     directory: "/token-sheriff-quarkus-parent/token-sheriff-quarkus-integration-tests"
@@ -34,11 +34,10 @@ updates:
     # doesn't scan compose files. Current versions in docker-compose.yml:
     # - quay.io/keycloak/keycloak:26.4.0
     # - prom/prometheus:v3.6.0
+    # Only `default-days`: as with github-actions above, the `semver-*-days` keys
+    # are rejected for the docker ecosystem and would invalidate the whole file.
     cooldown:
       default-days: 3
-      semver-major-days: 7
-      semver-minor-days: 3
-      semver-patch-days: 1
 
   - package-ecosystem: npm
     directory: "/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus-deployment"


### PR DESCRIPTION
## Dependabot version updates have been disabled in this repo since 2026-06-28

`.github/dependabot.yml` is invalid. Dependabot's check-run on `9ecafa8` — the last commit to touch the file:

```
The property '#/updates/1/cooldown/semver-major-days' is not supported for the package ecosystem 'github-actions'.
The property '#/updates/1/cooldown/semver-minor-days' is not supported for the package ecosystem 'github-actions'.
The property '#/updates/1/cooldown/semver-patch-days' is not supported for the package ecosystem 'github-actions'.
The property '#/updates/2/cooldown/semver-major-days' is not supported for the package ecosystem 'docker'.
The property '#/updates/2/cooldown/semver-minor-days' is not supported for the package ecosystem 'docker'.
The property '#/updates/2/cooldown/semver-patch-days' is not supported for the package ecosystem 'docker'.
```

A single rejected property invalidates the **entire file**, so version updates have been off for **every** ecosystem here — maven and npm included, not just the two offending entries — for over five weeks.

It stayed invisible for two reasons: Dependabot reports config errors in a *check-run*, not an Actions run (so `gh run list` and a green build never show it), and that check only re-runs when `dependabot.yml` itself changes — so every commit since has been silent about it.

## The fix

Removed the three `semver-*-days` keys from the `github-actions` and `docker` entries, keeping `default-days: 3`.

| entry | ecosystem | cooldown after |
|---|---|---|
| `updates/0` | maven | `default-days` + tiered semver keys (unchanged) |
| `updates/1` | github-actions | `default-days: 3` |
| `updates/2` | docker | `default-days: 3` |
| `updates/3` | npm | `default-days` + tiered semver keys (unchanged) |

`maven` and `npm` support the keys — Dependabot's own error flags only `updates/1` and `updates/2` — so those entries are untouched and keep their tiering. A short comment on each edited entry records why the keys must not come back.

## Verification

- Parses locally; the four entries resolve to the shapes in the table above.
- The authoritative confirmation is the `.github/dependabot.yml` check-run on the merge commit, which is where Dependabot re-validates. Will verify there after merge.

## Root cause

The org-level `/update-github-actions` command instructed adding the full tiered block to *every* ecosystem entry. Fixed in cuioss/cuioss-organization#233, with the "repair an existing wrong block" case in cuioss/cuioss-organization#234.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CucanbUKECmSi3Bn6TFxxw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update scheduling with a three-day default cooldown.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->