### PR TITLE
feat(dpop): support EC/OKP keys and PS256/ES256/EdDSA signing

### DIFF
--- a/token-sheriff-client/README.adoc
+++ b/token-sheriff-client/README.adoc
@@ -37,7 +37,12 @@ Organized by package under `de.cuioss.sheriff.token.client`:
 * *Client authentication* (`auth`) — `client_secret_basic` / `client_secret_post`,
   `private_key_jwt` (RFC 7523), and mTLS (RFC 8705) via `ClientAuthenticationSelector`.
 * *Sender-constraining* (`dpop`) — DPoP proof generation (`DpopProofGenerator`, RFC 9449)
-  with replay-safe `jti` handling and constraint binding.
+  with replay-safe `jti` handling and constraint binding. Proof keys may be RSA, EC (curve
+  `P-256`) or OKP (curve `Ed25519`), signed with `RS256` / `RS384` / `RS512`, `PS256`, `ES256`
+  or `EdDSA`. FAPI 2.0 §5.4.1 conformance is reached through the DPoP route by passing `PS256`,
+  `ES256` or `EdDSA` to the existing algorithm parameter — there is no separate
+  algorithm-allowlist configuration knob. The algorithm and the proof key are checked against
+  each other at construction time, so a mismatch fails fast.
 * *Token handling* (`token`) — every retrieved token is validated through
   `token-sheriff-validation` (`TokenValidationBridge`, `IdTokenValidationBridge`), userinfo
   retrieval with `sub` binding (`UserInfoClient`, `SubBindingValidator`), and refresh-token

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/dpop/DpopProofGenerator.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/dpop/DpopProofGenerator.java
@@ -17,6 +17,8 @@ package de.cuioss.sheriff.token.client.dpop;
 
 import de.cuioss.sheriff.token.client.internal.ClientLogMessages;
 import de.cuioss.sheriff.token.client.internal.JsonEscaper;
+import de.cuioss.sheriff.token.validation.util.EcdsaSignatureFormatConverter;
+import de.cuioss.sheriff.token.validation.util.JwkThumbprintUtil;
 import de.cuioss.tools.logging.CuiLogger;
 import org.jspecify.annotations.Nullable;
 
@@ -25,8 +27,14 @@ import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.security.MessageDigest;
+import java.security.PublicKey;
 import java.security.Signature;
+import java.security.interfaces.ECPublicKey;
+import java.security.interfaces.EdECPublicKey;
 import java.security.interfaces.RSAPublicKey;
