### PR TITLE
feat(validation): ship GraalVM native-image reflection metadata in the core module

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -68,7 +68,7 @@
     "phase-6-finalize": {
       "max_iterations": 3,
       "finalize_without_asking": true,
-      "loop_back_without_asking": false,
+      "loop_back_without_asking": true,
       "checks_wait_timeout_seconds": 600,
       "steps": {
         "default:finalize-step-sync-baseline": {

--- a/token-sheriff-quarkus-parent/doc/configuration/native-image-configuration.adoc
+++ b/token-sheriff-quarkus-parent/doc/configuration/native-image-configuration.adoc
@@ -23,15 +23,23 @@ quarkus.native.resources.includes=**/*.p12,**/*.crt,**/*.key,**/*.pem
 
 === Reflection Configuration
 
-The Token-Sheriff Quarkus deployment automatically registers the following classes for reflection:
+The core library ships its own GraalVM reflection metadata inside the `token-sheriff-validation`
+jar, under `META-INF/native-image/de.cuioss.sheriff.token/token-sheriff-validation/`. GraalVM
+auto-detects that metadata from the classpath, so the following classes are registered for
+reflection without any extension-side or application-side configuration:
 
 * **JWT Validation Pipeline**: `NonValidatingJwtParser`, `TokenSignatureValidator`, `TokenHeaderValidator`, `TokenClaimValidator`, `TokenBuilder`, `DecodedJwt`
 * **JWKS Loading**: `HttpJwksLoader`, `JWKSKeyLoader`, `KeyInfo`, `JwksParser`
 * **Token Content**: `AccessTokenContent`, `IdTokenContent`, `UnvalidatedRefreshToken`, `ClaimValue`
 * **Security/Algorithm**: `SignatureAlgorithmPreferences`, `JwkAlgorithmPreferences`, `SecurityEventCounter`
 
-All reflection classes are registered automatically by the deployment module's build steps
-(see `TokenSheriffProcessor`) — no manual `reflect-config.json` entries are required.
+Because this metadata travels with the core jar, it applies to Quarkus and non-Quarkus native
+builds alike — no manual `reflect-config.json` entries are required in consuming applications.
+
+The Quarkus deployment module (`TokenSheriffProcessor`) registers only the types the extension
+itself owns or bridges, such as the Micrometer `MeterRegistry`, the MicroProfile `JsonWebToken`
+adapter, and the CDI-discoverable claim mapper interface. It does not declare the core library's
+reflection contract.
 
 === Resource Configuration
 
@@ -170,7 +178,7 @@ quarkus.native.container-runtime-options=-m=64m
 
 * Native image size: 96-104MB (distroless: 104MB, JFR/UBI: 96MB)
 * Startup time: <1 second
-* Reflection classes: registered automatically by `TokenSheriffProcessor`
+* Reflection classes: registered automatically from the metadata shipped in the `token-sheriff-validation` jar
 * Security services: All enabled for JWT support
 
 [source,bash]
@@ -185,6 +193,6 @@ curl http://localhost:8080/q/health/ready
 
 == Troubleshooting
 
-* **Missing Reflection**: Ensure token-sheriff-validation module is built before native image
+* **Missing Reflection**: Ensure the `token-sheriff-validation` jar is on the native-image classpath and that its `META-INF/native-image/de.cuioss.sheriff.token/token-sheriff-validation/` metadata is intact — a shaded or repackaged jar that drops `META-INF/native-image` entries loses the reflection registrations
 * **Build Memory Issues**: Increase `native-image-xmx` to 8g or higher
 * **Runtime Issues**: Verify security services are enabled; check resource inclusion for certificates

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus-deployment/README.adoc
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus-deployment/README.adoc
@@ -17,10 +17,13 @@ For Maven dependency information, see xref:../README.adoc#_maven_coordinates[Mav
 
 === Build-Time Processing
 
-* Automatic reflection registration for JWT validation classes
+* Reflection registration for the Quarkus-specific types this extension owns or bridges
 * Native image configuration for GraalVM compatibility
-* Runtime initialization setup for HTTP-based JWKS loaders
 * Integration with Quarkus deployment pipeline
+
+NOTE: The core library's reflection metadata and the `--initialize-at-run-time` setting for
+`HttpJwksLoader` ship inside the `token-sheriff-validation` jar and are auto-detected by GraalVM.
+They are not declared by this module.
 
 === DevUI Integration
 
@@ -41,10 +44,9 @@ For Maven dependency information, see xref:../README.adoc#_maven_coordinates[Mav
 Main deployment processor handling build-time configuration:
 
 * link:src/main/java/de/cuioss/sheriff/token/quarkus/deployment/TokenSheriffProcessor.java[TokenSheriffProcessor]
-* Registers JWT validation classes for reflection
-* Configures runtime initialization for HTTP components
+* Registers the extension's own Quarkus-specific classes for reflection
+* Registers CDI beans, JAX-RS providers, and DSL-JSON service providers
 * Sets up DevUI integration in development mode
-* Provides health check integration
 
 === DevUI Components
 Development interface components:
@@ -84,27 +86,20 @@ Access DevUI components during development:
 The deployment module automatically configures build-time settings. No additional configuration is required for basic usage.
 
 === Reflection Configuration
-Automatically registers classes for reflection across 5 build steps (36 classes total). Key classes include:
+Registers only the types this extension owns or bridges:
 
-**Classes with Methods and Constructors:**
-
-* `de.cuioss.sheriff.token.validation.TokenValidator` - Main validation component
-* `de.cuioss.sheriff.token.validation.IssuerConfigCache` - Issuer configuration cache
-* `de.cuioss.sheriff.token.validation.security.SecurityEventCounter` - Security metrics
 * `io.micrometer.core.instrument.MeterRegistry` - Metrics registry
+* `org.eclipse.microprofile.jwt.JsonWebToken` and `JsonWebTokenAdapter` - MicroProfile JWT bridge for CDI injection
+* `de.cuioss.sheriff.token.quarkus.mapper.DiscoverableClaimMapper` - CDI-discoverable claim mapper interface
 
-**Configuration Classes (Methods Only):**
-
-* `de.cuioss.sheriff.token.validation.IssuerConfig` - Issuer configuration
-* `de.cuioss.sheriff.token.commons.transport.ParserConfig` - Parser settings
-* `de.cuioss.sheriff.token.commons.transport.HttpJwksLoaderConfig` - JWKS loader configuration
-
-**Runtime Initialization:**
-
-* `de.cuioss.sheriff.token.validation.jwks.http.HttpJwksLoader` (runtime initialized for native image compatibility)
+The core validation types — `TokenValidator`, `IssuerConfig`, `ParserConfig`,
+`HttpJwksLoaderConfig`, the validation pipeline, and the claim mappers — are registered from the
+metadata shipped in the `token-sheriff-validation` jar, not from this module.
 
 === Native Image Support
-Configures GraalVM native image compilation with automatic reflection registration and runtime initialization.
+Configures GraalVM native image compilation for the extension's own types. Core-library reflection
+metadata and the `--initialize-at-run-time` setting for `HttpJwksLoader` come from the
+`token-sheriff-validation` jar, which GraalVM auto-detects.
 
 For detailed configuration, reflection classes, and testing information, see xref:../doc/configuration/native-image-configuration.adoc[Native Image Configuration].
 

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus-deployment/src/main/java/de/cuioss/sheriff/token/quarkus/deployment/TokenSheriffProcessor.java
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus-deployment/src/main/java/de/cuioss/sheriff/token/quarkus/deployment/TokenSheriffProcessor.java
@@ -15,9 +15,6 @@
  */
 package de.cuioss.sheriff.token.quarkus.deployment;
 
-import de.cuioss.sheriff.token.commons.events.SecurityEventCounter;
-import de.cuioss.sheriff.token.commons.transport.HttpJwksLoaderConfig;
-import de.cuioss.sheriff.token.commons.transport.ParserConfig;
 import de.cuioss.sheriff.token.quarkus.config.AccessLogFilterConfigResolver;
 import de.cuioss.sheriff.token.quarkus.interceptor.BearerTokenInterceptor;
 import de.cuioss.sheriff.token.quarkus.logging.CustomAccessLogFilter;
@@ -33,29 +30,7 @@ import de.cuioss.sheriff.token.quarkus.runtime.TokenSheriffDevUIRuntimeService;
 import de.cuioss.sheriff.token.quarkus.servlet.VertxServletObjectsResolver;
 import de.cuioss.sheriff.token.quarkus.validation.DiscoverableTokenValidationRule;
 import de.cuioss.sheriff.token.quarkus.validation.TokenValidationRuleRegistry;
-import de.cuioss.sheriff.token.validation.IssuerConfig;
-import de.cuioss.sheriff.token.validation.IssuerConfigCache;
 import de.cuioss.sheriff.token.validation.TokenValidator;
-import de.cuioss.sheriff.token.validation.domain.claim.ClaimName;
-import de.cuioss.sheriff.token.validation.domain.claim.ClaimValue;
-import de.cuioss.sheriff.token.validation.domain.claim.ClaimValueType;
-import de.cuioss.sheriff.token.validation.domain.claim.mapper.*;
-import de.cuioss.sheriff.token.validation.domain.token.*;
-import de.cuioss.sheriff.token.validation.jwe.JweAlgorithmPreferences;
-import de.cuioss.sheriff.token.validation.jwe.JweDecryptionConfig;
-import de.cuioss.sheriff.token.validation.jwe.JweDecryptor;
-import de.cuioss.sheriff.token.validation.jwks.http.HttpJwksLoader;
-import de.cuioss.sheriff.token.validation.jwks.key.JWKSKeyLoader;
-import de.cuioss.sheriff.token.validation.jwks.key.KeyInfo;
-import de.cuioss.sheriff.token.validation.jwks.parser.JwksParser;
-import de.cuioss.sheriff.token.validation.pipeline.DecodedJwt;
-import de.cuioss.sheriff.token.validation.pipeline.NonValidatingJwtParser;
-import de.cuioss.sheriff.token.validation.pipeline.TokenBuilder;
-import de.cuioss.sheriff.token.validation.pipeline.validator.TokenClaimValidator;
-import de.cuioss.sheriff.token.validation.pipeline.validator.TokenHeaderValidator;
-import de.cuioss.sheriff.token.validation.pipeline.validator.TokenSignatureValidator;
-import de.cuioss.sheriff.token.validation.security.JwkAlgorithmPreferences;
-import de.cuioss.sheriff.token.validation.security.SignatureAlgorithmPreferences;
 import de.cuioss.tools.logging.CuiLogger;
 import de.cuioss.tools.logging.LogRecord;
 import de.cuioss.tools.logging.LogRecordModel;
@@ -66,9 +41,7 @@ import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
-import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
-import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
@@ -80,9 +53,15 @@ import org.jboss.jandex.DotName;
 /**
  * Processor for the Token-Sheriff Quarkus extension.
  * <p>
- * This class handles the build-time processing for the extension, including
- * registering the feature, setting up reflection configuration, and providing
- * DevUI integration.
+ * This class handles the build-time processing for the extension: registering the feature, the CDI
+ * and JAX-RS wiring, the Quarkus-specific reflection registrations and the DevUI integration.
+ * </p>
+ * <p>
+ * It does <em>not</em> declare the core library's reflection contract. {@code token-sheriff-validation}
+ * ships its own GraalVM metadata under
+ * {@code META-INF/native-image/de.cuioss.sheriff.token/token-sheriff-validation/}, which GraalVM
+ * auto-detects from the jar — for Quarkus and non-Quarkus native builds alike. Core types therefore
+ * belong in that metadata, never in this processor.
  * </p>
  */
 public class TokenSheriffProcessor {
@@ -119,130 +98,39 @@ public class TokenSheriffProcessor {
 
 
     /**
-     * Register JWT validation classes that need methods and constructors for reflection.
-     * These are core library classes instantiated directly and called via methods.
+     * Register the Quarkus-specific classes that need reflection.
+     * <p>
+     * Only types this extension owns or bridges are registered here. The core library's own
+     * reflection contract ships with {@code token-sheriff-validation} under
+     * {@code META-INF/native-image/de.cuioss.sheriff.token/token-sheriff-validation/} and is
+     * auto-detected by GraalVM, so it must not be duplicated in this processor.
      *
-     * @return A {@link ReflectiveClassBuildItem} for the JWT validation classes with constructors
+     * @param reflectiveClasses producer for reflective class build items
      */
     @BuildStep
-    public ReflectiveClassBuildItem registerJwtValidationConstructorClassesForReflection() {
-        return ReflectiveClassBuildItem.builder(
-                // Classes that need methods + constructors for instantiation
-                TokenValidator.class,        // Public constructors, API methods
-                IssuerConfigCache.class,  // Package constructor, internal methods
-                SecurityEventCounter.class,  // Default constructor, counter methods
-                MeterRegistry.class)         // Micrometer registry for metrics
-                .methods(true)    // Methods needed for API calls and getters
-                .fields(false)    // No direct field access needed
-                .constructors(true) // Constructors needed for instantiation
-                .build();
-    }
+    public void registerQuarkusSpecificClassesForReflection(BuildProducer<ReflectiveClassBuildItem> reflectiveClasses) {
+        // Micrometer registry for metrics
+        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(MeterRegistry.class)
+                .methods(true)
+                .fields(false)
+                .constructors(true)
+                .build());
 
-    /**
-     * Register JWT configuration classes that only need methods for reflection.
-     * These classes are created via builder pattern and accessed via getters.
-     *
-     * @return A {@link ReflectiveClassBuildItem} for the JWT configuration classes
-     */
-    @BuildStep
-    public ReflectiveClassBuildItem registerJwtConfigurationClassesForReflection() {
-        return ReflectiveClassBuildItem.builder(
-                // Configuration classes created via builder pattern
-                IssuerConfig.class,         // Builder pattern, getter methods
-                ParserConfig.class,         // Builder pattern, configuration getters
-                HttpJwksLoaderConfig.class) // Builder pattern, configuration getters
-                .methods(true)    // Methods needed for getter access
-                .fields(false)    // No direct field access needed
-                .constructors(false) // Created via builder, no constructor reflection needed
-                .build();
-    }
+        // MicroProfile JWT interface and adapter for CDI injection
+        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(
+                        JsonWebToken.class,
+                        JsonWebTokenAdapter.class)
+                .methods(true)
+                .fields(true)
+                .constructors(true)
+                .build());
 
-    /**
-     * Register JWT validation pipeline classes for reflection.
-     * These are the performance-critical classes in the validation pipeline.
-     *
-     * @return A {@link ReflectiveClassBuildItem} for JWT validation pipeline classes
-     */
-    @BuildStep
-    public ReflectiveClassBuildItem registerJwtPipelineClassesForReflection() {
-        return ReflectiveClassBuildItem.builder(
-                // Critical validation pipeline classes
-                NonValidatingJwtParser.class,
-                TokenSignatureValidator.class,
-                TokenHeaderValidator.class,
-                TokenClaimValidator.class,
-                TokenBuilder.class,
-                DecodedJwt.class,
-                // JWKS loading classes
-                HttpJwksLoader.class,
-                JWKSKeyLoader.class,
-                KeyInfo.class,
-                JwksParser.class,
-                // Security and algorithm classes
-                SignatureAlgorithmPreferences.class,
-                JwkAlgorithmPreferences.class,
-                // JWE decryption classes
-                JweDecryptor.class,
-                JweDecryptionConfig.class,
-                JweAlgorithmPreferences.class)
-                .methods(false)  // Methods not needed - these are instantiated and called directly
-                .fields(false)   // Fields not needed - no direct field access
-                .constructors(true) // Only constructors needed for instantiation
-                .build();
-    }
-
-    /**
-     * Register JWT token content classes for reflection.
-     * These classes need full reflection for getter/setter access and field binding.
-     *
-     * @return A {@link ReflectiveClassBuildItem} for JWT token content classes
-     */
-    @BuildStep
-    public ReflectiveClassBuildItem registerJwtTokenContentClassesForReflection() {
-        return ReflectiveClassBuildItem.builder(
-                // Token content classes - need full reflection for getter/setter access
-                AccessTokenContent.class,
-                IdTokenContent.class,
-                UnvalidatedRefreshToken.class,
-                TokenContent.class,
-                BaseTokenContent.class,
-                MinimalTokenContent.class,
-                // MicroProfile JWT interface and adapter for CDI injection
-                JsonWebToken.class,
-                JsonWebTokenAdapter.class,
-                // Claim handling classes - need full reflection for enum handling
-                ClaimValue.class,
-                ClaimName.class,
-                ClaimValueType.class)
-                .methods(true)  // Methods needed for getters/setters on token content
-                .fields(true)   // Fields needed for direct field access in token content
-                .constructors(true) // Constructors needed for instantiation
-                .build();
-    }
-
-    /**
-     * Register JWT claim mapper classes for reflection.
-     * These classes only need constructors for instantiation - no method/field access.
-     *
-     * @return A {@link ReflectiveClassBuildItem} for JWT claim mapper classes
-     */
-    @BuildStep
-    public ReflectiveClassBuildItem registerJwtClaimMapperClassesForReflection() {
-        return ReflectiveClassBuildItem.builder(
-                // Claim mappers - only need constructors for instantiation
-                IdentityMapper.class,
-                JsonCollectionMapper.class,
-                KeycloakDefaultGroupsMapper.class,
-                KeycloakDefaultRolesMapper.class,
-                OffsetDateTimeMapper.class,
-                ScopeMapper.class,
-                StringSplitterMapper.class,
-                // CDI-discoverable claim mapper interface
-                DiscoverableClaimMapper.class)
-                .methods(false)  // Methods not needed - mappers are called via interface
-                .fields(false)   // Fields not needed - no field access
-                .constructors(true) // Only constructors needed for instantiation
-                .build();
+        // CDI-discoverable claim mapper interface
+        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(DiscoverableClaimMapper.class)
+                .methods(false)
+                .fields(false)
+                .constructors(true)
+                .build());
     }
 
     /**
@@ -253,35 +141,6 @@ public class TokenSheriffProcessor {
     public void registerDslJsonServiceProviders(BuildProducer<ServiceProviderBuildItem> serviceProvider) {
         // Register all DSL-JSON configurations from classpath
         serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath("com.dslplatform.json.Configuration"));
-
-        // Explicitly register our generated converters as service providers
-        serviceProvider.produce(new ServiceProviderBuildItem("com.dslplatform.json.Configuration",
-                "de.cuioss.sheriff.token.commons.transport._WellKnownResult_DslJsonConverter",
-                "de.cuioss.sheriff.token.commons.transport._Jwks_DslJsonConverter",
-                "de.cuioss.sheriff.token.commons.transport._JwkKey_DslJsonConverter",
-                "de.cuioss.sheriff.token.validation.json._JwtHeader_DslJsonConverter"));
-    }
-
-
-    /**
-     * Register classes that need to be initialized at runtime.
-     *
-     * @return A {@link RuntimeInitializedClassBuildItem} for classes that need runtime initialization
-     */
-    @BuildStep
-    public RuntimeInitializedClassBuildItem runtimeInitializedClasses() {
-        return new RuntimeInitializedClassBuildItem(HttpJwksLoader.class.getName());
-    }
-
-    /**
-     * Register native image resources that JWT validation needs access to.
-     * This ensures configuration files and other resources are included in the native image.
-     */
-    @BuildStep
-    public void registerJwtValidationResources(BuildProducer<NativeImageResourceBuildItem> resourceProducer) {
-        // Include any JWT validation configuration files that might exist
-        resourceProducer.produce(new NativeImageResourceBuildItem("META-INF/services/de.cuioss.sheriff.token.validation.jwks.JwksLoader"));
-        resourceProducer.produce(new NativeImageResourceBuildItem("META-INF/services/de.cuioss.sheriff.token.validation.domain.claim.mapper.ClaimMapper"));
     }
 
 

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus-deployment/src/main/java/de/cuioss/sheriff/token/quarkus/deployment/TokenSheriffProcessor.java
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus-deployment/src/main/java/de/cuioss/sheriff/token/quarkus/deployment/TokenSheriffProcessor.java
@@ -118,8 +118,8 @@ public class TokenSheriffProcessor {
 
         // MicroProfile JWT interface and adapter for CDI injection
         reflectiveClasses.produce(ReflectiveClassBuildItem.builder(
-                        JsonWebToken.class,
-                        JsonWebTokenAdapter.class)
+                JsonWebToken.class,
+                JsonWebTokenAdapter.class)
                 .methods(true)
                 .fields(true)
                 .constructors(true)

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus-deployment/src/test/java/de/cuioss/sheriff/token/quarkus/deployment/TokenSheriffProcessorBuildStepTest.java
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus-deployment/src/test/java/de/cuioss/sheriff/token/quarkus/deployment/TokenSheriffProcessorBuildStepTest.java
@@ -15,158 +15,113 @@
  */
 package de.cuioss.sheriff.token.quarkus.deployment;
 
-import de.cuioss.sheriff.token.commons.events.SecurityEventCounter;
-import de.cuioss.sheriff.token.commons.transport.HttpJwksLoaderConfig;
-import de.cuioss.sheriff.token.commons.transport.ParserConfig;
-import de.cuioss.sheriff.token.validation.IssuerConfig;
-import de.cuioss.sheriff.token.validation.IssuerConfigCache;
+import de.cuioss.sheriff.token.quarkus.mapper.DiscoverableClaimMapper;
+import de.cuioss.sheriff.token.quarkus.producer.JsonWebTokenAdapter;
 import de.cuioss.sheriff.token.validation.TokenValidator;
-import de.cuioss.sheriff.token.validation.domain.claim.ClaimValue;
-import de.cuioss.sheriff.token.validation.domain.claim.mapper.IdentityMapper;
-import de.cuioss.sheriff.token.validation.domain.claim.mapper.ScopeMapper;
 import de.cuioss.sheriff.token.validation.domain.token.AccessTokenContent;
-import de.cuioss.sheriff.token.validation.jwks.http.HttpJwksLoader;
 import de.cuioss.test.juli.junit5.EnableTestLogger;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
-import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for {@link TokenSheriffProcessor} build step methods.
  */
 @EnableTestLogger
+@DisplayName("Tests for TokenSheriffProcessor build steps")
 class TokenSheriffProcessorBuildStepTest {
 
     private final TokenSheriffProcessor processor = new TokenSheriffProcessor();
 
     @Test
+    @DisplayName("Should create the feature build item")
     void shouldCreateFeatureBuildItem() {
-        // Act
         FeatureBuildItem featureItem = processor.feature();
 
-        // Assert
         assertNotNull(featureItem);
         assertEquals("token-sheriff", featureItem.getName());
     }
 
     @Test
-    void shouldRegisterJwtValidationConstructorClassesForReflection() {
-        // Act
-        ReflectiveClassBuildItem reflectiveItem = processor.registerJwtValidationConstructorClassesForReflection();
+    @DisplayName("Should register Quarkus-specific types for reflection and no core types")
+    void shouldRegisterQuarkusSpecificClassesForReflection() {
+        List<ReflectiveClassBuildItem> reflectiveItems = new ArrayList<>();
+        BuildProducer<ReflectiveClassBuildItem> producer = reflectiveItems::add;
 
-        // Assert
-        assertNotNull(reflectiveItem);
-        assertTrue(reflectiveItem.getClassNames().contains(TokenValidator.class.getName()));
-        assertTrue(reflectiveItem.getClassNames().contains(IssuerConfigCache.class.getName()));
-        assertTrue(reflectiveItem.getClassNames().contains(SecurityEventCounter.class.getName()));
-        assertFalse(reflectiveItem.getClassNames().contains(IssuerConfig.class.getName()));
-        assertFalse(reflectiveItem.getClassNames().contains(ParserConfig.class.getName()));
+        processor.registerQuarkusSpecificClassesForReflection(producer);
+
+        Set<String> registered = new HashSet<>();
+        for (ReflectiveClassBuildItem item : reflectiveItems) {
+            registered.addAll(item.getClassNames());
+        }
+        assertAll("Quarkus-specific reflection registrations",
+                () -> assertTrue(registered.contains(MeterRegistry.class.getName()),
+                        "MeterRegistry should stay registered by the extension"),
+                () -> assertTrue(registered.contains(JsonWebToken.class.getName()),
+                        "JsonWebToken should stay registered by the extension"),
+                () -> assertTrue(registered.contains(JsonWebTokenAdapter.class.getName()),
+                        "JsonWebTokenAdapter should stay registered by the extension"),
+                () -> assertTrue(registered.contains(DiscoverableClaimMapper.class.getName()),
+                        "DiscoverableClaimMapper should stay registered by the extension"),
+                () -> assertFalse(registered.contains(TokenValidator.class.getName()),
+                        "Core types ship their own metadata and must not creep back into the extension"),
+                () -> assertFalse(registered.contains(AccessTokenContent.class.getName()),
+                        "Core types ship their own metadata and must not creep back into the extension"));
     }
 
     @Test
-    void shouldRegisterJwtConfigurationClassesForReflection() {
-        // Act
-        ReflectiveClassBuildItem reflectiveItem = processor.registerJwtConfigurationClassesForReflection();
-
-        // Assert
-        assertNotNull(reflectiveItem);
-        assertTrue(reflectiveItem.getClassNames().contains(IssuerConfig.class.getName()));
-        assertTrue(reflectiveItem.getClassNames().contains(ParserConfig.class.getName()));
-        assertTrue(reflectiveItem.getClassNames().contains(HttpJwksLoaderConfig.class.getName()));
-        // These classes are in the constructor group
-        assertFalse(reflectiveItem.getClassNames().contains(TokenValidator.class.getName()));
-    }
-
-    @Test
-    void shouldRegisterJwtTokenContentClassesForReflection() {
-        // Act
-        ReflectiveClassBuildItem reflectiveItem = processor.registerJwtTokenContentClassesForReflection();
-
-        // Assert
-        assertNotNull(reflectiveItem);
-        assertTrue(reflectiveItem.getClassNames().contains(AccessTokenContent.class.getName()));
-        assertTrue(reflectiveItem.getClassNames().contains(ClaimValue.class.getName()));
-        // Claim mappers are in separate group
-        assertFalse(reflectiveItem.getClassNames().contains(IdentityMapper.class.getName()));
-    }
-
-    @Test
-    void shouldRegisterJwtClaimMapperClassesForReflection() {
-        // Act
-        ReflectiveClassBuildItem reflectiveItem = processor.registerJwtClaimMapperClassesForReflection();
-
-        // Assert
-        assertNotNull(reflectiveItem);
-        assertTrue(reflectiveItem.getClassNames().contains(IdentityMapper.class.getName()));
-        assertTrue(reflectiveItem.getClassNames().contains(ScopeMapper.class.getName()));
-        // Token content classes are in separate group
-        assertFalse(reflectiveItem.getClassNames().contains(AccessTokenContent.class.getName()));
-    }
-
-    // REMOVED: registerBearerTokenClassesForReflection test
-    // This follows the standard: application-level classes use annotations,
-    // infrastructure/library classes use deployment processor
-
-    @Test
-    void shouldRegisterRuntimeInitializedClasses() {
-        // Act
-        RuntimeInitializedClassBuildItem runtimeItem = processor.runtimeInitializedClasses();
-
-        // Assert
-        assertNotNull(runtimeItem);
-        assertEquals(HttpJwksLoader.class.getName(), runtimeItem.getClassName());
-    }
-
-    @Test
+    @DisplayName("Should create the additional beans build item")
     void shouldCreateAdditionalBeans() {
-        // Act
         AdditionalBeanBuildItem beanItem = processor.additionalBeans();
 
-        // Assert
         assertNotNull(beanItem);
     }
 
     @Test
+    @DisplayName("Should create the DevUI card with both pages")
     void shouldCreateDevUICard() {
-        // Act
         CardPageBuildItem cardItem = processor.createJwtDevUICard();
 
-        // Assert
         assertNotNull(cardItem);
         assertFalse(cardItem.getPages().isEmpty());
         assertEquals(2, cardItem.getPages().size());
     }
 
     @Test
+    @DisplayName("Should create the DevUI JSON-RPC service")
     void shouldCreateDevUIJsonRPCService() {
-        // Act
         JsonRPCProvidersBuildItem jsonRpcItem = processor.createJwtDevUIJsonRPCService();
 
-        // Assert
         assertNotNull(jsonRpcItem);
     }
 
     @Test
+    @DisplayName("Should register unremovable beans")
     void shouldRegisterUnremovableBeans() {
-        // Arrange
         List<UnremovableBeanBuildItem> unremovableBeans = new ArrayList<>();
         BuildProducer<UnremovableBeanBuildItem> producer = unremovableBeans::add;
 
-        // Act
         processor.registerUnremovableBeans(producer);
 
-        // Assert - We produce 1 UnremovableBeanBuildItem containing 5 bean types
         assertEquals(1, unremovableBeans.size());
     }
 }

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus-deployment/src/test/java/de/cuioss/sheriff/token/quarkus/deployment/TokenSheriffProcessorBuildStepTest.java
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus-deployment/src/test/java/de/cuioss/sheriff/token/quarkus/deployment/TokenSheriffProcessorBuildStepTest.java
@@ -33,8 +33,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -82,6 +84,38 @@ class TokenSheriffProcessorBuildStepTest {
                         "Core types ship their own metadata and must not creep back into the extension"),
                 () -> assertFalse(registered.contains(AccessTokenContent.class.getName()),
                         "Core types ship their own metadata and must not creep back into the extension"));
+    }
+
+    @Test
+    @DisplayName("Should register each Quarkus-specific type with the expected reflection flags")
+    void shouldRegisterQuarkusSpecificClassesWithExpectedReflectionFlags() {
+        List<ReflectiveClassBuildItem> reflectiveItems = new ArrayList<>();
+        BuildProducer<ReflectiveClassBuildItem> producer = reflectiveItems::add;
+
+        processor.registerQuarkusSpecificClassesForReflection(producer);
+
+        Map<String, ReflectiveClassBuildItem> byClassName = new HashMap<>();
+        for (ReflectiveClassBuildItem item : reflectiveItems) {
+            for (String className : item.getClassNames()) {
+                byClassName.put(className, item);
+            }
+        }
+        assertAll("per-type reflection flags",
+                () -> assertReflectionFlags(byClassName, MeterRegistry.class, true, false, true),
+                () -> assertReflectionFlags(byClassName, JsonWebToken.class, true, true, true),
+                () -> assertReflectionFlags(byClassName, JsonWebTokenAdapter.class, true, true, true),
+                () -> assertReflectionFlags(byClassName, DiscoverableClaimMapper.class, false, false, true));
+    }
+
+    private static void assertReflectionFlags(Map<String, ReflectiveClassBuildItem> byClassName,
+            Class<?> type, boolean methods, boolean fields, boolean constructors) {
+        ReflectiveClassBuildItem item = byClassName.get(type.getName());
+        assertNotNull(item, type.getName() + " should be registered for reflection");
+        assertAll(type.getSimpleName() + " reflection flags",
+                () -> assertEquals(methods, item.isMethods(), "methods flag for " + type.getName()),
+                () -> assertEquals(fields, item.isFields(), "fields flag for " + type.getName()),
+                () -> assertEquals(constructors, item.isConstructors(),
+                        "constructors flag for " + type.getName()));
     }
 
     @Test

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus-deployment/src/test/java/de/cuioss/sheriff/token/quarkus/deployment/TokenSheriffProcessorBuildStepTest.java
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus-deployment/src/test/java/de/cuioss/sheriff/token/quarkus/deployment/TokenSheriffProcessorBuildStepTest.java
@@ -17,8 +17,6 @@ package de.cuioss.sheriff.token.quarkus.deployment;
 
 import de.cuioss.sheriff.token.quarkus.mapper.DiscoverableClaimMapper;
 import de.cuioss.sheriff.token.quarkus.producer.JsonWebTokenAdapter;
-import de.cuioss.sheriff.token.validation.TokenValidator;
-import de.cuioss.sheriff.token.validation.domain.token.AccessTokenContent;
 import de.cuioss.test.juli.junit5.EnableTestLogger;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
@@ -71,19 +69,16 @@ class TokenSheriffProcessorBuildStepTest {
         for (ReflectiveClassBuildItem item : reflectiveItems) {
             registered.addAll(item.getClassNames());
         }
-        assertAll("Quarkus-specific reflection registrations",
-                () -> assertTrue(registered.contains(MeterRegistry.class.getName()),
-                        "MeterRegistry should stay registered by the extension"),
-                () -> assertTrue(registered.contains(JsonWebToken.class.getName()),
-                        "JsonWebToken should stay registered by the extension"),
-                () -> assertTrue(registered.contains(JsonWebTokenAdapter.class.getName()),
-                        "JsonWebTokenAdapter should stay registered by the extension"),
-                () -> assertTrue(registered.contains(DiscoverableClaimMapper.class.getName()),
-                        "DiscoverableClaimMapper should stay registered by the extension"),
-                () -> assertFalse(registered.contains(TokenValidator.class.getName()),
-                        "Core types ship their own metadata and must not creep back into the extension"),
-                () -> assertFalse(registered.contains(AccessTokenContent.class.getName()),
-                        "Core types ship their own metadata and must not creep back into the extension"));
+        Set<String> expected = Set.of(
+                MeterRegistry.class.getName(),
+                JsonWebToken.class.getName(),
+                JsonWebTokenAdapter.class.getName(),
+                DiscoverableClaimMapper.class.getName());
+        assertEquals(expected, registered,
+                "The extension must register exactly its own bridge types. Core types such as "
+                        + "TokenValidator and AccessTokenContent ship their own GraalVM metadata with "
+                        + "token-sheriff-validation and must not creep back into the extension, and no "
+                        + "further type may be added here without updating this contract.");
     }
 
     @Test

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus-deployment/src/test/java/de/cuioss/sheriff/token/quarkus/deployment/TokenSheriffProcessorBuildStepTest.java
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus-deployment/src/test/java/de/cuioss/sheriff/token/quarkus/deployment/TokenSheriffProcessorBuildStepTest.java
@@ -37,11 +37,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Unit tests for {@link TokenSheriffProcessor} build step methods.

--- a/token-sheriff-validation/README.adoc
+++ b/token-sheriff-validation/README.adoc
@@ -75,6 +75,26 @@ This library uses DSL-JSON for secure, high-performance JSON parsing with config
 DSL-JSON provides compile-time code generation and actual enforcement of security constraints,
 unlike reflection-based parsers that often ignore configured limits.
 
+== Native Image
+
+The library is usable in a GraalVM native image on its own. No Quarkus extension is required to
+obtain reflection metadata — the artifact ships its own GraalVM configuration under:
+
+[source,text]
+----
+META-INF/native-image/de.cuioss.sheriff.token/token-sheriff-validation/
+----
+
+GraalVM auto-detects that directory from the jar, so the validation pipeline, JWKS loading, token
+content, claim mapping, and DSL-JSON converter types are registered for reflection without any
+application-side `reflect-config.json`. The bundled `native-image.properties` also applies
+`--initialize-at-run-time` for `HttpJwksLoader` automatically, keeping its HTTP client state out
+of the image heap.
+
+Consuming applications therefore need no Token-Sheriff-specific native-image configuration. When
+repackaging the artifact — for example into a shaded or uber jar — preserve the
+`META-INF/native-image` entries, since dropping them removes the reflection registrations.
+
 == Test Support
 
 [[test-artifact]]

--- a/token-sheriff-validation/src/main/resources/META-INF/native-image/de.cuioss.sheriff.token/token-sheriff-validation/native-image.properties
+++ b/token-sheriff-validation/src/main/resources/META-INF/native-image/de.cuioss.sheriff.token/token-sheriff-validation/native-image.properties
@@ -1,0 +1,1 @@
+Args=--initialize-at-run-time=de.cuioss.sheriff.token.validation.jwks.http.HttpJwksLoader

--- a/token-sheriff-validation/src/main/resources/META-INF/native-image/de.cuioss.sheriff.token/token-sheriff-validation/reflect-config.json
+++ b/token-sheriff-validation/src/main/resources/META-INF/native-image/de.cuioss.sheriff.token/token-sheriff-validation/reflect-config.json
@@ -1,0 +1,187 @@
+[
+  {
+    "name": "de.cuioss.sheriff.token.validation.TokenValidator",
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "de.cuioss.sheriff.token.validation.IssuerConfigCache",
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "de.cuioss.sheriff.token.commons.events.SecurityEventCounter",
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "de.cuioss.sheriff.token.validation.IssuerConfig",
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "de.cuioss.sheriff.token.commons.transport.ParserConfig",
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "de.cuioss.sheriff.token.commons.transport.HttpJwksLoaderConfig",
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "de.cuioss.sheriff.token.validation.pipeline.NonValidatingJwtParser",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "de.cuioss.sheriff.token.validation.pipeline.validator.TokenSignatureValidator",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "de.cuioss.sheriff.token.validation.pipeline.validator.TokenHeaderValidator",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "de.cuioss.sheriff.token.validation.pipeline.validator.TokenClaimValidator",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "de.cuioss.sheriff.token.validation.pipeline.TokenBuilder",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "de.cuioss.sheriff.token.validation.pipeline.DecodedJwt",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "de.cuioss.sheriff.token.validation.jwks.http.HttpJwksLoader",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "de.cuioss.sheriff.token.validation.jwks.key.JWKSKeyLoader",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "de.cuioss.sheriff.token.validation.jwks.key.KeyInfo",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "de.cuioss.sheriff.token.validation.jwks.parser.JwksParser",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "de.cuioss.sheriff.token.validation.security.SignatureAlgorithmPreferences",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "de.cuioss.sheriff.token.validation.security.JwkAlgorithmPreferences",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "de.cuioss.sheriff.token.validation.jwe.JweDecryptor",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "de.cuioss.sheriff.token.validation.jwe.JweDecryptionConfig",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "de.cuioss.sheriff.token.validation.jwe.JweAlgorithmPreferences",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "de.cuioss.sheriff.token.validation.domain.token.AccessTokenContent",
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "de.cuioss.sheriff.token.validation.domain.token.IdTokenContent",
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "de.cuioss.sheriff.token.validation.domain.token.UnvalidatedRefreshToken",
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "de.cuioss.sheriff.token.validation.domain.token.TokenContent",
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "de.cuioss.sheriff.token.validation.domain.token.BaseTokenContent",
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "de.cuioss.sheriff.token.validation.domain.token.MinimalTokenContent",
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "de.cuioss.sheriff.token.validation.domain.claim.ClaimValue",
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "de.cuioss.sheriff.token.validation.domain.claim.ClaimName",
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "de.cuioss.sheriff.token.validation.domain.claim.ClaimValueType",
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "de.cuioss.sheriff.token.validation.domain.claim.mapper.IdentityMapper",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "de.cuioss.sheriff.token.validation.domain.claim.mapper.JsonCollectionMapper",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "de.cuioss.sheriff.token.validation.domain.claim.mapper.KeycloakDefaultGroupsMapper",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "de.cuioss.sheriff.token.validation.domain.claim.mapper.KeycloakDefaultRolesMapper",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "de.cuioss.sheriff.token.validation.domain.claim.mapper.OffsetDateTimeMapper",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "de.cuioss.sheriff.token.validation.domain.claim.mapper.ScopeMapper",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "de.cuioss.sheriff.token.validation.domain.claim.mapper.StringSplitterMapper",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "de.cuioss.sheriff.token.commons.transport._WellKnownResult_DslJsonConverter",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "de.cuioss.sheriff.token.commons.transport._Jwks_DslJsonConverter",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "de.cuioss.sheriff.token.commons.transport._JwkKey_DslJsonConverter",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "de.cuioss.sheriff.token.validation.json._JwtHeader_DslJsonConverter",
+    "allDeclaredConstructors": true
+  }
+]

--- a/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/NativeImageMetadataTest.java
+++ b/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/NativeImageMetadataTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.token.validation;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+import jakarta.json.JsonValue;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Drift guard for the GraalVM native-image metadata this module ships.
+ * <p>
+ * The core library declares its own reflection contract under
+ * {@code META-INF/native-image/de.cuioss.sheriff.token/token-sheriff-validation/}, where GraalVM
+ * auto-detects it from the packaged jar. Because that contract is a hand-maintained list of class
+ * names, it can silently rot when a listed type is renamed, moved or deleted. This test resolves
+ * every listed name against the module's own classpath so such a drift fails the build here rather
+ * than at native-image build time in a downstream consumer.
+ *
+ * @author Oliver Wolff
+ */
+@DisplayName("Tests for the shipped native-image metadata")
+class NativeImageMetadataTest {
+
+    private static final String METADATA_DIR =
+            "META-INF/native-image/de.cuioss.sheriff.token/token-sheriff-validation/";
+    private static final String REFLECT_CONFIG = METADATA_DIR + "reflect-config.json";
+    private static final String NATIVE_IMAGE_PROPERTIES = METADATA_DIR + "native-image.properties";
+    private static final String CORE_PACKAGE_PREFIX = "de.cuioss.sheriff.token.";
+    private static final String RUNTIME_INITIALIZED_CLASS =
+            "de.cuioss.sheriff.token.validation.jwks.http.HttpJwksLoader";
+    private static final String NAME_ATTRIBUTE = "name";
+
+    @Nested
+    @DisplayName("reflect-config.json")
+    class ReflectConfig {
+
+        @Test
+        @DisplayName("Should parse as a JSON array of objects each carrying a name")
+        void shouldParseAsArrayOfObjectsEachCarryingAName() {
+            JsonArray entries = readReflectConfig();
+
+            assertFalse(entries.isEmpty(), "reflect-config.json should declare at least one entry");
+            List<Executable> assertions = new ArrayList<>(entries.size());
+            for (JsonValue entry : entries) {
+                assertions.add(() -> {
+                    assertEquals(JsonValue.ValueType.OBJECT, entry.getValueType(),
+                            "Entry should be a JSON object: " + entry);
+                    JsonObject object = entry.asJsonObject();
+                    assertTrue(object.containsKey(NAME_ATTRIBUTE),
+                            "Entry should carry a name attribute: " + object);
+                    assertFalse(object.getString(NAME_ATTRIBUTE).isBlank(),
+                            "Entry name should not be blank: " + object);
+                });
+            }
+            assertAll("every entry is an object carrying a non-blank name", assertions);
+        }
+
+        @Test
+        @DisplayName("Should resolve every listed name on the core module classpath")
+        void shouldResolveEveryListedNameOnTheCoreClasspath() {
+            List<String> names = registeredNames();
+
+            List<Executable> assertions = new ArrayList<>(names.size());
+            for (String name : names) {
+                assertions.add(() -> assertDoesNotThrow(
+                        () -> Class.forName(name, false, classLoader()),
+                        "Registered type is not resolvable on the core classpath: " + name));
+            }
+            assertAll("every registered type resolves", assertions);
+        }
+
+        @Test
+        @DisplayName("Should list core types only")
+        void shouldListCoreTypesOnly() {
+            List<String> names = registeredNames();
+
+            List<Executable> assertions = new ArrayList<>(names.size());
+            for (String name : names) {
+                assertions.add(() -> assertTrue(name.startsWith(CORE_PACKAGE_PREFIX),
+                        "Only core types belong in the core reflection contract: " + name));
+            }
+            assertAll("every registered type is core-owned", assertions);
+        }
+    }
+
+    @Nested
+    @DisplayName("native-image.properties")
+    class NativeImageProperties {
+
+        @Test
+        @DisplayName("Should be shipped and initialize HttpJwksLoader at run time")
+        void shouldBeShippedAndInitializeHttpJwksLoaderAtRunTime() {
+            String properties = readResource(NATIVE_IMAGE_PROPERTIES);
+
+            assertAll("runtime initialization contract",
+                    () -> assertTrue(properties.contains("--initialize-at-run-time"),
+                            "native-image.properties should declare --initialize-at-run-time"),
+                    () -> assertTrue(properties.contains(RUNTIME_INITIALIZED_CLASS),
+                            "native-image.properties should name " + RUNTIME_INITIALIZED_CLASS));
+        }
+    }
+
+    private static List<String> registeredNames() {
+        JsonArray entries = readReflectConfig();
+        List<String> names = new ArrayList<>(entries.size());
+        for (JsonValue entry : entries) {
+            names.add(entry.asJsonObject().getString(NAME_ATTRIBUTE));
+        }
+        return names;
+    }
+
+    private static JsonArray readReflectConfig() {
+        try (JsonReader reader = Json.createReader(new StringReader(readResource(REFLECT_CONFIG)))) {
+            return reader.readArray();
+        }
+    }
+
+    private static String readResource(String resource) {
+        try (InputStream stream = classLoader().getResourceAsStream(resource)) {
+            assertNotNull(stream, "Shipped native-image metadata is missing: " + resource);
+            return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Unable to read " + resource, e);
+        }
+    }
+
+    private static ClassLoader classLoader() {
+        return NativeImageMetadataTest.class.getClassLoader();
+    }
+}

--- a/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/NativeImageMetadataTest.java
+++ b/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/NativeImageMetadataTest.java
@@ -15,11 +15,7 @@
  */
 package de.cuioss.sheriff.token.validation;
 
-import jakarta.json.Json;
-import jakarta.json.JsonArray;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonReader;
-import jakarta.json.JsonValue;
+import jakarta.json.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -33,12 +29,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Drift guard for the GraalVM native-image metadata this module ships.

--- a/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/NativeImageMetadataTest.java
+++ b/token-sheriff-validation/src/test/java/de/cuioss/sheriff/token/validation/NativeImageMetadataTest.java
@@ -27,7 +27,9 @@ import java.io.StringReader;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -106,6 +108,17 @@ class NativeImageMetadataTest {
             }
             assertAll("every registered type is core-owned", assertions);
         }
+
+        @Test
+        @DisplayName("Should list every name at most once")
+        void shouldListEveryNameAtMostOnce() {
+            List<String> names = registeredNames();
+
+            Set<String> distinctNames = new HashSet<>(names);
+
+            assertEquals(distinctNames.size(), names.size(),
+                    "reflect-config.json should not declare the same name twice: " + names);
+        }
     }
 
     @Nested
@@ -117,11 +130,9 @@ class NativeImageMetadataTest {
         void shouldBeShippedAndInitializeHttpJwksLoaderAtRunTime() {
             String properties = readResource(NATIVE_IMAGE_PROPERTIES);
 
-            assertAll("runtime initialization contract",
-                    () -> assertTrue(properties.contains("--initialize-at-run-time"),
-                            "native-image.properties should declare --initialize-at-run-time"),
-                    () -> assertTrue(properties.contains(RUNTIME_INITIALIZED_CLASS),
-                            "native-image.properties should name " + RUNTIME_INITIALIZED_CLASS));
+            assertTrue(properties.contains("--initialize-at-run-time=" + RUNTIME_INITIALIZED_CLASS),
+                    "native-image.properties should declare --initialize-at-run-time="
+                            + RUNTIME_INITIALIZED_CLASS);
         }
     }
 


### PR DESCRIPTION
## Summary

`token-sheriff-validation` shipped no GraalVM native-image reflection metadata of its own — every
reflection registration for `de.cuioss.sheriff.token.validation.*` and
`de.cuioss.sheriff.token.commons.*` types was emitted only at Quarkus augmentation time by
`TokenSheriffProcessor`, so a non-Quarkus native consumer (or a Quarkus consumer that does not want the
extension's beans) had no way to obtain it. This moves the reflection contract into the core library
itself, so a single native-image-classpath jar carries the metadata regardless of how it is consumed.

## Changes

- Added `META-INF/native-image/de.cuioss.sheriff.token/token-sheriff-validation/{reflect-config.json,native-image.properties}` to `token-sheriff-validation`, GraalVM auto-detects these from any jar on the native-image classpath.
- Added `NativeImageMetadataTest` as a drift guard, asserting the core library's registered reflection names match the actual validation/commons class surface.
- Reduced `TokenSheriffProcessor` in `token-sheriff-validation-quarkus-deployment` to only the registrations that are genuinely Quarkus-specific, removing the now-duplicated core-type registrations.
- Rewrote `TokenSheriffProcessorBuildStepTest` to assert the Quarkus-only registration set.
- Documented the standalone native-image contract in `native-image-configuration.adoc` and both module `README.adoc` files.

## Test Plan

- [ ] Verification command passed (`mvn verify`)
- [ ] Manual testing completed (if applicable)

## Related Issues

Closes #617

---
Generated by plan-finalize skill

## Intent

**Problem**: `token-sheriff-validation` declared its GraalVM reflection contract nowhere in its own
jar — the Quarkus deployment processor was the sole place the metadata existed, so anything reading
`token-sheriff-validation` directly (a plain native-image build, or a Quarkus consumer that skips the
extension's beans) silently lost reflection support for its own types.

**Approach**: move the reflection contract to the module that owns the types. The core library now
ships `META-INF/native-image/.../{reflect-config.json,native-image.properties}`, which GraalVM
auto-detects from any jar on the classpath. The Quarkus processor is cut down to only the
registrations that are genuinely deployment-specific, and a new `NativeImageMetadataTest` in the core
module guards against the two lists drifting apart again by construction (there is now only one list
to drift).

**Non-goals**: this does not change any runtime reflection behavior for existing Quarkus consumers —
the augmentation-time registrations for the moved types are removed from the processor precisely
because the same names are now supplied by the jar itself, not because the classes stopped needing
reflection. It also does not attempt to generalize native-image metadata generation for any other
module.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bundled GraalVM Native Image metadata for token validation, transport, JWKS, encryption, claims, and serialization.
  * Added runtime initialization support for JWKS loading in native executables.
  * Improved Quarkus native-image registration for extension-specific components.

* **Documentation**
  * Added standalone Native Image setup, verification, repackaging, and troubleshooting guidance.
  * Updated Quarkus documentation to clarify automatic metadata discovery and extension-specific registrations.

* **Tests**
  * Added validation ensuring bundled Native Image metadata is present, valid, complete, and references available classes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->