### PR TITLE
feat: name the originating bound in bounded-read failure messages

### DIFF
--- a/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/jfr/JfrVarianceAnalyzer.java
+++ b/benchmarking/benchmarking-common/src/main/java/de/cuioss/benchmarking/common/jfr/JfrVarianceAnalyzer.java
@@ -123,7 +123,11 @@ public class JfrVarianceAnalyzer {
          * Prints a summary of the variance analysis to stdout.
          */
         // cui-rewrite:disable CuiLogRecordPatternRecipe
-        // This is a CLI analysis tool that outputs formatted reports to console
+        // cui-rewrite:disable CuiLoggerStandardsRecipe
+        // This is a CLI analysis tool that outputs formatted reports to console.
+        // CuiLoggerStandardsRecipe is disabled because it misreads the argument-less
+        // %n conversion as a value placeholder and rewrites it to %s, corrupting these
+        // format strings — see https://github.com/cuioss/cui-open-rewrite/issues/135
         public void printSummary() {
             LOGGER.info("\n=== JFR Variance Analysis Report ===\n");
 

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/discovery/DiscoveryResolver.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/discovery/DiscoveryResolver.java
@@ -179,7 +179,7 @@ public class DiscoveryResolver {
         if (bytes.length > maxContentSize) {
             throw new TransportException(ClientLogMessages.ERROR.DISCOVERY_FAILED.format(
                     issuer, "discovery response exceeds maximum allowed size of " + maxContentSize
-                            + " bytes (" + BOUND_ORIGIN + ")"));
+                    + " bytes (" + BOUND_ORIGIN + ")"));
         }
         try {
             ProviderMetadata metadata = dslJson.deserialize(ProviderMetadata.class, bytes, bytes.length);

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/discovery/DiscoveryResolver.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/discovery/DiscoveryResolver.java
@@ -69,6 +69,13 @@ public class DiscoveryResolver {
     private static final String WELL_KNOWN_SUFFIX = "/.well-known/openid-configuration";
     private static final String SCHEME_HTTPS = "https";
 
+    /**
+     * Human-readable provenance of the discovery-document byte ceiling, reported with every
+     * over-limit rejection so a reader knows which knob produced the bound and that it is settable.
+     */
+    private static final String BOUND_ORIGIN =
+            "ClientConfiguration.discoveryDocumentMaxSize; settable via ClientConfiguration.builder()";
+
     private final ClientConfiguration configuration;
     private final DslJson<Object> dslJson;
     private final int maxContentSize;
@@ -88,7 +95,7 @@ public class DiscoveryResolver {
         // size profiles, and an ordinary Keycloak realm already publishes a document larger than the
         // 8 KiB payload bound, which failed discovery outright with no deployment-side remedy.
         this.maxContentSize = configuration.getDiscoveryDocumentMaxSize();
-        this.backChannel = new BackChannelHttp(configuration, maxContentSize);
+        this.backChannel = new BackChannelHttp(configuration, maxContentSize, BOUND_ORIGIN);
     }
 
     /**
@@ -171,7 +178,8 @@ public class DiscoveryResolver {
         byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
         if (bytes.length > maxContentSize) {
             throw new TransportException(ClientLogMessages.ERROR.DISCOVERY_FAILED.format(
-                    issuer, "discovery response exceeds maximum allowed size"));
+                    issuer, "discovery response exceeds maximum allowed size of " + maxContentSize
+                            + " bytes (" + BOUND_ORIGIN + ")"));
         }
         try {
             ProviderMetadata metadata = dslJson.deserialize(ProviderMetadata.class, bytes, bytes.length);

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/ParClient.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/ParClient.java
@@ -73,7 +73,8 @@ public class ParClient {
         ParserConfig parserConfig = ParserConfig.builder().build();
         this.dslJson = parserConfig.getDslJson();
         this.maxContentSize = parserConfig.getMaxPayloadSize();
-        this.backChannel = new BackChannelHttp(configuration, maxContentSize);
+        this.backChannel = new BackChannelHttp(configuration, maxContentSize,
+                BackChannelHttp.FIXED_PARSER_CONFIG_ORIGIN);
     }
 
     /**
@@ -134,7 +135,8 @@ public class ParClient {
         }
         byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
         if (bytes.length > maxContentSize) {
-            throw new TransportException("PAR endpoint response exceeds maximum allowed size");
+            throw new TransportException("PAR endpoint response exceeds maximum allowed size of "
+                    + maxContentSize + " bytes (" + BackChannelHttp.FIXED_PARSER_CONFIG_ORIGIN + ")");
         }
         try {
             ParResponse parResponse = dslJson.deserialize(ParResponse.class, bytes, bytes.length);

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/TokenEndpointClient.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/flow/TokenEndpointClient.java
@@ -74,7 +74,8 @@ public class TokenEndpointClient {
         ParserConfig parserConfig = ParserConfig.builder().build();
         this.dslJson = parserConfig.getDslJson();
         this.maxContentSize = parserConfig.getMaxPayloadSize();
-        this.backChannel = new BackChannelHttp(configuration, maxContentSize);
+        this.backChannel = new BackChannelHttp(configuration, maxContentSize,
+                BackChannelHttp.FIXED_PARSER_CONFIG_ORIGIN);
     }
 
     /**
@@ -199,7 +200,8 @@ public class TokenEndpointClient {
         }
         byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
         if (bytes.length > maxContentSize) {
-            throw new TransportException("Token endpoint response exceeds maximum allowed size");
+            throw new TransportException("Token endpoint response exceeds maximum allowed size of "
+                    + maxContentSize + " bytes (" + BackChannelHttp.FIXED_PARSER_CONFIG_ORIGIN + ")");
         }
         try {
             TokenResponse tokenResponse = dslJson.deserialize(TokenResponse.class, bytes, bytes.length);

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/internal/BackChannelHttp.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/internal/BackChannelHttp.java
@@ -66,7 +66,9 @@ import java.util.concurrent.ConcurrentMap;
  *   <li><strong>Configurable timeouts (L15):</strong> connect / read timeouts are read from
  *       {@link ClientConfiguration}, not hardcoded per client.</li>
  *   <li><strong>Bounded body reads (M7):</strong> {@link #bodyHandler()} enforces the payload ceiling
- *       during the read via {@link BoundedContentBodyHandler}.</li>
+ *       during the read via {@link BoundedContentBodyHandler}. The ceiling's provenance travels with
+ *       the failure: each construction site supplies a {@code boundOrigin} descriptor naming the knob
+ *       that set the bound and whether it is settable, and the over-limit message reports it.</li>
  * </ul>
  *
  * @since 1.0
@@ -76,19 +78,36 @@ public final class BackChannelHttp {
 
     private static final CuiLogger LOGGER = new CuiLogger(BackChannelHttp.class);
 
+    /**
+     * Bound origin for the back-channel clients (token, PAR, userinfo, revocation) that build their
+     * own {@code ParserConfig} internally: their payload ceiling is deliberately fixed on that path
+     * and is <em>not</em> reachable from {@link ClientConfiguration} nor from the
+     * {@code sheriff.token.parser.max-payload-size} property, which feeds a different object graph.
+     * The message must say so rather than let a reader chase a setting that has no effect here.
+     * <p>
+     * This is a shared descriptor, not a default: {@link #BackChannelHttp(ClientConfiguration, int, String)}
+     * still requires the argument, so a new endpoint client cannot silently omit its origin.
+     */
+    public static final String FIXED_PARSER_CONFIG_ORIGIN =
+            "ParserConfig.maxPayloadSize; fixed on this path, not settable via ClientConfiguration";
+
     private final ClientConfiguration configuration;
     private final HttpSecurityValidator egressValidator;
     private final int maxContentSize;
+    private final String boundOrigin;
     private final ConcurrentMap<String, HttpClient> sharedClients = new ConcurrentHashMap<>();
 
     /**
      * @param configuration  the client configuration carrying the TLS policy and timeout knobs; must
      *                       not be {@code null}
      * @param maxContentSize the maximum response body size, in bytes, enforced during read
+     * @param boundOrigin    the human-readable provenance of {@code maxContentSize} — the knob that set
+     *                       it, and whether it is settable; reported in the over-limit failure message
      */
-    public BackChannelHttp(ClientConfiguration configuration, int maxContentSize) {
+    public BackChannelHttp(ClientConfiguration configuration, int maxContentSize, String boundOrigin) {
         this.configuration = Objects.requireNonNull(configuration, "configuration must not be null");
         this.maxContentSize = maxContentSize;
+        this.boundOrigin = Objects.requireNonNull(boundOrigin, "boundOrigin must not be null");
         this.egressValidator = PipelineFactory.createUrlPathPipeline(
                 SecurityConfiguration.defaults(), new SecurityEventCounter());
     }
@@ -176,6 +195,6 @@ public final class BackChannelHttp {
      * @return a bounded body handler that enforces the configured payload ceiling during the read (M7)
      */
     public HttpResponse.BodyHandler<String> bodyHandler() {
-        return BoundedContentBodyHandler.of(maxContentSize);
+        return BoundedContentBodyHandler.of(maxContentSize, boundOrigin);
     }
 }

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/internal/BoundedContentBodyHandler.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/internal/BoundedContentBodyHandler.java
@@ -15,6 +15,8 @@
  */
 package de.cuioss.sheriff.token.client.internal;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.http.HttpResponse;
@@ -89,7 +91,7 @@ public final class BoundedContentBodyHandler implements HttpResponse.BodyHandler
         private final String boundOrigin;
         private final CompletableFuture<String> result = new CompletableFuture<>();
         private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-        private Flow.Subscription subscription;
+        private Flow.@Nullable Subscription subscription;
         private long total;
 
         BoundedStringSubscriber(int maxBytes, Charset charset, String boundOrigin) {
@@ -115,7 +117,9 @@ public final class BoundedContentBodyHandler implements HttpResponse.BodyHandler
                 int remaining = item.remaining();
                 total += remaining;
                 if (total > maxBytes) {
-                    subscription.cancel();
+                    if (subscription != null) {
+                        subscription.cancel();
+                    }
                     buffer.reset();
                     result.completeExceptionally(new IOException(
                             "response body exceeds the maximum allowed size of " + maxBytes + " bytes ("

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/internal/BoundedContentBodyHandler.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/internal/BoundedContentBodyHandler.java
@@ -40,6 +40,10 @@ import java.util.concurrent.Flow;
  * {@link IOException} the instant the running total would exceed {@code maxBytes} — cancelling the
  * subscription so no further bytes are read. Back-channel clients translate that {@link IOException}
  * into the declared {@code TransportException} on their normal {@code IOException} catch path.
+ * <p>
+ * The rejection message names the ceiling <em>and</em> its origin: callers supply a
+ * {@code boundOrigin} descriptor identifying the knob that set the ceiling and whether it is
+ * settable, so a reader of the failure can tell a tunable bound from a fixed one.
  *
  * @since 1.0
  * @author Oliver Wolff
@@ -48,26 +52,30 @@ public final class BoundedContentBodyHandler implements HttpResponse.BodyHandler
 
     private final int maxBytes;
     private final Charset charset;
+    private final String boundOrigin;
 
-    private BoundedContentBodyHandler(int maxBytes, Charset charset) {
+    private BoundedContentBodyHandler(int maxBytes, Charset charset, String boundOrigin) {
         if (maxBytes < 0) {
             throw new IllegalArgumentException("maxBytes must not be negative");
         }
         this.maxBytes = maxBytes;
         this.charset = Objects.requireNonNull(charset, "charset must not be null");
+        this.boundOrigin = Objects.requireNonNull(boundOrigin, "boundOrigin must not be null");
     }
 
     /**
-     * @param maxBytes the maximum number of body bytes to read before failing; must not be negative
+     * @param maxBytes    the maximum number of body bytes to read before failing; must not be negative
+     * @param boundOrigin the human-readable provenance of the ceiling — the knob that set it, and
+     *                    whether it is settable; reported verbatim in the rejection message
      * @return a UTF-8 bounded body handler capped at {@code maxBytes}
      */
-    public static BoundedContentBodyHandler of(int maxBytes) {
-        return new BoundedContentBodyHandler(maxBytes, StandardCharsets.UTF_8);
+    public static BoundedContentBodyHandler of(int maxBytes, String boundOrigin) {
+        return new BoundedContentBodyHandler(maxBytes, StandardCharsets.UTF_8, boundOrigin);
     }
 
     @Override
     public HttpResponse.BodySubscriber<String> apply(HttpResponse.ResponseInfo responseInfo) {
-        return new BoundedStringSubscriber(maxBytes, charset);
+        return new BoundedStringSubscriber(maxBytes, charset, boundOrigin);
     }
 
     /**
@@ -78,14 +86,16 @@ public final class BoundedContentBodyHandler implements HttpResponse.BodyHandler
 
         private final int maxBytes;
         private final Charset charset;
+        private final String boundOrigin;
         private final CompletableFuture<String> result = new CompletableFuture<>();
         private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         private Flow.Subscription subscription;
         private long total;
 
-        BoundedStringSubscriber(int maxBytes, Charset charset) {
+        BoundedStringSubscriber(int maxBytes, Charset charset, String boundOrigin) {
             this.maxBytes = maxBytes;
             this.charset = charset;
+            this.boundOrigin = boundOrigin;
         }
 
         @Override
@@ -108,7 +118,8 @@ public final class BoundedContentBodyHandler implements HttpResponse.BodyHandler
                     subscription.cancel();
                     buffer.reset();
                     result.completeExceptionally(new IOException(
-                            "response body exceeds the maximum allowed size of " + maxBytes + " bytes"));
+                            "response body exceeds the maximum allowed size of " + maxBytes + " bytes ("
+                                    + boundOrigin + ")"));
                     return;
                 }
                 byte[] chunk = new byte[remaining];

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/lifecycle/RevocationClient.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/lifecycle/RevocationClient.java
@@ -65,7 +65,8 @@ public class RevocationClient {
      */
     public RevocationClient(ClientConfiguration configuration) {
         Objects.requireNonNull(configuration, "configuration must not be null");
-        this.backChannel = new BackChannelHttp(configuration, ParserConfig.builder().build().getMaxPayloadSize());
+        this.backChannel = new BackChannelHttp(configuration, ParserConfig.builder().build().getMaxPayloadSize(),
+                BackChannelHttp.FIXED_PARSER_CONFIG_ORIGIN);
     }
 
     /**

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/token/UserInfoClient.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/token/UserInfoClient.java
@@ -95,7 +95,8 @@ public class UserInfoClient {
         ParserConfig parserConfig = ParserConfig.builder().build();
         this.dslJson = parserConfig.getDslJson();
         this.maxContentSize = parserConfig.getMaxPayloadSize();
-        this.backChannel = new BackChannelHttp(configuration, maxContentSize);
+        this.backChannel = new BackChannelHttp(configuration, maxContentSize,
+                BackChannelHttp.FIXED_PARSER_CONFIG_ORIGIN);
     }
 
     /**
@@ -244,7 +245,8 @@ public class UserInfoClient {
         }
         byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
         if (bytes.length > maxContentSize) {
-            throw new TransportException("userinfo endpoint response exceeds maximum allowed size");
+            throw new TransportException("userinfo endpoint response exceeds maximum allowed size of "
+                    + maxContentSize + " bytes (" + BackChannelHttp.FIXED_PARSER_CONFIG_ORIGIN + ")");
         }
         try {
             UserInfoResponse userInfo = dslJson.deserialize(UserInfoResponse.class, bytes, bytes.length);

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/discovery/DiscoveryResolverTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/discovery/DiscoveryResolverTest.java
@@ -190,8 +190,16 @@ class DiscoveryResolverSizeCapTest {
                 .build();
         var resolver = new DiscoveryResolver(configuration);
 
-        assertThrows(TransportException.class, resolver::resolve,
+        var failure = assertThrows(TransportException.class, resolver::resolve,
                 "a discovery document exceeding the configured ceiling must be refused, not buffered whole");
+
+        // The reader must be able to tell WHICH knob produced the ceiling and that it is tunable,
+        // rather than chasing sheriff.token.parser.max-payload-size, which feeds a different graph.
+        assertAll("bound origin is named and declared settable",
+                () -> assertTrue(failure.getMessage().contains("ClientConfiguration.discoveryDocumentMaxSize"),
+                        "failure must name the originating knob, but was: " + failure.getMessage()),
+                () -> assertTrue(failure.getMessage().contains("settable via ClientConfiguration.builder()"),
+                        "failure must report the knob as settable, but was: " + failure.getMessage()));
     }
 
     /**

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/hardening/RetrievalParsingAttackDatabaseTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/hardening/RetrievalParsingAttackDatabaseTest.java
@@ -35,13 +35,16 @@ import mockwebserver3.MockResponse;
 import mockwebserver3.RecordedRequest;
 import okhttp3.Headers;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import java.util.Optional;
 import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Hardening sweep — drives the full {@code http.security} attack corpora through the userinfo
@@ -81,6 +84,29 @@ class RetrievalParsingAttackDatabaseTest {
     @DisplayName("Should reject a ModSecurity CRS attack payload served as a userinfo response body")
     void rejectsModSecurityAttackBodies(AttackTestCase testCase, URIBuilder uriBuilder) {
         assertRetrievalFailsClosed(testCase.attackString(), uriBuilder);
+    }
+
+    @Test
+    @DisplayName("Should declare the back-channel bound fixed when rejecting an over-limit userinfo body")
+    void shouldDeclareBackChannelBoundFixed(URIBuilder uriBuilder) {
+        // The back-channel clients build their own ParserConfig, so their payload ceiling is NOT
+        // reachable from ClientConfiguration nor from sheriff.token.parser.max-payload-size. The
+        // failure must say so rather than send a reader chasing a property that has no effect here.
+        moduleDispatcher.serve("{\"sub\": \"" + "x".repeat(9 * 1024) + "\"}");
+        var client = new UserInfoClient(config());
+        String userInfoEndpoint = uriBuilder.addPathSegment("userinfo").buildAsString();
+        String accessToken = Generators.letterStrings(20, 40).next();
+
+        var failure = assertThrows(TransportException.class,
+                () -> client.fetchUserInfo(userInfoEndpoint, accessToken),
+                "an over-limit userinfo response body must fail closed");
+
+        assertAll("bound origin is named and declared fixed",
+                () -> assertTrue(failure.getMessage().contains("ParserConfig.maxPayloadSize"),
+                        "failure must name the originating knob, but was: " + failure.getMessage()),
+                () -> assertTrue(
+                        failure.getMessage().contains("fixed on this path, not settable via ClientConfiguration"),
+                        "failure must declare the bound fixed on this path, but was: " + failure.getMessage()));
     }
 
     private void assertRetrievalFailsClosed(String attackBody, URIBuilder uriBuilder) {

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/internal/BackChannelHttpTlsTrustTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/internal/BackChannelHttpTlsTrustTest.java
@@ -133,7 +133,7 @@ class BackChannelHttpTlsTrustTest {
                 () -> assertSame(configured, tlsHandler.getSslContext(),
                         "the TLS handler must still carry the configured trust material"),
                 () -> assertSame(tlsClient, backChannel.sharedClient(
-                        backChannel.validatedHandler(TOKEN_ENDPOINT, FAILURE_CONTEXT)),
+                                backChannel.validatedHandler(TOKEN_ENDPOINT, FAILURE_CONTEXT)),
                         "two TLS endpoints on one configuration must still share a pooled client"));
     }
 

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/internal/BackChannelHttpTlsTrustTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/internal/BackChannelHttpTlsTrustTest.java
@@ -115,7 +115,7 @@ class BackChannelHttpTlsTrustTest {
         var backChannel = new BackChannelHttp(configurationBuilder()
                 .sslContext(configured)
                 .allowInsecureHttp(true)
-                .build(), MAX_CONTENT_SIZE);
+                .build(), MAX_CONTENT_SIZE, BackChannelHttp.FIXED_PARSER_CONFIG_ORIGIN);
 
         // The cleartext endpoint is reached FIRST, so it is the one that would seed a single shared
         // client. cui-http's HTTP path installs no SSLContext and no TLS-version pinning, so a client
@@ -138,11 +138,13 @@ class BackChannelHttpTlsTrustTest {
     }
 
     private static BackChannelHttp backChannelWith(SSLContext sslContext) {
-        return new BackChannelHttp(configurationBuilder().sslContext(sslContext).build(), MAX_CONTENT_SIZE);
+        return new BackChannelHttp(configurationBuilder().sslContext(sslContext).build(), MAX_CONTENT_SIZE,
+                BackChannelHttp.FIXED_PARSER_CONFIG_ORIGIN);
     }
 
     private static BackChannelHttp backChannelWithoutTrust() {
-        return new BackChannelHttp(configurationBuilder().build(), MAX_CONTENT_SIZE);
+        return new BackChannelHttp(configurationBuilder().build(), MAX_CONTENT_SIZE,
+                BackChannelHttp.FIXED_PARSER_CONFIG_ORIGIN);
     }
 
     private static ClientConfiguration.ClientConfigurationBuilder configurationBuilder() {

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/commons/transport/BoundedBodyHandlers.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/commons/transport/BoundedBodyHandlers.java
@@ -32,7 +32,7 @@ import java.util.concurrent.Flow;
  * <p>
  * The IdP-advertised discovery and JWKS endpoints are attacker-influenceable: a hostile or
  * slow-drip multi-gigabyte body would exhaust the heap if the whole body were buffered before any
- * size check. {@link #ofBoundedString(Charset, long)} closes that vector with two layers, both
+ * size check. {@link #ofBoundedString(Charset, long, String)} closes that vector with two layers, both
  * fail-closed:
  * <ol>
  *   <li><strong>Content-Length pre-check</strong> — a response that advertises a
@@ -43,6 +43,10 @@ import java.util.concurrent.Flow;
  *       its {@code Content-Length}, or advertised none, is caught here).</li>
  * </ol>
  * An over-limit body therefore fails closed with an {@link IOException}, never an {@code OutOfMemoryError}.
+ * <p>
+ * The rejection message names the ceiling <em>and</em> its origin: callers supply a
+ * {@code boundOrigin} descriptor identifying the knob that set the ceiling and whether it is
+ * settable, so a reader of the failure can tell a tunable bound from a fixed one.
  *
  * @since 1.0
  */
@@ -55,17 +59,19 @@ final class BoundedBodyHandlers {
      * Returns a body handler that decodes the response body to a {@link String} using {@code charset},
      * rejecting any body that exceeds {@code maxBytes} during streaming.
      *
-     * @param charset  the charset used to decode the accumulated bytes
-     * @param maxBytes the inclusive byte ceiling; a body strictly larger than this is rejected
+     * @param charset     the charset used to decode the accumulated bytes
+     * @param maxBytes    the inclusive byte ceiling; a body strictly larger than this is rejected
+     * @param boundOrigin the human-readable provenance of the ceiling — the knob that set it, and
+     *                    whether it is settable; reported verbatim in the rejection message
      * @return a bounded {@code BodyHandler<String>}
      */
-    static HttpResponse.BodyHandler<String> ofBoundedString(Charset charset, long maxBytes) {
+    static HttpResponse.BodyHandler<String> ofBoundedString(Charset charset, long maxBytes, String boundOrigin) {
         return responseInfo -> {
             OptionalLong advertised = responseInfo.headers().firstValueAsLong("Content-Length");
             if (advertised.isPresent() && advertised.getAsLong() > maxBytes) {
-                return rejectingSubscriber(maxBytes);
+                return rejectingSubscriber(maxBytes, boundOrigin);
             }
-            return new BoundedStringSubscriber(charset, maxBytes);
+            return new BoundedStringSubscriber(charset, maxBytes, boundOrigin);
         };
     }
 
@@ -75,8 +81,8 @@ final class BoundedBodyHandlers {
      * Used for the {@code Content-Length} pre-check rejection path, honouring the class contract
      * that an over-advertised body is "rejected without reading its body".
      */
-    private static HttpResponse.BodySubscriber<String> rejectingSubscriber(long maxBytes) {
-        return new CancellingRejectSubscriber(maxBytes);
+    private static HttpResponse.BodySubscriber<String> rejectingSubscriber(long maxBytes, String boundOrigin) {
+        return new CancellingRejectSubscriber(maxBytes, boundOrigin);
     }
 
     /**
@@ -92,8 +98,8 @@ final class BoundedBodyHandlers {
 
         private final CompletableFuture<String> result = new CompletableFuture<>();
 
-        CancellingRejectSubscriber(long maxBytes) {
-            result.completeExceptionally(new IOException(overLimitMessage(maxBytes)));
+        CancellingRejectSubscriber(long maxBytes, String boundOrigin) {
+            result.completeExceptionally(new IOException(overLimitMessage(maxBytes, boundOrigin)));
         }
 
         @Override
@@ -122,8 +128,8 @@ final class BoundedBodyHandlers {
         }
     }
 
-    private static String overLimitMessage(long maxBytes) {
-        return "Response body exceeds maximum allowed size of " + maxBytes + " bytes";
+    private static String overLimitMessage(long maxBytes, String boundOrigin) {
+        return "Response body exceeds maximum allowed size of " + maxBytes + " bytes (" + boundOrigin + ")";
     }
 
     /**
@@ -135,14 +141,16 @@ final class BoundedBodyHandlers {
 
         private final Charset charset;
         private final long maxBytes;
+        private final String boundOrigin;
         private final CompletableFuture<String> result = new CompletableFuture<>();
         private final List<byte[]> chunks = new ArrayList<>();
         private long total;
         private Flow.Subscription subscription;
 
-        BoundedStringSubscriber(Charset charset, long maxBytes) {
+        BoundedStringSubscriber(Charset charset, long maxBytes, String boundOrigin) {
             this.charset = charset;
             this.maxBytes = maxBytes;
+            this.boundOrigin = boundOrigin;
         }
 
         @Override
@@ -166,7 +174,7 @@ final class BoundedBodyHandlers {
                 total += remaining;
                 if (total > maxBytes) {
                     subscription.cancel();
-                    result.completeExceptionally(new IOException(overLimitMessage(maxBytes)));
+                    result.completeExceptionally(new IOException(overLimitMessage(maxBytes, boundOrigin)));
                     return;
                 }
                 byte[] chunk = new byte[remaining];

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/commons/transport/JwksHttpContentConverter.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/commons/transport/JwksHttpContentConverter.java
@@ -39,7 +39,10 @@ import java.util.Optional;
  * <p>
  * A byte ceiling ({@link ParserConfig#getMaxPayloadSize()}) is enforced on the JWKS body while it
  * streams (see {@link BoundedBodyHandlers}), so an oversized key set is rejected before it is fully
- * buffered rather than being read unbounded into memory (H2).
+ * buffered rather than being read unbounded into memory (H2). Both the streaming rejection and the
+ * post-materialization rejection report the enforced bound together with its origin — the
+ * {@code ParserConfig.maxPayloadSize} knob and how to set it — so a reader of the failure knows
+ * which setting produced the ceiling.
  *
  * @since 1.0
  * @author Oliver Wolff
@@ -47,6 +50,13 @@ import java.util.Optional;
 public class JwksHttpContentConverter extends StringContentConverter<Jwks> {
 
     private static final CuiLogger LOGGER = new CuiLogger(JwksHttpContentConverter.class);
+
+    /**
+     * Human-readable provenance of the JWKS byte ceiling, reported with every over-limit rejection
+     * so a reader knows which knob produced the bound and that it is settable.
+     */
+    private static final String BOUND_ORIGIN =
+            "ParserConfig.maxPayloadSize; settable via ParserConfig.builder().maxPayloadSize(...)";
 
     private final DslJson<Object> dslJson;
     private final int maxContentSize;
@@ -66,7 +76,7 @@ public class JwksHttpContentConverter extends StringContentConverter<Jwks> {
     public HttpResponse.BodyHandler<?> getBodyHandler() {
         // Bound the JWKS body during streaming so an oversized response fails closed before it is
         // fully materialized. The size check in convertString(...) remains as defense in depth.
-        return BoundedBodyHandlers.ofBoundedString(StandardCharsets.UTF_8, maxContentSize);
+        return BoundedBodyHandlers.ofBoundedString(StandardCharsets.UTF_8, maxContentSize, BOUND_ORIGIN);
     }
 
     @Override
@@ -78,7 +88,8 @@ public class JwksHttpContentConverter extends StringContentConverter<Jwks> {
 
         byte[] bodyBytes = rawContent.getBytes(StandardCharsets.UTF_8);
         if (bodyBytes.length > maxContentSize) {
-            LOGGER.warn(TransportLogMessages.WARN.JWKS_JSON_PARSE_FAILED, "JWKS response size exceeds maximum allowed size");
+            LOGGER.warn(TransportLogMessages.WARN.JWKS_JSON_PARSE_FAILED,
+                    "JWKS response size exceeds maximum allowed size of " + maxContentSize + " bytes (" + BOUND_ORIGIN + ")");
             return Optional.empty();
         }
 

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/commons/transport/JwksHttpContentConverter.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/commons/transport/JwksHttpContentConverter.java
@@ -88,8 +88,9 @@ public class JwksHttpContentConverter extends StringContentConverter<Jwks> {
 
         byte[] bodyBytes = rawContent.getBytes(StandardCharsets.UTF_8);
         if (bodyBytes.length > maxContentSize) {
-            LOGGER.warn(TransportLogMessages.WARN.JWKS_JSON_PARSE_FAILED,
-                    "JWKS response size exceeds maximum allowed size of " + maxContentSize + " bytes (" + BOUND_ORIGIN + ")");
+            String overLimitMessage = "JWKS response size exceeds maximum allowed size of "
+                    + maxContentSize + " bytes (" + BOUND_ORIGIN + ")";
+            LOGGER.warn(TransportLogMessages.WARN.JWKS_JSON_PARSE_FAILED, overLimitMessage);
             return Optional.empty();
         }
 

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/commons/transport/WellKnownConfigurationConverter.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/commons/transport/WellKnownConfigurationConverter.java
@@ -44,6 +44,13 @@ class WellKnownConfigurationConverter implements HttpResponseConverter<WellKnown
 
     private static final CuiLogger LOGGER = new CuiLogger(WellKnownConfigurationConverter.class);
 
+    /**
+     * Human-readable provenance of the well-known byte ceiling, reported with every over-limit
+     * rejection so a reader knows which knob produced the bound and that it is settable.
+     */
+    private static final String BOUND_ORIGIN =
+            "WellKnownConfig.parserConfig.maxPayloadSize; settable via WellKnownConfig.builder().parserConfig(...)";
+
     private final DslJson<Object> dslJson;
     private final SecurityEventCounter securityEventCounter;
     private final int maxContentSize;
@@ -79,10 +86,12 @@ class WellKnownConfigurationConverter implements HttpResponseConverter<WellKnown
         // Check content size limit
         byte[] contentBytes = stringContent.getBytes(StandardCharsets.UTF_8);
         if (contentBytes.length > maxContentSize) {
-            LOGGER.warn(TransportLogMessages.WARN.JWKS_JSON_PARSE_FAILED, "Well-known response size exceeds maximum allowed size");
+            String overLimitMessage = "Well-known response size exceeds maximum allowed size of "
+                    + maxContentSize + " bytes (" + BOUND_ORIGIN + ")";
+            LOGGER.warn(TransportLogMessages.WARN.JWKS_JSON_PARSE_FAILED, overLimitMessage);
             securityEventCounter.increment(EventType.JWKS_JSON_PARSE_FAILED);
             throw new TransportException(
-                    TransportLogMessages.WARN.JWKS_JSON_PARSE_FAILED.format("Well-known response size exceeds maximum allowed size")
+                    TransportLogMessages.WARN.JWKS_JSON_PARSE_FAILED.format(overLimitMessage)
             );
         }
 
@@ -133,7 +142,7 @@ class WellKnownConfigurationConverter implements HttpResponseConverter<WellKnown
         // Enforce the byte ceiling while the body streams — an over-limit discovery document is
         // rejected before it is fully buffered, closing the unbounded-buffering DoS vector (H2).
         // The post-materialization check in convert(...) remains as defense in depth.
-        return BoundedBodyHandlers.ofBoundedString(StandardCharsets.UTF_8, maxContentSize);
+        return BoundedBodyHandlers.ofBoundedString(StandardCharsets.UTF_8, maxContentSize, BOUND_ORIGIN);
     }
 
     @Override

--- a/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/commons/transport/JwksHttpContentConverterTest.java
+++ b/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/commons/transport/JwksHttpContentConverterTest.java
@@ -155,6 +155,9 @@ class JwksHttpContentConverterTest {
 
     private static final int BOUNDED_MAX = 64;
 
+    /** The knob a JWKS bounded-read failure must name as the origin of its ceiling. */
+    private static final String BOUND_ORIGIN_KNOB = "ParserConfig.maxPayloadSize";
+
     private JwksHttpContentConverter boundedConverter() {
         return new JwksHttpContentConverter(ParserConfig.builder().maxPayloadSize(BOUNDED_MAX).build());
     }
@@ -170,6 +173,8 @@ class JwksHttpContentConverterTest {
         assertNotNull(result.failure());
         assertTrue(result.failure().getMessage().contains("exceeds maximum allowed size"),
                 "Failure must name the size-ceiling breach, but was: " + result.failure().getMessage());
+        assertTrue(result.failure().getMessage().contains(BOUND_ORIGIN_KNOB),
+                "Failure must name the knob that set the ceiling, but was: " + result.failure().getMessage());
         assertTrue(result.cancelled(),
                 "Subscription must be cancelled mid-stream — the over-limit body is not fully buffered");
     }
@@ -185,6 +190,8 @@ class JwksHttpContentConverterTest {
         assertNotNull(result.failure());
         assertTrue(result.failure().getMessage().contains("exceeds maximum allowed size"),
                 "Failure must name the size-ceiling breach, but was: " + result.failure().getMessage());
+        assertTrue(result.failure().getMessage().contains(BOUND_ORIGIN_KNOB),
+                "Failure must name the knob that set the ceiling, but was: " + result.failure().getMessage());
         assertTrue(result.cancelled(),
                 "Content-Length pre-check must cancel the subscription — the over-limit body is never read, not drained");
     }
@@ -211,5 +218,6 @@ class JwksHttpContentConverterTest {
         assertTrue(result.isEmpty(), "convertString() must reject an over-limit body as defense in depth");
         LogAsserts.assertLogMessagePresentContaining(TestLogLevel.WARN,
                 WARN.JWKS_JSON_PARSE_FAILED.resolveIdentifierString());
+        LogAsserts.assertLogMessagePresentContaining(TestLogLevel.WARN, BOUND_ORIGIN_KNOB);
     }
 }

--- a/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/commons/transport/JwksHttpContentConverterTest.java
+++ b/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/commons/transport/JwksHttpContentConverterTest.java
@@ -175,6 +175,8 @@ class JwksHttpContentConverterTest {
                 "Failure must name the size-ceiling breach, but was: " + result.failure().getMessage());
         assertTrue(result.failure().getMessage().contains(BOUND_ORIGIN_KNOB),
                 "Failure must name the knob that set the ceiling, but was: " + result.failure().getMessage());
+        assertTrue(result.failure().getMessage().contains(String.valueOf(BOUNDED_MAX)),
+                "Failure must report the enforced ceiling, but was: " + result.failure().getMessage());
         assertTrue(result.cancelled(),
                 "Subscription must be cancelled mid-stream — the over-limit body is not fully buffered");
     }
@@ -192,6 +194,8 @@ class JwksHttpContentConverterTest {
                 "Failure must name the size-ceiling breach, but was: " + result.failure().getMessage());
         assertTrue(result.failure().getMessage().contains(BOUND_ORIGIN_KNOB),
                 "Failure must name the knob that set the ceiling, but was: " + result.failure().getMessage());
+        assertTrue(result.failure().getMessage().contains(String.valueOf(BOUNDED_MAX)),
+                "Failure must report the enforced ceiling, but was: " + result.failure().getMessage());
         assertTrue(result.cancelled(),
                 "Content-Length pre-check must cancel the subscription — the over-limit body is never read, not drained");
     }
@@ -219,5 +223,6 @@ class JwksHttpContentConverterTest {
         LogAsserts.assertLogMessagePresentContaining(TestLogLevel.WARN,
                 WARN.JWKS_JSON_PARSE_FAILED.resolveIdentifierString());
         LogAsserts.assertLogMessagePresentContaining(TestLogLevel.WARN, BOUND_ORIGIN_KNOB);
+        LogAsserts.assertLogMessagePresentContaining(TestLogLevel.WARN, String.valueOf(BOUNDED_MAX));
     }
 }

--- a/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/commons/transport/WellKnownResultConverterTest.java
+++ b/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/commons/transport/WellKnownResultConverterTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -54,6 +55,9 @@ class WellKnownResultConverterTest {
                 "jwks_uri": "https://example.com/.well-known/jwks.json"
             }
             """;
+
+    /** The knob a well-known bounded-read failure must name as the origin of its ceiling. */
+    private static final String BOUND_ORIGIN_KNOB = "WellKnownConfig.parserConfig.maxPayloadSize";
 
     private WellKnownConfigurationConverter converter;
 
@@ -182,14 +186,39 @@ class WellKnownResultConverterTest {
                 }
                 """;
 
-        assertThrows(TransportException.class, () ->
+        TransportException thrown = assertThrows(TransportException.class, () ->
                 restrictiveConverter.convert(largeJson));
 
+        assertTrue(thrown.getMessage().contains(BOUND_ORIGIN_KNOB),
+                "Rejection must name the knob that set the ceiling, but was: " + thrown.getMessage());
+        assertTrue(thrown.getMessage().contains(String.valueOf(maxContentSize)),
+                "Rejection must report the enforced ceiling, but was: " + thrown.getMessage());
         assertTrue(securityEventCounter.getCount(SecurityEventCounter.EventType.JWKS_JSON_PARSE_FAILED) > 0);
 
-        // Verify the log message was written
+        // Verify the log message was written, and that it carries the same origin as the exception
         LogAsserts.assertLogMessagePresentContaining(TestLogLevel.WARN,
                 TransportLogMessages.WARN.JWKS_JSON_PARSE_FAILED.resolveIdentifierString());
+        LogAsserts.assertLogMessagePresentContaining(TestLogLevel.WARN, BOUND_ORIGIN_KNOB);
+    }
+
+    @Test
+    @DisplayName("Should name the bound origin when rejecting an over-limit body during streaming")
+    void shouldNameBoundOriginWhenRejectingOverLimitBodyDuringStreaming() {
+        ParserConfig config = ParserConfig.builder().build();
+        int maxContentSize = 64;
+        WellKnownConfigurationConverter restrictiveConverter =
+                new WellKnownConfigurationConverter(config.getDslJson(), new SecurityEventCounter(), maxContentSize);
+        byte[] overLimit = "x".repeat(maxContentSize + 40).getBytes(StandardCharsets.UTF_8);
+
+        var result = BoundedBodyHandlerTestSupport.drive(restrictiveConverter.getBodyHandler(), overLimit, null);
+
+        assertFalse(result.succeeded(), "Over-limit well-known body must fail closed during streaming");
+        assertNotNull(result.failure());
+        assertTrue(result.failure().getMessage().contains(BOUND_ORIGIN_KNOB),
+                "Streaming rejection must name the same knob as the post-materialization rejection, but was: "
+                        + result.failure().getMessage());
+        assertTrue(result.failure().getMessage().contains(String.valueOf(maxContentSize)),
+                "Streaming rejection must report the enforced ceiling, but was: " + result.failure().getMessage());
     }
 
     @Test

--- a/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/TokenValidatorMetricsTest.java
+++ b/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/TokenValidatorMetricsTest.java
@@ -45,6 +45,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * This test focuses on reproducing missing metric entries and timing discrepancies
  * observed in the benchmark results.
  */
+// cui-rewrite:disable CuiLoggerStandardsRecipe
+// The timing-report log calls below use the argument-less %n conversion, which
+// CuiLoggerStandardsRecipe misreads as a value placeholder and rewrites to %s,
+// corrupting the format strings — see https://github.com/cuioss/cui-open-rewrite/issues/135
 @EnableGeneratorController
 @EnableTestLogger
 class TokenValidatorMetricsTest {

--- a/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/TokenValidatorMetricsTest.java
+++ b/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/TokenValidatorMetricsTest.java
@@ -45,10 +45,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * This test focuses on reproducing missing metric entries and timing discrepancies
  * observed in the benchmark results.
  */
-// cui-rewrite:disable CuiLoggerStandardsRecipe
-// The timing-report log calls below use the argument-less %n conversion, which
-// CuiLoggerStandardsRecipe misreads as a value placeholder and rewrites to %s,
-// corrupting the format strings — see https://github.com/cuioss/cui-open-rewrite/issues/135
 @EnableGeneratorController
 @EnableTestLogger
 class TokenValidatorMetricsTest {
@@ -114,6 +110,10 @@ class TokenValidatorMetricsTest {
                 .map(StripedRingBufferStatistics::p50).orElse(Duration.ZERO).toNanos() + " ns");
     }
 
+    // cui-rewrite:disable CuiLoggerStandardsRecipe
+    // The timing-report log call below uses the argument-less %n conversion, which
+    // CuiLoggerStandardsRecipe misreads as a value placeholder and rewrites to %s,
+    // corrupting the format string — see https://github.com/cuioss/cui-open-rewrite/issues/135
     @Test
     @DisplayName("Should show timing discrepancy between complete validation and sum of individual steps")
     void shouldShowTimingDiscrepancy() {
@@ -162,6 +162,10 @@ class TokenValidatorMetricsTest {
                         "Complete: " + completeValidationTime + " ns, Sum: " + sumOfSteps + " ns");
     }
 
+    // cui-rewrite:disable CuiLoggerStandardsRecipe
+    // The timing-report log calls below use the argument-less %n conversion, which
+    // CuiLoggerStandardsRecipe misreads as a value placeholder and rewrites to %s,
+    // corrupting the format strings — see https://github.com/cuioss/cui-open-rewrite/issues/135
     @Test
     @DisplayName("Should detect fast operations that might show as empty metrics")
     void shouldDetectFastOperations() {
@@ -192,6 +196,10 @@ class TokenValidatorMetricsTest {
         assertTrue(issuerExtraction.toNanos() >= 0, "ISSUER_EXTRACTION should have a duration");
     }
 
+    // cui-rewrite:disable CuiLoggerStandardsRecipe
+    // The timing-report log call below uses the argument-less %n conversion, which
+    // CuiLoggerStandardsRecipe misreads as a value placeholder and rewrites to %s,
+    // corrupting the format string — see https://github.com/cuioss/cui-open-rewrite/issues/135
     @Test
     @DisplayName("Should measure JWKS operations separately from signature validation")
     void shouldMeasureJwksOperationsSeparately() {


### PR DESCRIPTION
## Summary

Every bounded-read rejection in Token-Sheriff reports a byte ceiling without saying where that
ceiling comes from, so a reader cannot tell a tunable bound from a fixed one and burns time
chasing a setting that may not exist on that path. This PR makes each bounded-read failure
message carry the provenance of the bound it enforced — the owning knob's name, supplied by the
caller that knows which ceiling it configured.

## Intent

**Problem.** Bounded-read rejections across the client and validation modules report only a byte
ceiling ("...exceeds the maximum allowed size of N bytes"), never where that ceiling comes from.
A reader cannot distinguish a tunable bound from a fixed one, so the natural next step — find the
matching config property and raise it — sometimes edits an object graph the failing check never
reads (e.g. `sheriff.token.parser.max-payload-size` reconfigures `ParserConfigResolver`, not the
`ParserConfig` the back-channel clients build for themselves), and the change appears to work
because the property is accepted even though it has no effect on the path that failed.

**Approach.** Each of the six bounded-read failure sites now receives the name of the bound it
enforced from its caller, so the exception message states both the ceiling and its origin —
either the config knob that produced it, or an explicit statement that the bound is fixed and not
reachable from configuration on that path. The provenance is threaded through as a caller-supplied
label rather than inferred, since only the caller knows which `ParserConfig` / `ClientConfiguration`
field it configured.

**Non-goals.** This change does not alter any size ceiling's value, does not make a fixed bound
configurable, and does not touch the discovery-document size limit mechanics addressed separately
by issue #628 (that plan's

_[Intent truncated — 1394 of 1491 characters shown; full outline in the plan workspace]_

## Changes

- `token-sheriff-client/.../discovery/DiscoveryResolver.java` — bounded-read failure message
  now names its origin (`ClientConfiguration.discoveryDocumentMaxSize`)
- `token-sheriff-client/.../flow/ParClient.java`, `TokenEndpointClient.java` — back-channel
  request/response bounded-read messages name their origin
- `token-sheriff-client/.../internal/BackChannelHttp.java`, `BoundedContentBodyHandler.java` —
  bound-provenance plumbing shared by the back-channel clients
- `token-sheriff-client/.../lifecycle/RevocationClient.java`, `.../token/UserInfoClient.java` —
  bounded-read failure messages name their origin
- `token-sheriff-validation/.../transport/BoundedBodyHandlers.java`,
  `JwksHttpContentConverter.java`, `WellKnownConfigurationConverter.java` — bounded-read failure
  messages name their origin (`ParserConfig.maxPayloadSize` / `WellKnownConfig`) and state when a
  bound is not reachable from configuration
- Corresponding test updates:
  `token-sheriff-client/.../discovery/DiscoveryResolverTest.java`,
  `token-sheriff-client/.../hardening/RetrievalParsingAttackDatabaseTest.java`,
  `token-sheriff-client/.../internal/BackChannelHttpTlsTrustTest.java`,
  `token-sheriff-validation/.../transport/JwksHttpContentConverterTest.java`,
  `token-sheriff-validation/.../transport/WellKnownResultConverterTest.java`

### Out-of-scope files carried on this branch

Two files unrelated to issue #630 also changed, both receiving a
`// cui-rewrite:disable CuiLoggerStandardsRecipe` suppression:

- `benchmarking/benchmarking-common/.../jfr/JfrVarianceAnalyzer.java`
- `token-sheriff-validation/.../validation/TokenValidatorMetricsTest.java`

Reason: the pre-commit `CuiLoggerStandardsRecipe` (`cui-open-rewrite` 1.4.0) misreads the
argument-less `%n` conversion in these files as a value placeholder, rewrites it to `%s`, and then
flags its own rewritten output as a placeholder/param mismatch. The rewrite is non-idempotent, so
it re-dirtied the tree on every pre-commit gate run until suppressed. Upstream issue:
[cuioss/cui-open-rewrite#135](https://github.com/cuioss/cui-open-rewrite/issues/135). The
suppression comments should be removed once that issue is fixed upstream.

## Test Plan

- [ ] Verification command passed (`mvn verify`)
- [ ] Manual testing completed (if applicable)

## Related Issues

Closes #630

---
Generated by plan-finalize skill


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved oversized-response handling across discovery, token, PAR, revocation, user-info, JWKS, and configuration endpoints.
  * Error messages now identify the enforced byte limit and whether it is configurable, improving troubleshooting.
  * Preserved fail-closed behavior when response-size limits are exceeded.

* **Tests**
  * Expanded coverage for streaming and content-length violations, including error details and warning messages.

* **Documentation**
  * Documented a formatting-tool exception to preserve correct timing-report output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->