+import java.security.spec.EdECPoint;
+import java.security.spec.MGF1ParameterSpec;
+import java.security.spec.PSSParameterSpec;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Base64;
@@ -47,9 +55,20 @@ import java.util.function.Supplier;
  * ({@link #jkt()}), so a stolen bearer token cannot be replayed without the private key
  * ({@code CLIENT-11}, {@code T-TOKEN-REPLAY}).
  * <p>
- * The generator signs with a JDK {@link Signature} (RSA {@code RS256}/{@code RS384}/{@code RS512}) —
- * the engine adds no cryptographic library of its own — and mirrors the {@code DpopProofHelper}
- * conventions already used by the integration harness.
+ * The generator signs with a JDK {@link Signature} — the engine adds no cryptographic library of its
+ * own — and mirrors the {@code DpopProofHelper} conventions already used by the integration harness.
+ * The supported proof-key and algorithm matrix is:
+ * <table border="1">
+ *   <caption>Supported proof keys and signing algorithms</caption>
+ *   <tr><th>Proof key</th><th>Signing algorithms</th></tr>
+ *   <tr><td>RSA</td><td>{@code RS256}, {@code RS384}, {@code RS512}, {@code PS256}</td></tr>
+ *   <tr><td>EC, curve P-256</td><td>{@code ES256}</td></tr>
+ *   <tr><td>OKP, curve Ed25519</td><td>{@code EdDSA}</td></tr>
+ * </table>
+ * <p>
+ * Passing {@code PS256}, {@code ES256} or {@code EdDSA} reaches FAPI 2.0 §5.4.1 conformance through
+ * the DPoP route. The algorithm and the proof key are checked against each other at construction
+ * time, so a mismatch fails fast rather than surfacing later from the JCA layer.
  * <p>
  * <strong>Replay defence:</strong> every emitted proof carries a fresh, single-use {@code jti}. The
  * generator tracks the identifiers it has issued and fails closed if its {@code jti} source ever
@@ -76,6 +95,36 @@ public class DpopProofGenerator {
      */
     private static final int MAX_TRACKED_JTIS = 10_000;
 
+    private static final String KTY_RSA = "RSA";
+    private static final String KTY_EC = "EC";
+    private static final String KTY_OKP = "OKP";
+    private static final String CRV_P256 = "P-256";
+    private static final String CRV_ED25519 = "Ed25519";
+    private static final String ALG_PS256 = "PS256";
+    private static final String ALG_ES256 = "ES256";
+
+    /** Field size of curve P-256 in bits; the guard that rejects any other EC curve. */
+    private static final int P256_FIELD_SIZE_BITS = 256;
+
+    /** Fixed width of a P-256 affine coordinate per RFC 7518 §6.2.1.2. */
+    private static final int P256_COORDINATE_BYTES = 32;
+
+    /** Fixed width of an Ed25519 public key per RFC 8032. */
+    private static final int ED25519_KEY_BYTES = 32;
+
+    /**
+     * The proof-key type ({@code kty}) each supported signing algorithm requires. Consulted at
+     * construction time so an algorithm/key mismatch fails fast instead of surfacing from the JCA
+     * layer at the first {@code sign()} call.
+     */
+    private static final Map<String, String> ALGORITHM_KEY_TYPES = Map.of(
+            "RS256", KTY_RSA,
+            "RS384", KTY_RSA,
+            "RS512", KTY_RSA,
+            ALG_PS256, KTY_RSA,
+            ALG_ES256, KTY_EC,
+            "EdDSA", KTY_OKP);
+
     private final KeyPair keyPair;
     private final String jwtAlgorithm;
     private final String jcaAlgorithm;
@@ -96,8 +145,11 @@ public class DpopProofGenerator {
     /**
      * Creates a generator that mints a random {@code jti} for every proof.
      *
-     * @param keyPair   the RSA proof key pair; must not be {@code null}
-     * @param algorithm the JWT signing algorithm ({@code RS256} / {@code RS384} / {@code RS512})
+     * @param keyPair   the proof key pair (RSA, EC P-256 or OKP Ed25519); must not be {@code null}
+     * @param algorithm the JWT signing algorithm ({@code RS256} / {@code RS384} / {@code RS512} /
+     *                  {@code PS256} / {@code ES256} / {@code EdDSA})
+     * @throws IllegalArgumentException if the algorithm is unsupported, the proof key is not an RSA,
+     *         EC P-256 or OKP Ed25519 key, or the algorithm does not match the proof-key type
      */
     public DpopProofGenerator(KeyPair keyPair, String algorithm) {
         this(keyPair, algorithm, () -> UUID.randomUUID().toString());
@@ -108,21 +160,91 @@ public class DpopProofGenerator {
      * a repeated identifier and assert the reuse defence; production code uses the random-{@code jti}
      * constructor above.
      *
-     * @param keyPair   the RSA proof key pair; must not be {@code null}, public key must be RSA
-     * @param algorithm the JWT signing algorithm ({@code RS256} / {@code RS384} / {@code RS512})
+     * @param keyPair   the proof key pair (RSA, EC P-256 or OKP Ed25519); must not be {@code null}
+     * @param algorithm the JWT signing algorithm ({@code RS256} / {@code RS384} / {@code RS512} /
+     *                  {@code PS256} / {@code ES256} / {@code EdDSA})
      * @param jtiSource the source of proof identifiers; must not be {@code null}
+     * @throws IllegalArgumentException if the algorithm is unsupported, the proof key is not an RSA,
+     *         EC P-256 or OKP Ed25519 key, or the algorithm does not match the proof-key type
      */
     public DpopProofGenerator(KeyPair keyPair, String algorithm, Supplier<String> jtiSource) {
         this.keyPair = Objects.requireNonNull(keyPair, "keyPair must not be null");
         this.jwtAlgorithm = Objects.requireNonNull(algorithm, "algorithm must not be null");
         this.jtiSource = Objects.requireNonNull(jtiSource, "jtiSource must not be null");
         this.jcaAlgorithm = toJcaAlgorithm(algorithm);
-        if (!(keyPair.getPublic() instanceof RSAPublicKey)) {
-            throw new IllegalArgumentException("DPoP proof key must be an RSA key pair");
+        // One JWK map feeds both the header 'jwk' and the cnf.jkt thumbprint, so a proof can never
+        // advertise a key whose thumbprint does not match the embedded JWK.
+        Map<String, Object> jwk = buildJwk(keyPair.getPublic(), algorithm);
+        this.jwkJson = JwkThumbprintUtil.canonicalJson(jwk);
+        this.jkt = JwkThumbprintUtil.computeThumbprint(jwk);
+    }
+
+    /**
+     * Classifies the proof key, verifies it matches the requested signing algorithm, and builds the
+     * canonical JWK members for its key type.
+     *
+     * @param publicKey the proof key's public key
+     * @param algorithm the requested JWT signing algorithm
+     * @return the JWK members required for this key type by RFC 7638
+     * @throws IllegalArgumentException if the key type or curve is unsupported, or the algorithm does
+     *         not match the key type
+     */
+    private static Map<String, Object> buildJwk(PublicKey publicKey, String algorithm) {
+        if (publicKey instanceof RSAPublicKey rsaKey) {
+            requireKeyTypeMatches(algorithm, KTY_RSA);
+            return Map.of(
+                    "kty", KTY_RSA,
+                    "e", base64UrlUnsigned(rsaKey.getPublicExponent()),
+                    "n", base64UrlUnsigned(rsaKey.getModulus()));
         }
-        RSAPublicKey publicKey = (RSAPublicKey) keyPair.getPublic();
-        this.jwkJson = rsaJwkJson(publicKey);
-        this.jkt = computeJkt(publicKey);
+        if (publicKey instanceof ECPublicKey ecKey) {
+            requireKeyTypeMatches(algorithm, KTY_EC);
+            int fieldSize = ecKey.getParams().getCurve().getField().getFieldSize();
+            if (fieldSize != P256_FIELD_SIZE_BITS) {
+                throw new IllegalArgumentException(
+                        "DPoP EC proof key must use curve P-256, but the key's field size is %d bits".formatted(
+                                fieldSize));
+            }
+            return Map.of(
+                    "kty", KTY_EC,
+                    "crv", CRV_P256,
+                    // RFC 7518 §6.2.1.2: coordinates are left-padded to the full coordinate width,
+                    // so base64UrlUnsigned (which strips rather than pads) must not be used here.
+                    "x", base64UrlFixedWidth(ecKey.getW().getAffineX(), P256_COORDINATE_BYTES),
+                    "y", base64UrlFixedWidth(ecKey.getW().getAffineY(), P256_COORDINATE_BYTES));
+        }
+        if (publicKey instanceof EdECPublicKey edKey) {
+            requireKeyTypeMatches(algorithm, KTY_OKP);
+            String curve = edKey.getParams().getName();
+            if (!CRV_ED25519.equals(curve)) {
+                throw new IllegalArgumentException(
+                        "DPoP OKP proof key must use curve Ed25519, but the key uses " + curve);
+            }
+            return Map.of(
+                    "kty", KTY_OKP,
+                    "crv", CRV_ED25519,
+                    "x", encodeEd25519Point(edKey.getPoint()));
+        }
+        throw new IllegalArgumentException(
+                "DPoP proof key must be an RSA, EC P-256 or OKP Ed25519 key pair, but was "
+                        + publicKey.getAlgorithm());
+    }
+
+    /**
+     * Fails fast when the requested signing algorithm does not match the proof key's type — for
+     * example {@code ES256} with an RSA pair, or {@code RS256} with an EC pair.
+     *
+     * @param algorithm     the requested JWT signing algorithm
+     * @param actualKeyType the {@code kty} of the supplied proof key
+     * @throws IllegalArgumentException if the algorithm requires a different key type
+     */
+    private static void requireKeyTypeMatches(String algorithm, String actualKeyType) {
+        String requiredKeyType = ALGORITHM_KEY_TYPES.get(algorithm);
+        if (!actualKeyType.equals(requiredKeyType)) {
+            throw new IllegalArgumentException(
+                    "DPoP signing algorithm %s requires a %s proof key, but the key pair is %s".formatted(
+                            algorithm, requiredKeyType, actualKeyType));
+        }
     }
 
     /**
@@ -229,36 +351,100 @@ public class DpopProofGenerator {
     private String sign(String signingInput) {
         try {
             Signature signature = Signature.getInstance(jcaAlgorithm);
+            if (ALG_PS256.equals(jwtAlgorithm)) {
+                // The JCA RSASSA-PSS instance carries no defaults — PS256's parameters are explicit.
+                signature.setParameter(new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1));
+            }
             signature.initSign(keyPair.getPrivate());
             signature.update(signingInput.getBytes(StandardCharsets.UTF_8));
-            return BASE64_URL.encodeToString(signature.sign());
+            byte[] rawSignature = signature.sign();
+            if (ALG_ES256.equals(jwtAlgorithm)) {
+                // SHA256withECDSA emits ASN.1/DER; JOSE requires the IEEE P1363 R||S concatenation.
+                rawSignature = EcdsaSignatureFormatConverter.toJoseSignature(rawSignature, ALG_ES256);
+            }
+            return BASE64_URL.encodeToString(rawSignature);
         } catch (GeneralSecurityException e) {
             throw new IllegalStateException("Failed to sign DPoP proof", e);
         }
     }
 
-    private static String rsaJwkJson(RSAPublicKey publicKey) {
-        // Canonical RFC 7638 member order for RSA: e, kty, n. Reused as the header 'jwk' too.
-        return "{\"e\":\"" + base64UrlUnsigned(publicKey.getPublicExponent())
-                + "\",\"kty\":\"RSA\",\"n\":\"" + base64UrlUnsigned(publicKey.getModulus()) + "\"}";
-    }
-
-    private static String computeJkt(RSAPublicKey publicKey) {
-        try {
-            byte[] hash = MessageDigest.getInstance("SHA-256")
-                    .digest(rsaJwkJson(publicKey).getBytes(StandardCharsets.UTF_8));
-            return BASE64_URL.encodeToString(hash);
-        } catch (GeneralSecurityException e) {
-            throw new IllegalStateException("SHA-256 not available for JWK thumbprint", e);
-        }
-    }
-
+    /**
+     * Encodes an RSA JWK member as an unsigned big-endian base64url value, stripping the sign byte
+     * {@link BigInteger#toByteArray()} prepends. Suitable for {@code e} and {@code n}, which are
+     * variable-width; it MUST NOT be used for EC coordinates, which are fixed-width and require
+     * left-padding — see {@link #base64UrlFixedWidth(BigInteger, int)}.
+     */
     private static String base64UrlUnsigned(BigInteger value) {
         byte[] bytes = value.toByteArray();
         if (bytes.length > 1 && bytes[0] == 0) {
             bytes = Arrays.copyOfRange(bytes, 1, bytes.length);
         }
         return BASE64_URL.encodeToString(bytes);
+    }
+
+    /**
+     * Encodes a fixed-width JWK member as a big-endian base64url value left-padded with zeros to
+     * exactly {@code width} bytes, per RFC 7518 §6.2.1.2.
+     *
+     * @param value the non-negative value to encode
+     * @param width the fixed member width in bytes
+     * @return the base64url encoding of the zero-padded big-endian value
+     * @throws IllegalArgumentException if the value does not fit into {@code width} bytes
+     */
+    private static String base64UrlFixedWidth(BigInteger value, int width) {
+        return BASE64_URL.encodeToString(toFixedWidth(value, width));
+    }
+
+    /**
+     * Renders a non-negative value as a big-endian byte array of exactly {@code width} bytes.
+     *
+     * @param value the non-negative value to render
+     * @param width the target width in bytes
+     * @return the zero-padded big-endian representation
+     * @throws IllegalArgumentException if the value does not fit into {@code width} bytes
+     */
+    private static byte[] toFixedWidth(BigInteger value, int width) {
+        byte[] magnitude = value.toByteArray();
+        int offset = 0;
+        while (offset < magnitude.length - 1 && magnitude[offset] == 0) {
+            offset++;
+        }
+        int significantLength = magnitude.length - offset;
+        if (significantLength > width) {
+            throw new IllegalArgumentException(
+                    "JWK member is %d bytes, exceeds the %d-byte member width".formatted(significantLength, width));
+        }
+        byte[] fixedWidth = new byte[width];
+        System.arraycopy(magnitude, offset, fixedWidth, width - significantLength, significantLength);
+        return fixedWidth;
+    }
+
+    /**
+     * Encodes an Ed25519 public point as the RFC 8032 32-byte {@code x} member: the point's
+     * {@code y} coordinate big-endian left-padded to 32 bytes, byte-reversed to little-endian, with
+     * the most significant bit of the final byte set when {@code x} is odd.
+     * <p>
+     * This is the exact inverse of {@code JwkKeyHandler.parseOkpKey}, the reference implementation
+     * for the encoding.
+     */
+    private static String encodeEd25519Point(EdECPoint point) {
+        byte[] encoded = toFixedWidth(point.getY(), ED25519_KEY_BYTES);
+        reverseInPlace(encoded);
+        if (point.isXOdd()) {
+            encoded[encoded.length - 1] |= (byte) 0x80;
+        }
+        return BASE64_URL.encodeToString(encoded);
+    }
+
+    /**
+     * Reverses a byte array in place (big-endian to little-endian conversion).
+     */
+    private static void reverseInPlace(byte[] array) {
+        for (int i = 0, j = array.length - 1; i < j; i++, j--) {
+            byte tmp = array[i];
+            array[i] = array[j];
+            array[j] = tmp;
+        }
     }
 
     private static String encode(String json) {
@@ -270,6 +456,9 @@ public class DpopProofGenerator {
             case "RS256" -> "SHA256withRSA";
             case "RS384" -> "SHA384withRSA";
             case "RS512" -> "SHA512withRSA";
+            case ALG_PS256 -> "RSASSA-PSS";
+            case ALG_ES256 -> "SHA256withECDSA";
+            case "EdDSA" -> "Ed25519";
             default -> throw new IllegalArgumentException("unsupported DPoP signing algorithm: " + jwtAlgorithm);
         };
     }

--- a/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/dpop/DpopProofGenerator.java
+++ b/token-sheriff-client/src/main/java/de/cuioss/sheriff/token/client/dpop/DpopProofGenerator.java
@@ -24,6 +24,7 @@ import org.jspecify.annotations.Nullable;
 
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
+import java.security.AlgorithmParameters;
 import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.security.MessageDigest;
@@ -32,6 +33,8 @@ import java.security.Signature;
 import java.security.interfaces.ECPublicKey;
 import java.security.interfaces.EdECPublicKey;
 import java.security.interfaces.RSAPublicKey;
+import java.security.spec.ECGenParameterSpec;
+import java.security.spec.ECParameterSpec;
 import java.security.spec.EdECPoint;
 import java.security.spec.MGF1ParameterSpec;
 import java.security.spec.PSSParameterSpec;
@@ -103,8 +106,16 @@ public class DpopProofGenerator {
     private static final String ALG_PS256 = "PS256";
     private static final String ALG_ES256 = "ES256";
 
-    /** Field size of curve P-256 in bits; the guard that rejects any other EC curve. */
-    private static final int P256_FIELD_SIZE_BITS = 256;
+    /** JCA standard name of curve P-256, the only curve an EC proof key may use. */
+    private static final String CURVE_SECP256R1 = "secp256r1";
+
+    /**
+     * Curve P-256's domain parameters, resolved once from the JCA provider. Every EC proof key is
+     * compared against these in full — a field-size check alone would admit any other 256-bit curve
+     * (secp256k1, brainpoolP256r1), whose key would then be published in a JWK claiming
+     * {@code "crv":"P-256"}: a curve-confusion defect.
+     */
+    private static final ECParameterSpec P256_PARAMS = resolveP256Params();
 
     /** Fixed width of a P-256 affine coordinate per RFC 7518 §6.2.1.2. */
     private static final int P256_COORDINATE_BYTES = 32;
@@ -199,12 +210,7 @@ public class DpopProofGenerator {
         }
         if (publicKey instanceof ECPublicKey ecKey) {
             requireKeyTypeMatches(algorithm, KTY_EC);
-            int fieldSize = ecKey.getParams().getCurve().getField().getFieldSize();
-            if (fieldSize != P256_FIELD_SIZE_BITS) {
-                throw new IllegalArgumentException(
-                        "DPoP EC proof key must use curve P-256, but the key's field size is %d bits".formatted(
-                                fieldSize));
-            }
+            requireP256Curve(ecKey.getParams());
             return Map.of(
                     "kty", KTY_EC,
                     "crv", CRV_P256,
@@ -228,6 +234,47 @@ public class DpopProofGenerator {
         throw new IllegalArgumentException(
                 "DPoP proof key must be an RSA, EC P-256 or OKP Ed25519 key pair, but was "
                         + publicKey.getAlgorithm());
+    }
+
+    /**
+     * Resolves curve P-256's domain parameters from the JCA provider.
+     *
+     * @return the {@code secp256r1} domain parameters
+     * @throws IllegalStateException if the provider does not offer curve P-256
+     */
+    private static ECParameterSpec resolveP256Params() {
+        try {
+            AlgorithmParameters parameters = AlgorithmParameters.getInstance(KTY_EC);
+            parameters.init(new ECGenParameterSpec(CURVE_SECP256R1));
+            return parameters.getParameterSpec(ECParameterSpec.class);
+        } catch (GeneralSecurityException e) {
+            throw new IllegalStateException("JCA provider does not offer curve P-256 (secp256r1)", e);
+        }
+    }
+
+    /**
+     * Fails fast when an EC proof key is not on curve P-256. The comparison covers the full domain
+     * parameters — curve, generator, order and cofactor — because matching only the field size would
+     * accept a different 256-bit curve and publish it as {@code "crv":"P-256"}.
+     * <p>
+     * {@link ECParameterSpec} does not define {@code equals}, so its components are compared
+     * individually; {@link java.security.spec.EllipticCurve} and {@link java.security.spec.ECPoint}
+     * do define value equality.
+     *
+     * @param params the supplied proof key's domain parameters
+     * @throws IllegalArgumentException if the parameters are not curve P-256's
+     */
+    private static void requireP256Curve(ECParameterSpec params) {
+        boolean onP256 = P256_PARAMS.getCurve().equals(params.getCurve())
+                && P256_PARAMS.getGenerator().equals(params.getGenerator())
+                && P256_PARAMS.getOrder().equals(params.getOrder())
+                && P256_PARAMS.getCofactor() == params.getCofactor();
+        if (!onP256) {
+            throw new IllegalArgumentException(
+                    ("DPoP EC proof key must use curve P-256 (secp256r1), but the key's domain parameters "
+                            + "are those of another curve over a %d-bit field").formatted(
+                            params.getCurve().getField().getFieldSize()));
+        }
     }
 
     /**
@@ -458,7 +505,9 @@ public class DpopProofGenerator {
             case "RS512" -> "SHA512withRSA";
             case ALG_PS256 -> "RSASSA-PSS";
             case ALG_ES256 -> "SHA256withECDSA";
-            case "EdDSA" -> "Ed25519";
+            // The JCA signature algorithm name for EdDSA over curve Ed25519 is the curve name itself,
+            // so the JWK 'crv' constant is the single definition of that string.
+            case "EdDSA" -> CRV_ED25519;
             default -> throw new IllegalArgumentException("unsupported DPoP signing algorithm: " + jwtAlgorithm);
         };
     }

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/dpop/DpopProofGeneratorTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/dpop/DpopProofGeneratorTest.java
@@ -94,7 +94,7 @@ class DpopProofGeneratorTest {
     }
 
     @ParameterizedTest(name = "{0}")
-    @ValueSource(strings = {"RS256", "PS256", "ES256", "EdDSA"})
+    @ValueSource(strings = {"RS256", "RS384", "RS512", "PS256", "ES256", "EdDSA"})
     @DisplayName("Should build a signed dpop+jwt proof carrying the htm/htu/jti/iat claims and embedded JWK")
     void shouldBuildSignedProof(String algorithm) {
         KeyPair proofKey = proofKeyFor(algorithm);
@@ -122,7 +122,7 @@ class DpopProofGeneratorTest {
     }
 
     @ParameterizedTest(name = "{0}")
-    @ValueSource(strings = {"RS256", "PS256", "ES256", "EdDSA"})
+    @ValueSource(strings = {"RS256", "RS384", "RS512", "PS256", "ES256", "EdDSA"})
     @DisplayName("Should expose a stable jkt computed over the key type's canonical JWK members")
     void shouldExposeJktOverCanonicalMembers(String algorithm) {
         KeyPair proofKey = proofKeyFor(algorithm);
@@ -209,7 +209,9 @@ class DpopProofGeneratorTest {
             "EdDSA, RSA",
             "RS256, EC",
             "PS256, EC",
+            "EdDSA, EC",
             "RS256, OKP",
+            "PS256, OKP",
             "ES256, OKP"
     })
     @DisplayName("Should reject an algorithm that does not match the proof-key type")
@@ -292,6 +294,8 @@ class DpopProofGeneratorTest {
         try {
             Signature verifier = Signature.getInstance(switch (algorithm) {
                 case "RS256" -> "SHA256withRSA";
+                case "RS384" -> "SHA384withRSA";
+                case "RS512" -> "SHA512withRSA";
                 case "PS256" -> "RSASSA-PSS";
                 case "ES256" -> "SHA256withECDSAinP1363Format";
                 case "EdDSA" -> "Ed25519";

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/dpop/DpopProofGeneratorTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/dpop/DpopProofGeneratorTest.java
@@ -307,7 +307,7 @@ class DpopProofGeneratorTest {
         }
         byte[] encoded = publicKey.getEncoded();
         if ("EC".equals(publicKey.getAlgorithm())) {
-            // A P-256 SubjectPublicKeyInfo ends with the uncompressed point 0x04 || X(32) || Y(32).
+            // A P-256 SubjectPublicKeyInfo ends with the uncompressed point 0x04 || X(32) || Y(32). // NOSONAR java:S125 - explanatory prose describing byte layout, not commented-out code
             byte[] point = Arrays.copyOfRange(encoded, encoded.length - UNCOMPRESSED_POINT_BYTES, encoded.length);
             assertEquals(0x04, point[0] & 0xFF, "expected an uncompressed P-256 point in the X.509 encoding");
             return Map.of(

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/dpop/DpopProofGeneratorTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/dpop/DpopProofGeneratorTest.java
@@ -15,6 +15,7 @@
  */
 package de.cuioss.sheriff.token.client.dpop;
 
+import de.cuioss.sheriff.token.validation.util.JwkThumbprintUtil;
 import de.cuioss.test.generator.junit.EnableGeneratorController;
 import de.cuioss.test.juli.LogAsserts;
 import de.cuioss.test.juli.TestLogLevel;
@@ -22,14 +23,25 @@ import de.cuioss.test.juli.junit5.EnableTestLogger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
+import java.security.PublicKey;
 import java.security.Signature;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.ECGenParameterSpec;
+import java.security.spec.MGF1ParameterSpec;
+import java.security.spec.PSSParameterSpec;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -40,7 +52,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Mechanics + fail-closed unit tests for {@link DpopProofGenerator} ({@code CLIENT-11}, RFC 9449) —
- * deliverable 8.
+ * deliverable 8, generalized to the full RSA / EC P-256 / OKP Ed25519 proof-key matrix.
  */
 @EnableTestLogger
 @EnableGeneratorController
@@ -50,19 +62,37 @@ class DpopProofGeneratorTest {
     private static final String HTM = "POST";
     private static final String HTU = "https://as.example.com/realms/demo/protocol/openid-connect/token";
 
+    /** Fixed width of a P-256 affine coordinate, and of an Ed25519 raw public key. */
+    private static final int COORDINATE_BYTES = 32;
+
+    /** Length of the uncompressed P-256 point (0x04 || X || Y) that ends the X.509 encoding. */
+    private static final int UNCOMPRESSED_POINT_BYTES = 65;
+
+    private static final Base64.Encoder BASE64_URL = Base64.getUrlEncoder().withoutPadding();
+
     private KeyPair keyPair;
+    private KeyPair ecKeyPair;
+    private KeyPair okpKeyPair;
 
     @BeforeEach
     void setUp() throws Exception {
-        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
-        generator.initialize(2048);
-        keyPair = generator.generateKeyPair();
+        KeyPairGenerator rsa = KeyPairGenerator.getInstance("RSA");
+        rsa.initialize(2048);
+        keyPair = rsa.generateKeyPair();
+
+        KeyPairGenerator ec = KeyPairGenerator.getInstance("EC");
+        ec.initialize(new ECGenParameterSpec("secp256r1"));
+        ecKeyPair = ec.generateKeyPair();
+
+        okpKeyPair = KeyPairGenerator.getInstance("Ed25519").generateKeyPair();
     }
 
-    @Test
+    @ParameterizedTest(name = "{0}")
+    @ValueSource(strings = {"RS256", "PS256", "ES256", "EdDSA"})
     @DisplayName("Should build a signed dpop+jwt proof carrying the htm/htu/jti/iat claims and embedded JWK")
-    void shouldBuildSignedProof() {
-        var proofGenerator = new DpopProofGenerator(keyPair, "RS256");
+    void shouldBuildSignedProof(String algorithm) {
+        KeyPair proofKey = proofKeyFor(algorithm);
+        var proofGenerator = new DpopProofGenerator(proofKey, algorithm);
 
         String proof = proofGenerator.generateProof(HTM, HTU);
 
@@ -70,15 +100,60 @@ class DpopProofGeneratorTest {
         assertEquals(3, segments.length, "a DPoP proof is a three-segment compact JWT");
         String header = decode(segments[0]);
         String payload = decode(segments[1]);
+        String expectedJwk = JwkThumbprintUtil.canonicalJson(expectedJwkMembers(proofKey.getPublic()));
         assertAll("proof structure",
                 () -> assertTrue(header.contains("\"typ\":\"dpop+jwt\""), "header carries the dpop+jwt typ"),
-                () -> assertTrue(header.contains("\"alg\":\"RS256\""), "header carries the signing algorithm"),
-                () -> assertTrue(header.contains("\"jwk\":"), "header embeds the proof public JWK"),
+                () -> assertTrue(header.contains("\"alg\":\"" + algorithm + "\""),
+                        "header carries the signing algorithm"),
+                () -> assertTrue(header.contains("\"jwk\":" + expectedJwk),
+                        "header embeds the canonical proof public JWK"),
                 () -> assertTrue(payload.contains("\"htm\":\"" + HTM + "\""), "payload binds the HTTP method"),
                 () -> assertTrue(payload.contains("\"htu\":\"" + HTU + "\""), "payload binds the target URI"),
                 () -> assertTrue(payload.contains("\"jti\":"), "payload carries a proof identifier"),
                 () -> assertTrue(payload.contains("\"iat\":"), "payload carries the issue time"),
-                () -> assertTrue(signatureVerifies(segments), "the proof is signed by the proof key"));
+                () -> assertTrue(signatureVerifies(segments, proofKey.getPublic(), algorithm),
+                        "the proof is signed by the proof key"));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @ValueSource(strings = {"RS256", "PS256", "ES256", "EdDSA"})
+    @DisplayName("Should expose a stable jkt computed over the key type's canonical JWK members")
+    void shouldExposeJktOverCanonicalMembers(String algorithm) {
+        KeyPair proofKey = proofKeyFor(algorithm);
+        var first = new DpopProofGenerator(proofKey, algorithm);
+        var second = new DpopProofGenerator(proofKey, algorithm);
+        String expectedJkt = JwkThumbprintUtil.computeThumbprint(expectedJwkMembers(proofKey.getPublic()));
+
+        assertAll("jkt",
+                () -> assertTrue(first.jkt() != null && !first.jkt().isBlank(), "jkt is present"),
+                () -> assertEquals(first.jkt(), second.jkt(),
+                        "the same proof key yields the same RFC 7638 thumbprint"),
+                () -> assertTrue(first.jkt().matches("[A-Za-z0-9_-]+"), "jkt is base64url without padding"),
+                () -> assertEquals(expectedJkt, first.jkt(),
+                        "jkt must be the thumbprint over this key type's canonical member set"));
+    }
+
+    @Test
+    @DisplayName("Should derive a different jkt per key type so a thumbprint cannot be reused across keys")
+    void shouldDeriveDistinctJktPerKeyType() {
+        String rsaJkt = new DpopProofGenerator(keyPair, "RS256").jkt();
+        String ecJkt = new DpopProofGenerator(ecKeyPair, "ES256").jkt();
+        String okpJkt = new DpopProofGenerator(okpKeyPair, "EdDSA").jkt();
+
+        assertAll("per-key-type thumbprints",
+                () -> assertNotEquals(rsaJkt, ecJkt, "an EC jkt must differ from the RSA jkt"),
+                () -> assertNotEquals(rsaJkt, okpJkt, "an OKP jkt must differ from the RSA jkt"),
+                () -> assertNotEquals(ecJkt, okpJkt, "an OKP jkt must differ from the EC jkt"));
+    }
+
+    @Test
+    @DisplayName("Should keep the RSA jkt stable across the RS256 and PS256 algorithms")
+    void shouldKeepRsaJktStableAcrossRsaAlgorithms() {
+        var rs256 = new DpopProofGenerator(keyPair, "RS256");
+        var ps256 = new DpopProofGenerator(keyPair, "PS256");
+
+        assertEquals(rs256.jkt(), ps256.jkt(),
+                "the thumbprint binds the key, not the signing algorithm");
     }
 
     @Test
@@ -122,31 +197,46 @@ class DpopProofGeneratorTest {
                 "a jti still tracked in the bounded LRU window is detected as reuse and fails closed");
     }
 
-    @Test
-    @DisplayName("Should expose a stable RFC 7638 jkt thumbprint tied to the proof key")
-    void shouldExposeStableJkt() {
-        var first = new DpopProofGenerator(keyPair, "RS256");
-        var second = new DpopProofGenerator(keyPair, "RS256");
+    @ParameterizedTest(name = "{0} with a {1} key")
+    @CsvSource({
+            "ES256, RSA",
+            "EdDSA, RSA",
+            "RS256, EC",
+            "PS256, EC",
+            "RS256, OKP",
+            "ES256, OKP"
+    })
+    @DisplayName("Should reject an algorithm that does not match the proof-key type")
+    void shouldRejectAlgorithmKeyTypeMismatch(String algorithm, String keyType) {
+        KeyPair mismatchedKey = keyPairOfType(keyType);
 
-        assertAll("jkt",
-                () -> assertTrue(first.jkt() != null && !first.jkt().isBlank(), "jkt is present"),
-                () -> assertEquals(first.jkt(), second.jkt(),
-                        "the same proof key yields the same RFC 7638 thumbprint"),
-                () -> assertTrue(first.jkt().matches("[A-Za-z0-9_-]+"), "jkt is base64url without padding"));
+        assertThrows(IllegalArgumentException.class, () -> new DpopProofGenerator(mismatchedKey, algorithm),
+                "%s must not be accepted with a %s proof key".formatted(algorithm, keyType));
     }
 
     @Test
-    @DisplayName("Should reject a non-RSA key pair and an unsupported signing algorithm")
+    @DisplayName("Should reject an unsupported signing algorithm and an unsupported proof-key type")
     void shouldRejectInvalidConfiguration() throws Exception {
-        KeyPairGenerator ec = KeyPairGenerator.getInstance("EC");
-        ec.initialize(256);
-        KeyPair ecKeyPair = ec.generateKeyPair();
+        KeyPairGenerator dsa = KeyPairGenerator.getInstance("DSA");
+        dsa.initialize(2048);
+        KeyPair dsaKeyPair = dsa.generateKeyPair();
 
         assertAll("configuration guards",
-                () -> assertThrows(IllegalArgumentException.class, () -> new DpopProofGenerator(ecKeyPair, "RS256"),
-                        "a non-RSA proof key is rejected"),
                 () -> assertThrows(IllegalArgumentException.class, () -> new DpopProofGenerator(keyPair, "HS256"),
-                        "an unsupported signing algorithm is rejected"));
+                        "an unsupported signing algorithm is rejected"),
+                () -> assertThrows(IllegalArgumentException.class, () -> new DpopProofGenerator(dsaKeyPair, "RS256"),
+                        "a proof key that is neither RSA, EC P-256 nor OKP Ed25519 is rejected"));
+    }
+
+    @Test
+    @DisplayName("Should reject an EC proof key on a curve other than P-256")
+    void shouldRejectUnsupportedEcCurve() throws Exception {
+        KeyPairGenerator ec = KeyPairGenerator.getInstance("EC");
+        ec.initialize(new ECGenParameterSpec("secp384r1"));
+        KeyPair p384KeyPair = ec.generateKeyPair();
+
+        assertThrows(IllegalArgumentException.class, () -> new DpopProofGenerator(p384KeyPair, "ES256"),
+                "ES256 is defined over P-256 only");
     }
 
     @Test
@@ -159,15 +249,85 @@ class DpopProofGeneratorTest {
                 () -> assertThrows(IllegalArgumentException.class, () -> proofGenerator.generateProof(HTM, "  ")));
     }
 
-    private boolean signatureVerifies(String[] segments) {
+    private KeyPair proofKeyFor(String algorithm) {
+        return switch (algorithm) {
+            case "RS256", "RS384", "RS512", "PS256" -> keyPair;
+            case "ES256" -> ecKeyPair;
+            case "EdDSA" -> okpKeyPair;
+            default -> throw new IllegalStateException("no fixture for algorithm " + algorithm);
+        };
+    }
+
+    private KeyPair keyPairOfType(String keyType) {
+        return switch (keyType) {
+            case "RSA" -> keyPair;
+            case "EC" -> ecKeyPair;
+            case "OKP" -> okpKeyPair;
+            default -> throw new IllegalStateException("no fixture for key type " + keyType);
+        };
+    }
+
+    /**
+     * Verifies the proof signature against the proof public key, decoding each algorithm's JOSE
+     * signature form. ES256 arrives as the IEEE P1363 concatenation, so it is verified with the
+     * JDK-native P1363 signature variant rather than the DER-expecting one.
+     */
+    private boolean signatureVerifies(String[] segments, PublicKey publicKey, String algorithm) {
         try {
-            Signature verifier = Signature.getInstance("SHA256withRSA");
-            verifier.initVerify(keyPair.getPublic());
+            Signature verifier = Signature.getInstance(switch (algorithm) {
+                case "RS256" -> "SHA256withRSA";
+                case "PS256" -> "RSASSA-PSS";
+                case "ES256" -> "SHA256withECDSAinP1363Format";
+                case "EdDSA" -> "Ed25519";
+                default -> throw new IllegalStateException("no verifier for algorithm " + algorithm);
+            });
+            if ("PS256".equals(algorithm)) {
+                verifier.setParameter(new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1));
+            }
+            verifier.initVerify(publicKey);
             verifier.update((segments[0] + "." + segments[1]).getBytes(StandardCharsets.UTF_8));
             return verifier.verify(Base64.getUrlDecoder().decode(segments[2]));
         } catch (GeneralSecurityException | IllegalArgumentException e) {
             return false;
         }
+    }
+
+    /**
+     * Independently derives the JWK members the generator is expected to publish for a proof key.
+     * The EC and OKP members are read out of the key's X.509 encoding rather than re-implementing the
+     * production encoding, so the assertion is a genuine cross-check and not a copy of the code
+     * under test.
+     */
+    private static Map<String, Object> expectedJwkMembers(PublicKey publicKey) {
+        if (publicKey instanceof RSAPublicKey rsaKey) {
+            return Map.of(
+                    "kty", "RSA",
+                    "e", BASE64_URL.encodeToString(unsignedBytes(rsaKey.getPublicExponent())),
+                    "n", BASE64_URL.encodeToString(unsignedBytes(rsaKey.getModulus())));
+        }
+        byte[] encoded = publicKey.getEncoded();
+        if ("EC".equals(publicKey.getAlgorithm())) {
+            // A P-256 SubjectPublicKeyInfo ends with the uncompressed point 0x04 || X(32) || Y(32).
+            byte[] point = Arrays.copyOfRange(encoded, encoded.length - UNCOMPRESSED_POINT_BYTES, encoded.length);
+            assertEquals(0x04, point[0] & 0xFF, "expected an uncompressed P-256 point in the X.509 encoding");
+            return Map.of(
+                    "kty", "EC",
+                    "crv", "P-256",
+                    "x", BASE64_URL.encodeToString(Arrays.copyOfRange(point, 1, 1 + COORDINATE_BYTES)),
+                    "y", BASE64_URL.encodeToString(
+                            Arrays.copyOfRange(point, 1 + COORDINATE_BYTES, UNCOMPRESSED_POINT_BYTES)));
+        }
+        // An Ed25519 SubjectPublicKeyInfo ends with the raw RFC 8032 32-byte public key.
+        return Map.of(
+                "kty", "OKP",
+                "crv", "Ed25519",
+                "x", BASE64_URL.encodeToString(
+                        Arrays.copyOfRange(encoded, encoded.length - COORDINATE_BYTES, encoded.length)));
+    }
+
+    private static byte[] unsignedBytes(BigInteger value) {
+        byte[] bytes = value.toByteArray();
+        return bytes.length > 1 && bytes[0] == 0 ? Arrays.copyOfRange(bytes, 1, bytes.length) : bytes;
     }
 
     private static String extractJti(String payload) {

--- a/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/dpop/DpopProofGeneratorTest.java
+++ b/token-sheriff-client/src/test/java/de/cuioss/sheriff/token/client/dpop/DpopProofGeneratorTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.io.Serial;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
@@ -34,8 +35,13 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.PublicKey;
 import java.security.Signature;
+import java.security.interfaces.ECPublicKey;
 import java.security.interfaces.RSAPublicKey;
+import java.security.spec.ECFieldFp;
 import java.security.spec.ECGenParameterSpec;
+import java.security.spec.ECParameterSpec;
+import java.security.spec.ECPoint;
+import java.security.spec.EllipticCurve;
 import java.security.spec.MGF1ParameterSpec;
 import java.security.spec.PSSParameterSpec;
 import java.util.Arrays;
@@ -240,6 +246,16 @@ class DpopProofGeneratorTest {
     }
 
     @Test
+    @DisplayName("Should reject an EC proof key on a different curve that shares the P-256 field size")
+    void shouldRejectSameFieldSizeCurveOtherThanP256() {
+        KeyPair secp256k1KeyPair = new KeyPair(new Secp256k1PublicKey(), ecKeyPair.getPrivate());
+
+        assertThrows(IllegalArgumentException.class, () -> new DpopProofGenerator(secp256k1KeyPair, "ES256"),
+                "secp256k1 shares P-256's 256-bit field size but is a different curve, so publishing it "
+                        + "as crv:P-256 would be curve confusion");
+    }
+
+    @Test
     @DisplayName("Should reject a blank htm or htu")
     void shouldRejectBlankParameters() {
         var proofGenerator = new DpopProofGenerator(keyPair, "RS256");
@@ -338,5 +354,54 @@ class DpopProofGeneratorTest {
 
     private static String decode(String segment) {
         return new String(Base64.getUrlDecoder().decode(segment), StandardCharsets.UTF_8);
+    }
+
+    /**
+     * A public key on curve secp256k1 — a 256-bit curve that is <em>not</em> P-256, and therefore the
+     * case a field-size-only guard wrongly admits. SunEC dropped secp256k1 after JDK 15, so no
+     * {@code KeyPairGenerator} can produce one; the key is assembled from the curve's published
+     * domain parameters (SEC 2 §2.4.1) instead. The guard under test reads nothing but those
+     * parameters, so the missing key material is immaterial to what is asserted.
+     */
+    private static final class Secp256k1PublicKey implements ECPublicKey {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
+
+        private static final BigInteger PRIME =
+                new BigInteger("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F", 16);
+        private static final BigInteger ORDER =
+                new BigInteger("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141", 16);
+        private static final ECPoint GENERATOR = new ECPoint(
+                new BigInteger("79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798", 16),
+                new BigInteger("483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8", 16));
+        private static final ECParameterSpec PARAMS = new ECParameterSpec(
+                new EllipticCurve(new ECFieldFp(PRIME), BigInteger.ZERO, BigInteger.valueOf(7)),
+                GENERATOR, ORDER, 1);
+
+        @Override
+        public ECPoint getW() {
+            return GENERATOR;
+        }
+
+        @Override
+        public ECParameterSpec getParams() {
+            return PARAMS;
+        }
+
+        @Override
+        public String getAlgorithm() {
+            return "EC";
+        }
+
+        @Override
+        public String getFormat() {
+            return "X.509";
+        }
+
+        @Override
+        public byte[] getEncoded() {
+            return new byte[0];
+        }
     }
 }

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/util/EcdsaSignatureFormatConverter.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/util/EcdsaSignatureFormatConverter.java
@@ -47,6 +47,12 @@ public class EcdsaSignatureFormatConverter {
 
     private static final CuiLogger LOGGER = new CuiLogger(EcdsaSignatureFormatConverter.class);
 
+    /** ASN.1 tag identifying a DER SEQUENCE. */
+    private static final int ASN1_SEQUENCE_TAG = 0x30;
+
+    /** ASN.1 tag identifying a DER INTEGER. */
+    private static final int ASN1_INTEGER_TAG = 0x02;
+
     /**
      * Private constructor to prevent instantiation of utility class.
      */
@@ -101,6 +107,99 @@ public class EcdsaSignatureFormatConverter {
     }
 
     /**
+     * Converts an ECDSA signature from ASN.1/DER format to IEEE P1363 format.
+     *
+     * <p>This is the symmetric outbound counterpart to
+     * {@link #toJCACompatibleSignature(byte[], String)}: the JCA {@code SHA*withECDSA} signer emits
+     * an ASN.1/DER {@code SEQUENCE { r INTEGER, s INTEGER }}, whereas JOSE requires the fixed-width
+     * IEEE P1363 {@code R || S} concatenation. Use it when producing a JWS/JWT signature.</p>
+     *
+     * <p>Two DER encoding traps are handled explicitly:</p>
+     * <ul>
+     *   <li>A DER INTEGER carries a leading {@code 0x00} pad byte when the high bit of the first
+     *       significant byte is set — the pad is stripped.</li>
+     *   <li>A DER INTEGER drops leading zero bytes — each component is left-padded back to the
+     *       algorithm's fixed component width.</li>
+     * </ul>
+     *
+     * @param derSignature the signature in ASN.1/DER format as emitted by the JCA ECDSA signer
+     * @param algorithm the ECDSA algorithm (ES256, ES384, or ES512)
+     * @return the signature in IEEE P1363 format (raw R||S concatenation)
+     * @throws SignatureException if the signature is null, the algorithm is unsupported, or the DER
+     *         encoding is malformed (wrong tag, truncated length, trailing bytes, or a component
+     *         longer than the algorithm's component width)
+     * @since 1.0
+     */
+    public static byte[] toJoseSignature(byte[] derSignature, String algorithm) throws SignatureException {
+        if (derSignature == null) {
+            throw new SignatureException("Signature cannot be null");
+        }
+
+        int componentSize = getComponentSize(algorithm);
+
+        var reader = new DerReader(derSignature);
+        int sequenceLength = reader.readTagAndLength(ASN1_SEQUENCE_TAG, "SEQUENCE");
+        if (sequenceLength != reader.remaining()) {
+            throw new SignatureException(
+                    "Invalid DER signature: SEQUENCE declares %s content bytes but %s remain".formatted(
+                            sequenceLength, reader.remaining()));
+        }
+
+        byte[] rComponent = readFixedWidthComponent(reader, componentSize, "R");
+        byte[] sComponent = readFixedWidthComponent(reader, componentSize, "S");
+
+        if (reader.remaining() != 0) {
+            throw new SignatureException("Invalid DER signature: %s trailing byte(s) after the S component".formatted(
+                    reader.remaining()));
+        }
+
+        byte[] joseSignature = new byte[componentSize * 2];
+        System.arraycopy(rComponent, 0, joseSignature, 0, componentSize);
+        System.arraycopy(sComponent, 0, joseSignature, componentSize, componentSize);
+
+        LOGGER.debug("Converted ASN.1/DER signature to IEEE P1363 format (length: %s bytes)", joseSignature.length);
+
+        return joseSignature;
+    }
+
+    /**
+     * Reads one DER INTEGER and normalizes it to the algorithm's fixed component width.
+     *
+     * @param reader the cursor positioned at the INTEGER tag
+     * @param componentSize the fixed component width in bytes
+     * @param componentName the component name used in error messages (R or S)
+     * @return the component left-padded with zeros to exactly {@code componentSize} bytes
+     * @throws SignatureException if the INTEGER is malformed or exceeds {@code componentSize}
+     */
+    private static byte[] readFixedWidthComponent(DerReader reader, int componentSize, String componentName)
+            throws SignatureException {
+        int length = reader.readTagAndLength(ASN1_INTEGER_TAG, "INTEGER");
+        byte[] rawValue = reader.readBytes(length);
+
+        if (rawValue.length == 0) {
+            throw new SignatureException("Invalid DER signature: %s component has zero length".formatted(componentName));
+        }
+
+        // Strip leading zero padding (DER adds 0x00 when the high bit is set) while keeping at least one byte
+        int offset = 0;
+        while (offset < rawValue.length - 1 && rawValue[offset] == 0) {
+            offset++;
+        }
+        int significantLength = rawValue.length - offset;
+
+        if (significantLength > componentSize) {
+            throw new SignatureException(
+                    "Invalid DER signature: %s component is %s bytes, exceeds the %s-byte component width".formatted(
+                            componentName, significantLength, componentSize));
+        }
+
+        // Left-pad back to the fixed width (DER drops leading zero bytes)
+        byte[] component = new byte[componentSize];
+        System.arraycopy(rawValue, offset, component, componentSize - significantLength, significantLength);
+        return component;
+    }
+
+    /**
      * Gets the component size in bytes for the specified ECDSA algorithm.
      *
      * @param algorithm the ECDSA algorithm (ES256, ES384, or ES512)
@@ -147,7 +246,7 @@ public class EcdsaSignatureFormatConverter {
         ByteArrayOutputStream sequence = new ByteArrayOutputStream();
 
         // SEQUENCE tag
-        sequence.write(0x30);
+        sequence.write(ASN1_SEQUENCE_TAG);
 
         // Length of content
         writeLength(sequence, contentLength);
@@ -178,7 +277,7 @@ public class EcdsaSignatureFormatConverter {
         ByteArrayOutputStream integerEncoding = new ByteArrayOutputStream();
 
         // INTEGER tag
-        integerEncoding.write(0x02);
+        integerEncoding.write(ASN1_INTEGER_TAG);
 
         // Length of value
         writeLength(integerEncoding, valueBytes.length);
@@ -221,6 +320,106 @@ public class EcdsaSignatureFormatConverter {
             for (int i = bytesNeeded - 1; i >= 0; i--) {
                 out.write((length >> (i * 8)) & 0xFF);
             }
+        }
+    }
+
+    /**
+     * Minimal forward-only cursor over a DER byte array.
+     *
+     * <p>Reads only the tag/length/value shapes an ECDSA signature can contain and fails with
+     * {@link SignatureException} on any truncation or unsupported encoding, so a malformed input can
+     * never be read past the end of the buffer.</p>
+     */
+    private static final class DerReader {
+
+        /** Maximum number of long-form length bytes accepted; bounds the decoded length well below overflow. */
+        private static final int MAX_LONG_FORM_LENGTH_BYTES = 3;
+
+        private final byte[] data;
+        private int position;
+
+        DerReader(byte[] data) {
+            this.data = data;
+        }
+
+        /**
+         * @return the number of unread bytes
+         */
+        int remaining() {
+            return data.length - position;
+        }
+
+        /**
+         * Reads an expected tag byte followed by its length.
+         *
+         * @param expectedTag the ASN.1 tag that must appear at the cursor
+         * @param description the element name used in error messages
+         * @return the decoded content length
+         * @throws SignatureException if the tag does not match or the encoding is truncated
+         */
+        int readTagAndLength(int expectedTag, String description) throws SignatureException {
+            int tag = readByte(description + " tag");
+            if (tag != expectedTag) {
+                throw new SignatureException("Invalid DER signature: expected %s tag 0x%02X, got 0x%02X".formatted(
+                        description, expectedTag, tag));
+            }
+            return readLength(description);
+        }
+
+        /**
+         * Reads a definite-form length in either short or long form.
+         *
+         * @param description the element name used in error messages
+         * @return the decoded content length
+         * @throws SignatureException if the length is truncated or uses an unsupported encoding
+         */
+        private int readLength(String description) throws SignatureException {
+            int firstByte = readByte(description + " length");
+            if (firstByte < 0x80) {
+                return firstByte;
+            }
+            int lengthByteCount = firstByte & 0x7F;
+            if (lengthByteCount == 0 || lengthByteCount > MAX_LONG_FORM_LENGTH_BYTES) {
+                throw new SignatureException("Invalid DER signature: unsupported %s length encoding 0x%02X".formatted(
+                        description, firstByte));
+            }
+            int length = 0;
+            for (int i = 0; i < lengthByteCount; i++) {
+                length = (length << 8) | readByte(description + " length");
+            }
+            return length;
+        }
+
+        /**
+         * Reads a single unsigned byte.
+         *
+         * @param elementName the element name used in the truncation message
+         * @return the byte value in the range 0-255
+         * @throws SignatureException if the cursor is already at the end of the buffer
+         */
+        private int readByte(String elementName) throws SignatureException {
+            if (position >= data.length) {
+                throw new SignatureException("Invalid DER signature: truncated while reading " + elementName);
+            }
+            return data[position++] & 0xFF;
+        }
+
+        /**
+         * Reads a fixed number of bytes.
+         *
+         * @param length the number of bytes to read
+         * @return the bytes read
+         * @throws SignatureException if fewer than {@code length} bytes remain
+         */
+        byte[] readBytes(int length) throws SignatureException {
+            if (length > remaining()) {
+                throw new SignatureException("Invalid DER signature: truncated, need %s byte(s) but %s remain".formatted(
+                        length, remaining()));
+            }
+            byte[] value = new byte[length];
+            System.arraycopy(data, position, value, 0, length);
+            position += length;
+            return value;
         }
     }
 }

--- a/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/util/JwkThumbprintUtil.java
+++ b/token-sheriff-validation/src/main/java/de/cuioss/sheriff/token/validation/util/JwkThumbprintUtil.java
@@ -50,17 +50,28 @@ public final class JwkThumbprintUtil {
      * @throws IllegalArgumentException if the JWK is missing required fields
      */
     public static String computeThumbprint(Map<String, Object> jwkMap) {
-        String kty = getRequired(jwkMap, "kty");
-        String minimalJson = buildMinimalJson(jwkMap, kty);
+        String minimalJson = canonicalJson(jwkMap);
         byte[] hash = Sha256Util.digest(minimalJson.getBytes(StandardCharsets.UTF_8));
         return Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
     }
 
     /**
-     * Builds the minimal JSON representation with members in lexicographic order
-     * as required by RFC 7638 Section 3.2.
+     * Builds the canonical minimal JSON representation of a JWK with the required members in
+     * lexicographic order as required by RFC 7638 Section 3.2.
+     *
+     * <p>This is the exact string {@link #computeThumbprint(Map)} hashes. A caller that must both
+     * embed a JWK and publish its thumbprint — the DPoP proof header {@code jwk} together with
+     * {@code cnf.jkt} — derives both from this one builder, so it cannot emit a header whose
+     * thumbprint does not match the embedded key.</p>
+     *
+     * @param jwkMap the JWK as a {@code Map<String, Object>} containing at least {@code kty}
+     *               and the required members for that key type
+     * @return the canonical minimal JSON representation
+     * @throws IllegalArgumentException if the key type is unsupported or a required member is missing
+     * @since 1.0
      */
-    private static String buildMinimalJson(Map<String, Object> jwkMap, String kty) {
+    public static String canonicalJson(Map<String, Object> jwkMap) {
+        String kty = getRequired(jwkMap, "kty");
         return switch (kty) {
             case "RSA" -> buildJson(
                     "e", getRequired(jwkMap, "e"),

--- a/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/util/EcdsaSignatureFormatConverterTest.java
+++ b/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/util/EcdsaSignatureFormatConverterTest.java
@@ -403,7 +403,7 @@ class EcdsaSignatureFormatConverterTest {
         @DisplayName("Should throw SignatureException for malformed DER input")
         void shouldThrowForMalformedDer(String description, byte[] derSignature) {
             var exception = assertThrows(SignatureException.class, () ->
-                    EcdsaSignatureFormatConverter.toJoseSignature(derSignature, "ES256"),
+                            EcdsaSignatureFormatConverter.toJoseSignature(derSignature, "ES256"),
                     "Malformed DER (%s) must be rejected".formatted(description));
 
             assertTrue(exception.getMessage().startsWith("Invalid DER signature"),

--- a/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/util/EcdsaSignatureFormatConverterTest.java
+++ b/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/util/EcdsaSignatureFormatConverterTest.java
@@ -16,12 +16,22 @@
 package de.cuioss.sheriff.token.validation.util;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.Signature;
 import java.security.SignatureException;
+import java.security.spec.ECGenParameterSpec;
 import java.util.Arrays;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -289,6 +299,148 @@ class EcdsaSignatureFormatConverterTest {
         byte[] result2 = EcdsaSignatureFormatConverter.toJCACompatibleSignature(ieeeP1363Signature, "ES256");
 
         assertArrayEquals(result1, result2, "Conversion should produce deterministic results");
+    }
+
+    @Nested
+    @DisplayName("Outbound ASN.1/DER to IEEE P1363 conversion")
+    class ToJoseSignatureTests {
+
+        private static final byte[] PAYLOAD = "dpop-proof-payload".getBytes(StandardCharsets.UTF_8);
+
+        @ParameterizedTest(name = "{0} / {1}")
+        @CsvSource({"secp256r1, ES256, 64", "secp384r1, ES384, 96", "secp521r1, ES512, 132"})
+        @DisplayName("Should produce a P1363 signature the JDK verifies natively")
+        void shouldProduceJdkVerifiableP1363Signature(String curve, String algorithm, int expectedLength) throws Exception {
+            var generator = KeyPairGenerator.getInstance("EC");
+            generator.initialize(new ECGenParameterSpec(curve));
+            KeyPair keyPair = generator.generateKeyPair();
+
+            var signer = Signature.getInstance("SHA256withECDSA");
+            signer.initSign(keyPair.getPrivate());
+            signer.update(PAYLOAD);
+            byte[] derSignature = signer.sign();
+
+            byte[] joseSignature = EcdsaSignatureFormatConverter.toJoseSignature(derSignature, algorithm);
+
+            var verifier = Signature.getInstance("SHA256withECDSAinP1363Format");
+            verifier.initVerify(keyPair.getPublic());
+            verifier.update(PAYLOAD);
+
+            assertAll("JDK-native P1363 verification",
+                    () -> assertEquals(expectedLength, joseSignature.length,
+                            "P1363 signature width must match the curve"),
+                    () -> assertTrue(verifier.verify(joseSignature),
+                            "JDK must verify the converted P1363 signature"));
+        }
+
+        @ParameterizedTest(name = "{0}")
+        @CsvSource({"ES256, 32", "ES384, 48", "ES512, 66"})
+        @DisplayName("Should round-trip P1363 to DER and back to the identical bytes")
+        void shouldRoundTripP1363ToDerAndBack(String algorithm, int componentSize) throws Exception {
+            byte[] original = new byte[componentSize * 2];
+            // R keeps the high bit clear, S sets it — exercising both the padded and unpadded DER INTEGER forms
+            Arrays.fill(original, 0, componentSize, (byte) 0x42);
+            Arrays.fill(original, componentSize, original.length, (byte) 0x99);
+
+            byte[] derSignature = EcdsaSignatureFormatConverter.toJCACompatibleSignature(original, algorithm);
+            byte[] roundTripped = EcdsaSignatureFormatConverter.toJoseSignature(derSignature, algorithm);
+
+            assertArrayEquals(original, roundTripped, "P1363 -> DER -> P1363 must be lossless");
+        }
+
+        @Test
+        @DisplayName("Should left-pad a component whose big-endian form is shorter than the component width")
+        void shouldLeftPadShortComponent() throws Exception {
+            byte[] original = new byte[64];
+            // R: three leading zero bytes DER drops and the conversion must restore
+            original[3] = (byte) 0x7F;
+            Arrays.fill(original, 4, 32, (byte) 0x11);
+            // S: high bit set, so DER prepends a 0x00 pad byte the conversion must strip
+            Arrays.fill(original, 32, 64, (byte) 0xF3);
+
+            byte[] derSignature = EcdsaSignatureFormatConverter.toJCACompatibleSignature(original, "ES256");
+            byte[] roundTripped = EcdsaSignatureFormatConverter.toJoseSignature(derSignature, "ES256");
+
+            assertArrayEquals(original, roundTripped,
+                    "Short and high-bit components must round-trip at full component width");
+        }
+
+        @Test
+        @DisplayName("Should restore an all-zero component as a zero-filled P1363 component")
+        void shouldRestoreZeroComponent() throws Exception {
+            byte[] original = new byte[64];
+            Arrays.fill(original, 32, 64, (byte) 0x2A);
+
+            byte[] derSignature = EcdsaSignatureFormatConverter.toJCACompatibleSignature(original, "ES256");
+            byte[] roundTripped = EcdsaSignatureFormatConverter.toJoseSignature(derSignature, "ES256");
+
+            assertArrayEquals(original, roundTripped, "An all-zero R component must round-trip to 32 zero bytes");
+        }
+
+        @Test
+        @DisplayName("Should throw SignatureException for null signature")
+        void shouldThrowForNullSignature() {
+            var exception = assertThrows(SignatureException.class, () ->
+                    EcdsaSignatureFormatConverter.toJoseSignature(null, "ES256"));
+
+            assertEquals("Signature cannot be null", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("Should throw SignatureException for unsupported algorithm")
+        void shouldThrowForUnsupportedAlgorithm() {
+            byte[] derSignature = {0x30, 0x06, 0x02, 0x01, 0x01, 0x02, 0x01, 0x01};
+
+            var exception = assertThrows(SignatureException.class, () ->
+                    EcdsaSignatureFormatConverter.toJoseSignature(derSignature, "RS256"));
+
+            assertTrue(exception.getMessage().contains("Unsupported ECDSA algorithm"),
+                    "Message should name the unsupported algorithm rejection");
+        }
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("malformedDerSignatures")
+        @DisplayName("Should throw SignatureException for malformed DER input")
+        void shouldThrowForMalformedDer(String description, byte[] derSignature) {
+            var exception = assertThrows(SignatureException.class, () ->
+                    EcdsaSignatureFormatConverter.toJoseSignature(derSignature, "ES256"),
+                    "Malformed DER (%s) must be rejected".formatted(description));
+
+            assertTrue(exception.getMessage().startsWith("Invalid DER signature"),
+                    "Message should identify the malformed DER encoding, was: " + exception.getMessage());
+        }
+
+        static Stream<Arguments> malformedDerSignatures() {
+            return Stream.of(
+                    Arguments.of("empty input", new byte[0]),
+                    Arguments.of("wrong SEQUENCE tag", new byte[]{0x31, 0x06, 0x02, 0x01, 0x01, 0x02, 0x01, 0x01}),
+                    Arguments.of("truncated after SEQUENCE tag", new byte[]{0x30}),
+                    Arguments.of("SEQUENCE length exceeds available bytes", new byte[]{0x30, 0x20, 0x02, 0x01, 0x01}),
+                    Arguments.of("unsupported long-form length", new byte[]{0x30, (byte) 0x85, 0x00, 0x00, 0x00, 0x00, 0x01}),
+                    Arguments.of("wrong INTEGER tag for R", new byte[]{0x30, 0x06, 0x04, 0x01, 0x01, 0x02, 0x01, 0x01}),
+                    Arguments.of("truncated R content", new byte[]{0x30, 0x03, 0x02, 0x05, 0x01}),
+                    Arguments.of("zero-length R INTEGER", new byte[]{0x30, 0x05, 0x02, 0x00, 0x02, 0x01, 0x01}),
+                    Arguments.of("trailing bytes after S",
+                            new byte[]{0x30, 0x09, 0x02, 0x01, 0x01, 0x02, 0x01, 0x01, 0x00, 0x00, 0x00}),
+                    Arguments.of("R component wider than the component size", oversizedRComponent()));
+        }
+
+        /**
+         * Builds a structurally valid DER SEQUENCE whose R INTEGER carries 33 significant bytes —
+         * one more than the ES256 component width.
+         */
+        static byte[] oversizedRComponent() {
+            byte[] derSignature = new byte[40];
+            derSignature[0] = 0x30;
+            derSignature[1] = 0x26; // 38 content bytes
+            derSignature[2] = 0x02;
+            derSignature[3] = 0x21; // 33-byte R component
+            Arrays.fill(derSignature, 4, 37, (byte) 0x01);
+            derSignature[37] = 0x02;
+            derSignature[38] = 0x01;
+            derSignature[39] = 0x01;
+            return derSignature;
+        }
     }
 
     /**

--- a/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/util/JwkThumbprintUtilTest.java
+++ b/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/util/JwkThumbprintUtilTest.java
@@ -15,11 +15,16 @@
  */
 package de.cuioss.sheriff.token.validation.util;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -27,6 +32,7 @@ class JwkThumbprintUtilTest {
 
     private static final String EC_X = "f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU";
     private static final String EC_Y = "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0";
+    private static final String OKP_X = "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo";
 
     /**
      * Test vector from RFC 7638 Section 3.1.
@@ -69,7 +75,7 @@ class JwkThumbprintUtilTest {
         Map<String, Object> okpJwk = Map.of(
                 "kty", "OKP",
                 "crv", "Ed25519",
-                "x", "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"
+                "x", OKP_X
         );
 
         String thumbprint = JwkThumbprintUtil.computeThumbprint(okpJwk);
@@ -167,5 +173,81 @@ class JwkThumbprintUtilTest {
                 JwkThumbprintUtil.computeThumbprint(jwkMinimal),
                 JwkThumbprintUtil.computeThumbprint(jwkWithExtras)
         );
+    }
+
+    @Nested
+    @DisplayName("Canonical JSON builder")
+    class CanonicalJsonTests {
+
+        @Test
+        @DisplayName("Should emit e, kty, n in lexicographic order for an RSA key")
+        void shouldEmitCanonicalMemberOrderForRsaKey() {
+            Map<String, Object> rsaJwk = Map.of("kty", "RSA", "n", "abc", "e", "AQAB", "kid", "ignored");
+
+            assertEquals("{\"e\":\"AQAB\",\"kty\":\"RSA\",\"n\":\"abc\"}",
+                    JwkThumbprintUtil.canonicalJson(rsaJwk));
+        }
+
+        @Test
+        @DisplayName("Should emit crv, kty, x, y in lexicographic order for an EC key")
+        void shouldEmitCanonicalMemberOrderForEcKey() {
+            Map<String, Object> ecJwk = Map.of("kty", "EC", "crv", "P-256", "x", EC_X, "y", EC_Y, "kid", "ignored");
+
+            assertEquals("{\"crv\":\"P-256\",\"kty\":\"EC\",\"x\":\"" + EC_X + "\",\"y\":\"" + EC_Y + "\"}",
+                    JwkThumbprintUtil.canonicalJson(ecJwk));
+        }
+
+        @Test
+        @DisplayName("Should emit crv, kty, x in lexicographic order for an OKP key")
+        void shouldEmitCanonicalMemberOrderForOkpKey() {
+            Map<String, Object> okpJwk = Map.of("kty", "OKP", "crv", "Ed25519", "x", OKP_X, "kid", "ignored");
+
+            assertEquals("{\"crv\":\"Ed25519\",\"kty\":\"OKP\",\"x\":\"" + OKP_X + "\"}",
+                    JwkThumbprintUtil.canonicalJson(okpJwk));
+        }
+
+        @Test
+        @DisplayName("Should reject an unsupported key type")
+        void shouldRejectUnsupportedKeyType() {
+            Map<String, Object> jwk = Map.of("kty", "oct", "k", "abc");
+
+            assertThrows(IllegalArgumentException.class, () -> JwkThumbprintUtil.canonicalJson(jwk));
+        }
+
+        @Test
+        @DisplayName("Should reject a missing required member")
+        void shouldRejectMissingRequiredMember() {
+            Map<String, Object> jwk = Map.of("kty", "EC", "crv", "P-256", "x", EC_X);
+            // Missing 'y'
+
+            assertThrows(IllegalArgumentException.class, () -> JwkThumbprintUtil.canonicalJson(jwk));
+        }
+
+        @Test
+        @DisplayName("Should reject a missing kty")
+        void shouldRejectMissingKty() {
+            Map<String, Object> jwk = Map.of("n", "abc", "e", "AQAB");
+
+            assertThrows(IllegalArgumentException.class, () -> JwkThumbprintUtil.canonicalJson(jwk));
+        }
+
+        @ParameterizedTest
+        @MethodSource("delegationVectors")
+        @DisplayName("Should pin computeThumbprint to the SHA-256 of canonicalJson")
+        void shouldPinComputeThumbprintToCanonicalJson(Map<String, Object> jwk) {
+            String canonicalJson = JwkThumbprintUtil.canonicalJson(jwk);
+            byte[] expectedHash = Sha256Util.digest(canonicalJson.getBytes(StandardCharsets.UTF_8));
+            String expectedThumbprint = Base64.getUrlEncoder().withoutPadding().encodeToString(expectedHash);
+
+            assertEquals(expectedThumbprint, JwkThumbprintUtil.computeThumbprint(jwk),
+                    "computeThumbprint must hash exactly the canonicalJson output so the two cannot drift");
+        }
+
+        static Stream<Map<String, Object>> delegationVectors() {
+            return Stream.of(
+                    Map.of("kty", "RSA", "n", "abc", "e", "AQAB"),
+                    Map.of("kty", "EC", "crv", "P-256", "x", EC_X, "y", EC_Y),
+                    Map.of("kty", "OKP", "crv", "Ed25519", "x", OKP_X));
+        }
     }
 }


### PR DESCRIPTION
## Summary

`DpopProofGenerator` in `token-sheriff-client` was RSA/RS*-only: its constructor rejected any
non-`RSAPublicKey` key pair, its `jwk`/`jkt` serialization was hard-coded to the RSA `e`/`kty`/`n`
member set, and its `toJcaAlgorithm` switch closed over `RS256`/`RS384`/`RS512` only. A relying
party could not reach FAPI 2.0 §5.4.1 conformance through the DPoP route without falling back to
mTLS. This PR generalizes the generator to accept RSA, EC (P-256), and OKP (Ed25519) proof keys and
to sign with `PS256`, `ES256`, and `EdDSA` alongside the existing RSA algorithms, using only JDK 21
baseline cryptography (no new dependency).

## Changes

- **`token-sheriff-validation/.../util/EcdsaSignatureFormatConverter.java`**: added the outbound
  DER→IEEE P1363 signature conversion (`toJoseSignature()`), symmetric to the existing inbound
  P1363→DER conversion.
- **`token-sheriff-validation/.../util/JwkThumbprintUtil.java`**: extracted the canonical-JSON
  builder so the header `jwk` and the `cnf.jkt` thumbprint are derived from one RFC 7638 canonical
  per-`kty` (RSA/EC/OKP) source and can never diverge.
- **`token-sheriff-client/.../dpop/DpopProofGenerator.java`**: generalized the constructor to accept
  `RSAPublicKey`, `ECPublicKey` (P-256), and `EdECPublicKey` (Ed25519) key pairs, rejecting any other
  key type and any algorithm/key-type mismatch explicitly with `IllegalArgumentException`; added JCA
  signing for `PS256`, `ES256`, and `EdDSA`; generalized `jwk`/`jkt` serialization per key type.
- **`token-sheriff-client/README.adoc`**: updated to reflect the generalized key-type/algorithm
  support.
- Added tests per key type (RSA/EC/OKP × their respective algorithms) covering proof structure,
  signature verification, and the `jkt` value, plus tests for the new
  `EcdsaSignatureFormatConverter`/`JwkThumbprintUtil` seams.

## Test Plan

- [ ] Verification command passed (`python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "verify -pl token-sheriff-client -am"`)
- [ ] Manual testing completed (if applicable)

## Related Issues

Closes #618

---
Generated by plan-finalize skill

## Intent

**The problem**: `DpopProofGenerator` only accepted RSA key pairs and only signed with
`RS256`/`RS384`/`RS512` — the constructor rejected any non-`RSAPublicKey`, the `jwk`/`jkt`
serialization hard-coded the RSA member set, and `toJcaAlgorithm` closed over the RSA algorithms
only. That asymmetry blocked FAPI 2.0 §5.4.1 conformance via DPoP (mTLS was the only remaining
route) even though the validation side already supported EC/OKP keys and PS256/ES256/EdDSA end to
end.

**The chosen approach**: extend the generator in place (this project's `compatibility=breaking`
policy rules out a parallel overload) to classify RSA/EC/OKP key pairs, sign with the matching JCA
algorithm per type, and serialize `jwk`/`jkt` per RFC 7638's canonical member order for each `kty`.
Two capabilities the generator needs — DER→P1363 signature conversion and canonical per-`kty` JWK
JSON — already existed one direction only in `token-sheriff-validation/util`; both are now completed
symmetrically there and reused from the client, rather than reimplemented client-side, per the
project's `client → validation` layering (ADR-0001) and no-duplication standard. An
algorithm/key-type mismatch (e.g. `ES256` with an RSA key) is rejected explicitly at construction
time rather than surfacing as an opaque JCA failure.

**Explicit non-goals**: no new configuration surface for restricting the allowed algorithm

_[Intent truncated — 1389 of 1787 characters shown; full outline in the plan workspace]_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded DPoP proof support for RSA, RSA-PSS, P-256 EC, and Ed25519 keys.
  * Added validation to ensure signing algorithms match the selected proof key.
  * Improved JWK thumbprint generation with standards-compliant canonicalization.
  * Added reliable ECDSA signature format conversion for interoperability.
* **Documentation**
  * Updated DPoP documentation with supported keys, algorithms, replay-safe identifiers, and FAPI 2.0 guidance.
* **Tests**
  * Expanded coverage for supported algorithms, key compatibility, signatures, thumbprints, and invalid inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->