### PR TITLE
fix: give the OIDC discovery document its own configurable size ceiling

### DIFF
--- a/token-sheriff-client/README.adoc
+++ b/token-sheriff-client/README.adoc
@@ -67,6 +67,7 @@ ClientConfiguration config = ClientConfiguration.builder()
     .authMethod(ClientAuthMethod.CLIENT_SECRET_BASIC)
     .scope("openid")
     .sslContext(sslContext) // <1>
+    .discoveryDocumentMaxSize(128 * 1024) // <2>
     .build();
 ----
 <1> Optional. Supply an `SSLContext` when the authorization server presents a private-CA or
@@ -85,6 +86,13 @@ NOTE: The scope is this client engine only. JWKS retrieval for token *validation
 `HttpJwksLoaderConfig`, which carries its own independent `sslContext()`. Against a private-CA
 authorization server, configure both — otherwise token retrieval succeeds and validation then
 fails the JWKS fetch with a PKIX error.
+
+<2> Optional. The byte ceiling for the authorization server's discovery document, enforced during
+the read. Defaults to 64 KiB — a ceiling sized for a discovery document rather than borrowed from
+the 8 KiB JWT payload bound, which an ordinary Keycloak realm already exceeds. Raise it only for an
+authorization server whose `.well-known/openid-configuration` is larger still; it bounds how much
+of that response is buffered, so keep it as tight as the deployment's actual documents allow. Under
+Quarkus the same knob is `sheriff.client.discovery-document-max-size`.
 
 Endpoints are resolved via OIDC discovery against
 `{issuer}/.well-known/openid-configuration`. See the

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/config/ClientConfiguration.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/config/ClientConfiguration.java
@@ -57,6 +57,15 @@ public class ClientConfiguration {
     public static final int DEFAULT_READ_TIMEOUT_SECONDS = 10;
 
     /**
+     * Default byte ceiling for the OIDC discovery document, when the caller does not override it:
+     * 64&nbsp;KiB. Sized for what a discovery document actually is — a stock Keycloak realm already
+     * publishes upwards of 8&nbsp;KiB, and a document that enumerates a large
+     * {@code claims_supported} / {@code scopes_supported} set grows well past that — while still
+     * bounding the read so an unbounded response cannot be buffered.
+     */
+    public static final int DEFAULT_DISCOVERY_DOCUMENT_MAX_SIZE = 64 * 1024;
+
+    /**
      * The authorization server's issuer identifier URL (for example
      * {@code https://issuer.example.com/realms/demo}). Discovery is performed against
      * {@code {issuer}/.well-known/openid-configuration}. Must not be {@code null}.
@@ -131,6 +140,23 @@ public class ClientConfiguration {
     int readTimeoutSeconds = DEFAULT_READ_TIMEOUT_SECONDS;
 
     /**
+     * The maximum size, in bytes, of the authorization server's
+     * {@code .well-known/openid-configuration} response, enforced during the read. Defaults to
+     * {@value #DEFAULT_DISCOVERY_DOCUMENT_MAX_SIZE} bytes.
+     * <p>
+     * A discovery document is an unrelated artifact to a JWT payload and has its own size profile, so
+     * it carries its own ceiling rather than borrowing the JWT payload ceiling
+     * ({@code ParserConfig.getMaxPayloadSize()}, 8&nbsp;KiB) — a bound an ordinary Keycloak realm
+     * already exceeds, which failed discovery outright. Exposing it here also gives an embedder facing
+     * an unusually large document a deployment-side route that does not require a release.
+     * <p>
+     * Must be positive. Raising it widens how much of an authorization-server response is buffered;
+     * keep it as tight as the deployment's actual documents allow.
+     */
+    @Builder.Default
+    int discoveryDocumentMaxSize = DEFAULT_DISCOVERY_DOCUMENT_MAX_SIZE;
+
+    /**
      * The per-client outbound TLS trust material, applied to every discovery and back-channel call this
      * client issues, or {@code null} to use the cui-http / JVM default truststore (the behaviour when the
      * field is not configured).
@@ -186,7 +212,7 @@ public class ClientConfiguration {
     ClientConfiguration(@NonNull String issuer, @NonNull String clientId, @Nullable String clientSecret,
             @NonNull ClientAuthMethod authMethod, List<String> scopes, @Nullable String redirectUri,
             boolean allowInsecureHttp, int connectTimeoutSeconds, int readTimeoutSeconds,
-            @Nullable SSLContext sslContext) {
+            int discoveryDocumentMaxSize, @Nullable SSLContext sslContext) {
         this.issuer = requireNonBlank(issuer, "issuer");
         validateIssuerUrl(this.issuer);
         this.clientId = requireNonBlank(clientId, "clientId");
@@ -197,6 +223,7 @@ public class ClientConfiguration {
         this.allowInsecureHttp = allowInsecureHttp;
         this.connectTimeoutSeconds = requirePositive(connectTimeoutSeconds, "connectTimeoutSeconds");
         this.readTimeoutSeconds = requirePositive(readTimeoutSeconds, "readTimeoutSeconds");
+        this.discoveryDocumentMaxSize = requirePositive(discoveryDocumentMaxSize, "discoveryDocumentMaxSize");
         // No validation: null means "use the cui-http / JVM default truststore", the unconfigured default.
         this.sslContext = sslContext;
     }

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/discovery/DiscoveryResolver.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/discovery/DiscoveryResolver.java
@@ -48,6 +48,10 @@ import java.util.Objects;
  * therefore parses the document directly into the richer {@link ProviderMetadata} record, reusing
  * the commons {@link ParserConfig} DSL-JSON instance (secure limits, native-image friendly).
  * <p>
+ * The response is bounded during the read by
+ * {@link ClientConfiguration#getDiscoveryDocumentMaxSize()} — the discovery document's own ceiling,
+ * settable per client.
+ * <p>
  * <strong>Security:</strong> a non-TLS issuer is rejected unless
  * {@link ClientConfiguration#allowInsecureHttp} is set; the discovery document's
  * {@code issuer} must match the configured issuer (OpenID Connect Discovery §4.3, a mix-up
@@ -78,9 +82,12 @@ public class DiscoveryResolver {
      */
     public DiscoveryResolver(ClientConfiguration configuration) {
         this.configuration = Objects.requireNonNull(configuration, "configuration must not be null");
-        ParserConfig parserConfig = ParserConfig.builder().build();
-        this.dslJson = parserConfig.getDslJson();
-        this.maxContentSize = parserConfig.getMaxPayloadSize();
+        this.dslJson = ParserConfig.builder().build().getDslJson();
+        // The discovery document is bounded by its own configured ceiling, not by the JWT payload
+        // ceiling (ParserConfig.getMaxPayloadSize()): the two are unrelated artifacts with unrelated
+        // size profiles, and an ordinary Keycloak realm already publishes a document larger than the
+        // 8 KiB payload bound, which failed discovery outright with no deployment-side remedy.
+        this.maxContentSize = configuration.getDiscoveryDocumentMaxSize();
         this.backChannel = new BackChannelHttp(configuration, maxContentSize);
     }
 

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/config/ClientConfigurationTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/config/ClientConfigurationTest.java
@@ -158,6 +158,45 @@ class ClientConfigurationTest {
     }
 
     @Test
+    @DisplayName("Should default the discovery-document ceiling above the JWT payload ceiling and keep it settable")
+    void shouldExposeDiscoveryDocumentMaxSize() {
+        var defaulted = ClientConfiguration.builder()
+                .issuer(issuer()).clientId(Generators.nonBlankStrings().next())
+                .authMethod(ClientAuthMethod.CLIENT_SECRET_BASIC).build();
+        var explicit = ClientConfiguration.builder()
+                .issuer(issuer()).clientId(Generators.nonBlankStrings().next())
+                .authMethod(ClientAuthMethod.CLIENT_SECRET_BASIC)
+                .discoveryDocumentMaxSize(256 * 1024).build();
+
+        assertAll("discovery-document ceiling",
+                () -> assertEquals(ClientConfiguration.DEFAULT_DISCOVERY_DOCUMENT_MAX_SIZE,
+                        defaulted.getDiscoveryDocumentMaxSize()),
+                // The defect: the ceiling used to be the 8 KiB JWT payload bound, which an ordinary
+                // Keycloak realm already exceeds. The default must leave real documents room.
+                () -> assertTrue(defaulted.getDiscoveryDocumentMaxSize() > 8 * 1024,
+                        "the default must exceed the JWT payload ceiling it used to borrow"),
+                () -> assertEquals(256 * 1024, explicit.getDiscoveryDocumentMaxSize(),
+                        "an embedder facing a larger document can raise the ceiling"));
+    }
+
+    @Test
+    @DisplayName("Should reject a non-positive discovery-document ceiling at construction")
+    void shouldRejectNonPositiveDiscoveryDocumentMaxSize() {
+        var zero = ClientConfiguration.builder()
+                .issuer(issuer()).clientId(Generators.nonBlankStrings().next())
+                .authMethod(ClientAuthMethod.CLIENT_SECRET_BASIC).discoveryDocumentMaxSize(0);
+        var negative = ClientConfiguration.builder()
+                .issuer(issuer()).clientId(Generators.nonBlankStrings().next())
+                .authMethod(ClientAuthMethod.CLIENT_SECRET_BASIC).discoveryDocumentMaxSize(-1);
+
+        assertAll("discovery-document ceiling guards",
+                () -> assertThrows(IllegalArgumentException.class, zero::build,
+                        "a zero ceiling would reject every discovery document"),
+                () -> assertThrows(IllegalArgumentException.class, negative::build,
+                        "a negative ceiling is not a size"));
+    }
+
+    @Test
     @DisplayName("Should reject a null issuer, client id or auth method")
     void shouldRejectNullRequiredFields() {
         var clientId = Generators.nonBlankStrings().next();

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/discovery/DiscoveryResolverTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/discovery/DiscoveryResolverTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 
@@ -140,43 +141,64 @@ class DiscoveryResolverTest {
 }
 
 /**
- * Verifies that the discovery fetch enforces the response size ceiling <em>during</em> the read (M7):
- * an oversized well-known document is rejected as a {@link TransportException} rather than being fully
- * buffered into memory before the cap is checked.
+ * Verifies the discovery document's own size ceiling
+ * ({@link ClientConfiguration#getDiscoveryDocumentMaxSize()}): a document larger than the 8&nbsp;KiB
+ * JWT payload bound the resolver used to borrow now resolves (issue #628), the ceiling is settable per
+ * client, and a document beyond the configured ceiling is still rejected as a
+ * {@link TransportException} <em>during</em> the read rather than being buffered whole (M7).
  */
 @EnableTestLogger
 @EnableGeneratorController
 @EnableMockWebServer
-@DisplayName("DiscoveryResolver enforces the response size cap during read")
+@DisplayName("DiscoveryResolver bounds the discovery document by its own configured ceiling")
 class DiscoveryResolverSizeCapTest {
 
-    @Getter
-    private final OversizedWellKnownDispatcher moduleDispatcher = new OversizedWellKnownDispatcher();
+    /** Larger than the 8 KiB JWT payload ceiling, smaller than the discovery-document default. */
+    private static final int OVER_PAYLOAD_CEILING_PADDING = 9 * 1024;
 
-    private static ClientConfiguration configFor(String issuer) {
+    @Getter
+    private final PaddedWellKnownDispatcher moduleDispatcher =
+            new PaddedWellKnownDispatcher(OVER_PAYLOAD_CEILING_PADDING);
+
+    private static ClientConfiguration.ClientConfigurationBuilder builderFor(String issuer) {
         return ClientConfiguration.builder()
                 .issuer(issuer)
                 .clientId(Generators.nonBlankStrings().next())
                 .clientSecret(Generators.nonBlankStrings().next())
                 .authMethod(ClientAuthMethod.CLIENT_SECRET_BASIC)
-                .allowInsecureHttp(true)
-                .build();
+                .allowInsecureHttp(true);
     }
 
     @Test
-    @DisplayName("Should reject an oversized discovery document as a TransportException")
-    void shouldRejectOversizedDiscoveryDocument(URIBuilder uriBuilder) {
-        var resolver = new DiscoveryResolver(configFor(uriBuilder.buildAsString()));
+    @DisplayName("Should resolve a document larger than the JWT payload ceiling at the default setting (#628)")
+    void shouldResolveDocumentLargerThanPayloadCeiling(URIBuilder uriBuilder) {
+        // Regression: a stock Keycloak realm publishes a document a few hundred bytes past 8 KiB, which
+        // the borrowed JWT payload ceiling rejected outright, taking every confidential-client flow down.
+        var resolver = new DiscoveryResolver(builderFor(uriBuilder.buildAsString()).build());
+
+        var metadata = resolver.resolve();
+
+        assertTrue(metadata.getTokenEndpoint().isPresent(),
+                "a discovery document above the JWT payload ceiling must resolve at the default setting");
+    }
+
+    @Test
+    @DisplayName("Should reject a document beyond the configured ceiling as a TransportException (M7)")
+    void shouldRejectDocumentBeyondConfiguredCeiling(URIBuilder uriBuilder) {
+        var configuration = builderFor(uriBuilder.buildAsString())
+                .discoveryDocumentMaxSize(4 * 1024)
+                .build();
+        var resolver = new DiscoveryResolver(configuration);
 
         assertThrows(TransportException.class, resolver::resolve,
-                "a discovery document exceeding the payload ceiling must be refused, not buffered whole");
+                "a discovery document exceeding the configured ceiling must be refused, not buffered whole");
     }
 
     /**
-     * Serves a syntactically-valid well-known document padded well beyond the 8&nbsp;KiB payload
-     * ceiling, so the bounded body handler must trip during the read.
+     * Serves a syntactically-valid well-known document padded by a configurable number of bytes, so a
+     * test can place it either side of a given ceiling.
      */
-    static final class OversizedWellKnownDispatcher implements ModuleDispatcherElement {
+    record PaddedWellKnownDispatcher(int paddingBytes) implements ModuleDispatcherElement {
 
         @Override
         public String getBaseUrl() {
@@ -192,14 +214,26 @@ class DiscoveryResolverSizeCapTest {
         public Optional<MockResponse> handleGet(RecordedRequest request) {
             String issuer = request.getUrl().toString();
             issuer = issuer.substring(0, issuer.indexOf(WellKnownDispatcher.LOCAL_PATH));
-            String padding = "x".repeat(9 * 1024);
             String body = "{\n"
                     + "  \"issuer\": \"" + issuer + "\",\n"
                     + "  \"token_endpoint\": \"" + issuer + "/token\",\n"
                     + "  \"jwks_uri\": \"" + issuer + "/jwks\",\n"
-                    + "  \"padding\": \"" + padding + "\"\n"
+                    + "  \"token_endpoint_auth_methods_supported\": [" + paddingEntries() + "]\n"
                     + "}";
             return Optional.of(new MockResponse(200, Headers.of("Content-Type", "application/json"), body));
+        }
+
+        /**
+         * Pads through a real, list-valued metadata member (as an over-sized document does in the
+         * field) and with many short entries rather than one long string: the shared
+         * {@code ParserConfig} DSL-JSON instance caps an individual string buffer, so a single
+         * multi-KiB string would trip that unrelated limit instead of the size ceiling under test.
+         */
+        private String paddingEntries() {
+            int entryLength = 64;
+            String entry = "\"" + "x".repeat(entryLength) + "\"";
+            int count = paddingBytes / (entryLength + 3);
+            return String.join(",", Collections.nCopies(count, entry));
         }
     }
 }

--- a/token-sheriff-quarkus-parent/token-sheriff-client-quarkus/src/main/java/de/cuioss/sheriff/token/client/quarkus/config/ClientConfigMapper.java
+++ b/token-sheriff-quarkus-parent/token-sheriff-client-quarkus/src/main/java/de/cuioss/sheriff/token/client/quarkus/config/ClientConfigMapper.java
@@ -63,7 +63,9 @@ public final class ClientConfigMapper {
      * @throws IllegalStateException    when a required key ({@link ClientRuntimeConfig#ISSUER} or
      *                                  {@link ClientRuntimeConfig#CLIENT_ID}) is missing
      * @throws IllegalArgumentException when {@link ClientRuntimeConfig#AUTH_METHOD} names an
-     *                                  unrecognised authentication method
+     *                                  unrecognised authentication method, or when
+     *                                  {@link ClientRuntimeConfig#DISCOVERY_DOCUMENT_MAX_SIZE} is not
+     *                                  positive
      */
     public static ClientConfiguration map(Config config) {
         String issuer = requiredValue(config, ClientRuntimeConfig.ISSUER);
@@ -76,6 +78,8 @@ public final class ClientConfigMapper {
                 .allowInsecureHttp(config.getOptionalValue(ClientRuntimeConfig.ALLOW_INSECURE_HTTP, Boolean.class)
                         .orElse(Boolean.FALSE));
 
+        config.getOptionalValue(ClientRuntimeConfig.DISCOVERY_DOCUMENT_MAX_SIZE, Integer.class)
+                .ifPresent(builder::discoveryDocumentMaxSize);
         config.getOptionalValue(ClientRuntimeConfig.CLIENT_SECRET, String.class).ifPresent(builder::clientSecret);
         config.getOptionalValue(ClientRuntimeConfig.REDIRECT_URI, String.class).ifPresent(builder::redirectUri);
         resolveScopes(config).forEach(builder::scope);

--- a/token-sheriff-quarkus-parent/token-sheriff-client-quarkus/src/main/java/de/cuioss/sheriff/token/client/quarkus/config/ClientRuntimeConfig.java
+++ b/token-sheriff-quarkus-parent/token-sheriff-client-quarkus/src/main/java/de/cuioss/sheriff/token/client/quarkus/config/ClientRuntimeConfig.java
@@ -80,4 +80,13 @@ public final class ClientRuntimeConfig {
      * Property: {@code sheriff.client.allow-insecure-http}. Defaults to {@code false}.
      */
     public static final String ALLOW_INSECURE_HTTP = PREFIX + ".allow-insecure-http";
+
+    /**
+     * The maximum size, in bytes, of the authorization server's discovery document. Property:
+     * {@code sheriff.client.discovery-document-max-size}. Defaults to
+     * {@link de.cuioss.sheriff.token.client.config.ClientConfiguration#DEFAULT_DISCOVERY_DOCUMENT_MAX_SIZE}.
+     * Raise it only for an authorization server whose {@code .well-known/openid-configuration} exceeds
+     * that ceiling.
+     */
+    public static final String DISCOVERY_DOCUMENT_MAX_SIZE = PREFIX + ".discovery-document-max-size";
 }

--- a/token-sheriff-quarkus-parent/token-sheriff-client-quarkus/src/test/java/de/cuioss/sheriff/token/client/quarkus/TokenSheriffClientProducerTest.java
+++ b/token-sheriff-quarkus-parent/token-sheriff-client-quarkus/src/test/java/de/cuioss/sheriff/token/client/quarkus/TokenSheriffClientProducerTest.java
@@ -86,7 +86,8 @@ class TokenSheriffClientProducerTest {
                     ClientRuntimeConfig.AUTH_METHOD, ClientAuthMethod.CLIENT_SECRET_POST.getMetadataValue(),
                     ClientRuntimeConfig.SCOPES, "openid,profile,email",
                     ClientRuntimeConfig.REDIRECT_URI, REDIRECT_URI,
-                    ClientRuntimeConfig.ALLOW_INSECURE_HTTP, "true"));
+                    ClientRuntimeConfig.ALLOW_INSECURE_HTTP, "true",
+                    ClientRuntimeConfig.DISCOVERY_DOCUMENT_MAX_SIZE, "131072"));
 
             ClientConfiguration configuration = new TokenSheriffClientProducer(configOf(properties)).clientConfiguration();
 
@@ -99,7 +100,9 @@ class TokenSheriffClientProducerTest {
                     () -> assertEquals(List.of("openid", "profile", "email"), configuration.getScopes(),
                             "comma-separated scopes map to an ordered list"),
                     () -> assertEquals(REDIRECT_URI, configuration.getRedirectUri(), "redirectUri maps through"),
-                    () -> assertTrue(configuration.isAllowInsecureHttp(), "allowInsecureHttp maps through"));
+                    () -> assertTrue(configuration.isAllowInsecureHttp(), "allowInsecureHttp maps through"),
+                    () -> assertEquals(131072, configuration.getDiscoveryDocumentMaxSize(),
+                            "discoveryDocumentMaxSize maps through, so a large document needs no release"));
         }
 
         @Test
@@ -114,7 +117,10 @@ class TokenSheriffClientProducerTest {
                     () -> assertFalse(configuration.isAllowInsecureHttp(), "allowInsecureHttp defaults to false"),
                     () -> assertTrue(configuration.getScopes().isEmpty(), "scopes default to empty"),
                     () -> assertNull(configuration.getClientSecret(), "clientSecret is absent by default"),
-                    () -> assertNull(configuration.getRedirectUri(), "redirectUri is absent by default"));
+                    () -> assertNull(configuration.getRedirectUri(), "redirectUri is absent by default"),
+                    () -> assertEquals(ClientConfiguration.DEFAULT_DISCOVERY_DOCUMENT_MAX_SIZE,
+                            configuration.getDiscoveryDocumentMaxSize(),
+                            "discoveryDocumentMaxSize defaults to the discovery-document ceiling"));
         }
 
         @Test


### PR DESCRIPTION
Fixes #628

## Problem

`DiscoveryResolver` bounded the `.well-known/openid-configuration` response by
`ParserConfig.getMaxPayloadSize()` — the **JWT payload** ceiling, 8192 bytes — and built that
`ParserConfig` internally, so no caller could raise it. Two defects in one:

1. **Conflation.** A JWT payload and a discovery document are unrelated artifacts with unrelated
   size profiles. A stock Keycloak realm publishes a document past 8 KiB, so discovery failed
   outright and no confidential-client flow could start.
2. **Not injectable.** No seam existed to raise the ceiling, and
   `sheriff.token.parser.max-payload-size` feeds a different object graph — there was no
   deployment-side remedy.

## Change

* `ClientConfiguration` gains `discoveryDocumentMaxSize`, defaulting to
  `DEFAULT_DISCOVERY_DOCUMENT_MAX_SIZE` = 64 KiB and validated positive at construction like the
  timeout knobs.
* `DiscoveryResolver` takes its ceiling from the configuration; it still uses the commons
  `ParserConfig` DSL-JSON instance for parsing. The bound is still enforced *during* the read
  (M7) — an oversized response is refused, not buffered whole.
* Quarkus binding: `sheriff.client.discovery-document-max-size` maps onto the new field.
* Documented in `token-sheriff-client/README.adoc`.

## Tests

* `DiscoveryResolverSizeCapTest` — a document larger than the old 8 KiB bound now resolves at the
  default setting (the regression), and a document beyond an explicitly lowered ceiling is still
  rejected as a `TransportException`.
* `ClientConfigurationTest` — default above the JWT payload ceiling, settable, non-positive
  rejected.
* `TokenSheriffClientProducerTest` — the property maps through and defaults correctly.

`token-sheriff-client` (636 tests) and `token-sheriff-client-quarkus` pass locally.

## Note on scope

`TokenEndpointClient`, `ParClient`, `UserInfoClient` and `RevocationClient` also size their reads by
`ParserConfig.getMaxPayloadSize()`. Those responses carry JWTs, so the payload ceiling is a defensible
bound there and is left unchanged; only discovery, where the artifact is unrelated, is retargeted here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable maximum size for authorization-server discovery documents.
  * Discovery documents now default to a 64 KiB limit, with optional customization through the client API or Quarkus configuration.
  * Invalid zero or negative size values are rejected.

* **Bug Fixes**
  * Discovery-document limits are now applied independently from JWT payload-size limits, allowing valid documents larger than 8 KiB while enforcing the configured ceiling.

* **Documentation**
  * Updated quick-start guidance and configuration documentation with defaults, behavior, and usage details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->