### PR TITLE
chore(steward): reconcile marshal.json after plan-marshall upgrade

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -102,9 +102,11 @@
           "re_review_on_timeout": "ask",
           "review_rate_window_await": false,
           "review_rate_window_timeout_seconds": 3600,
-          "enabled_bots": "coderabbit,sourcery,pr-agent",
           "review_completion_poll_timeout_seconds": 600,
-          "lane": "ask"
+          "lane": "ask",
+          "required_bots": "coderabbit,pr-agent",
+          "optional_bots": "sourcery",
+          "bot_lists_provenance": "answered"
         },
         "default:create-pr": {
           "lane": "minimal"
@@ -117,13 +119,6 @@
           "do_transition": false,
           "ce_wait_timeout_seconds": 600,
           "lane": "ask"
-        },
-        "default:lessons-capture": {
-          "lane": "minimal"
-        },
-        "default:finalize-step-preference-emitter": {
-          "preference_min_recurrence": 2,
-          "lane": "minimal"
         },
         "default:adr-propose": {
           "lane": "off"
@@ -138,6 +133,13 @@
           "use_merge_queue": true,
           "admin_merge_on_stuck_state": false,
           "pre_merge_comment_barrier": "fail_into_loopback",
+          "lane": "minimal"
+        },
+        "default:lessons-capture": {
+          "lane": "minimal"
+        },
+        "default:finalize-step-preference-emitter": {
+          "preference_min_recurrence": 2,
           "lane": "minimal"
         },
         "default:record-metrics": {
@@ -303,9 +305,11 @@
       "lessons_superseded_days": 0,
       "temp_on_maintenance": true,
       "plugin_cache_keep_versions": 5,
-      "plugin_cache_keep_days": 3
+      "plugin_cache_keep_days": 3,
+      "no_plan_body_days": 7,
+      "build_results_days": 5
     },
-    "provisioned_version": "0.1.1212",
-    "config_seed_fingerprint": "4e859c03"
+    "provisioned_version": "0.1.1293",
+    "config_seed_fingerprint": "714f8058"
   }
 }


### PR DESCRIPTION
## Summary

Post-upgrade reconciliation of `.plan/marshal.json` after `/marshall-steward upgrade` brought the project to plan-marshall `0.1.1293`. Configuration only — no production code, tests, or build files touched.

## Changes

### Review-bot participation (`plan-marshall:automatic-review`)

The retired `enabled_bots` knob is replaced by the `required_bots` / `optional_bots` split:

| Knob | Value | Semantics |
|------|-------|-----------|
| `required_bots` | `coderabbit,pr-agent` | Silence is a failure — gates the completeness quorum |
| `optional_bots` | `sourcery` | Ingested and reported, never gating |
| `bot_lists_provenance` | `answered` | Explicit operator answer, not a never-asked default |

The automated `migrate-bot-lists` step **discarded** the legacy `coderabbit,sourcery,pr-agent` list rather than carrying it over: Stage 2 runs `sync-defaults` before `migrate-bot-lists`, so the migration saw the freshly-seeded empty keys and classified them as a deliberate operator answer (`state: operator_answer_kept`). That would have left both lists empty and nothing gating the review quorum. The lists were therefore re-answered explicitly.

### Retention defaults

Back-filled `system.retention.no_plan_body_days` (7) and `system.retention.build_results_days` (5).

### Provisioning stamps

`provisioned_version` `0.1.1212` → `0.1.1293`; `config_seed_fingerprint` re-stamped.

### Step ordering

`phase-6-finalize.steps` re-sorted into declared frontmatter order — `adr-propose` and `branch-cleanup` now precede `lessons-capture` and `finalize-step-preference-emitter`. Values are byte-identical; only key order changed.

## Verification

- `generate_executor preflight` → `marshal_status: fresh`, executor / manifest / config all at `0.1.1293`
- `build-map drift` → `in_sync: true`
- Plugin-cache retention sweep pruned 390 superseded version dirs, kept 60

## Review

Labelled `skip-bot-review` — steward-maintained configuration artifact.
