### PR TITLE
fix(quarkus): observe the produced TokenValidator, not property namespace

### DIFF
--- a/doc/adr/0002-Observability_beans_observe_the_resolved_TokenValidator_not_the_issuer_property_namespace.adoc
+++ b/doc/adr/0002-Observability_beans_observe_the_resolved_TokenValidator_not_the_issuer_property_namespace.adoc
@@ -1,0 +1,126 @@
+= ADR-0002: Observability beans observe the resolved TokenValidator, not the issuer property namespace
+:toc: left
+:toclevels: 3
+:toc-title: Table of Contents
+:sectnums:
+:source-highlighter: highlight.js
+
+// adr-metadata
+// Progressive-disclosure metadata block (see manage-adr SKILL.md → "ADR Template
+// Structure"). Read by `manage-adr.py scan` so a caller can assess an ADR's
+// relevance without reading the full file. List fields are comma-separated.
+// summary: Observability beans resolve against the TokenValidator object actually produced (any qualifier), never against the extension's own property-derived issuer state
+// tags: quarkus-extension, cdi, observability, health-checks, metrics
+// affects: token-sheriff-validation-quarkus
+// supersedes:
+// end-adr-metadata
+
+== Status
+
+Proposed
+
+== Context
+
+A Quarkus extension that exposes a facade type over a CDI-produced dependency graph faces a recurring
+choice point wherever it also ships observability beans (health checks, metrics collectors, admin/DevUI
+panels) for that facade: **what should those beans observe** — the facade instance an embedder is actually
+using, or the extension's own configuration namespace that would normally produce one?
+
+The two answers diverge sharply whenever an embedder supplies its own, differently-qualified instance of
+the facade type instead of relying on the extension's default producer. If the observability beans inject
+the *by-products* of the extension's own producer (its derived configuration objects, its internal
+counters) rather than the facade instance in use, every one of those by-products transitively triggers the
+producer's initialization — including its property-namespace validation — even though nothing about the
+embedder's setup is actually broken. The embedder is then punished for a configuration surface it never
+intended to use: liveness/readiness report failure, a scheduled collector throws on every tick, and any
+admin panel throws on every call. The extension's own fail-fast contract, which is correct and desirable
+when its *own* namespace is populated but invalid, fires for a namespace the embedder deliberately left
+empty.
+
+The structural choice this creates is whether an extension's observability layer couples to **how the
+extension configures its own default instance** (property namespace, defaults, internal derivation) or to
+**what CDI instance is actually resolved and in use**. The former is fragile to exactly the embedding
+pattern the extension exists to support; the latter requires a resolution seam that can find "the instance
+in use" without depending on, or eagerly instantiating, the extension's own default producer.
+
+A second, subtler choice point follows from the first: once observability decouples from the extension's
+own producer, it can no longer assume anything about the resolved instance's *internal* configuration
+state unless that state is exposed on the facade's public contract. A foreign-produced instance may not
+expose everything the extension's own producer's by-products used to.
+
+== Decision
+
+Observability beans resolve and observe the CDI instance actually in use, discovered as a first-class CDI
+lookup over the facade type, rather than reconstructing or re-deriving instance state from the extension's
+own configuration namespace or its own producer's by-products.
+
+The resolution seam performs a cheap, non-instantiating configuration probe first: when the extension's own
+namespace is populated, the extension's own produced instance is the observation target and behavior is
+unchanged. When the namespace is empty, the seam enumerates every CDI bean of the facade type (any
+qualifier) via a broad `@Any`-scoped lookup, explicitly **excluding the extension's own producer bean
+class from consideration without invoking it** — inspecting the CDI bean metadata is sufficient to identify
+and skip it; nothing about that exclusion requires calling the producer. Exactly one surviving candidate is
+the observation target; more than one is treated as ambiguous (the extension cannot guess which embedder
+instance is authoritative) and resolves to the same "not configured" outcome as finding none at all.
+
+Observability beans that cannot resolve any instance — neither the extension's own nor a foreign one —
+degrade honestly rather than failing: liveness reports available/up with an explicit status marker
+distinguishing "nothing configured" from "healthy," scheduled work becomes a silent no-op instead of a
+per-tick exception, and any admin/diagnostic surface renders an explicit "not configured" state instead of
+throwing on missing fields.
+
+The facade type's public contract is the sole source of information about a foreign instance. Observability
+does not reach past the facade to reconstruct internal configuration the facade does not expose — see
+Alternatives Considered for the extension-surface option this decision deliberately declines.
+
+== Consequences
+
+=== Positive
+
+* An embedder that supplies its own instance of the facade type is never penalized by the extension's own configuration surface — the extension's default producer's fail-fast validation only fires for extension-configured deployments, exactly where it belongs.
+* Observability behavior for the extension-configured path is unchanged: the resolution seam's first branch is the extension's own producer, so no regression is introduced for the common case.
+* The resolution seam is the single place that knows how to find "the instance in use," so every consumer (health checks, metrics, diagnostics) shares one honest-degradation contract instead of each reimplementing its own tolerance for an absent configuration.
+* The extension's own producer keeps its correct fail-fast contract for its own namespace; nothing about this decision weakens that validation for extension-configured deployments.
+
+=== Negative
+
+* Observability of a foreign-produced instance is limited to what the facade's public contract exposes. Anything the extension's own producer derives internally and does not retain on the facade (e.g. per-source configuration detail) is permanently unavailable for a foreign instance under this decision.
+* The resolution seam adds one more moving part between "an instance exists" and "observability sees it" — a lookup and a memoized outcome, rather than direct injection.
+
+=== Risks
+
+* Ambiguity between multiple foreign candidates is resolved conservatively (treated as unconfigured), which means a deployment with more than one differently-qualified instance never receives targeted observability for any of them without further extension-specific disambiguation.
+* Health checks and diagnostic surfaces for a foreign instance can only ever report a coarse "detected, limited visibility" state rather than the deep verification available for the extension-configured path. This is an accepted, permanent asymmetry, not a temporary gap.
+
+== Alternatives Considered
+
+**Extend the facade's public contract with a read-only accessor for its internal configuration state.**
+This would let observability beans recover full visibility into a foreign-produced instance — enumerating
+its sources, probing its internal loaders — by reading the accessor instead of stopping at "instance
+present." Rejected: it grows the facade's public surface specifically to serve an internal-only concern
+(the extension's own diagnostics), coupling the facade's stable contract to an observability need that
+belongs entirely inside the extension. The facade is deliberately kept minimal; any consumer needing this
+depth of visibility can supply its own facade construction, which already carries full knowledge of its own
+configuration.
+
+**Keep observability coupled to the extension's own producer and its by-products, and add defensive
+try/catch or lazy-initialization guards around each consumer.** This treats the symptom per-consumer
+instead of the cause: each observability bean would need its own tolerance logic for a producer that may or
+may not be safe to trigger, duplicating the same judgment call (initialize now? initialize later? never?)
+across every consumer instead of resolving it once. It also does nothing for the embedder scenario itself —
+the beans would still be blind to the instance actually in use, merely failing more quietly.
+
+**Gate the extension's own producer at build time so it is registered only when its property namespace is
+populated.** This would prevent the producer's `@PostConstruct` failure from firing at all in the
+unconfigured case, but does not solve the underlying problem: an embedder supplying a foreign instance
+still needs observability to find and observe *that* instance, which a build-time gate on the extension's
+own producer cannot provide. It only suppresses the failure; it does not deliver the intended capability.
+
+A summary that unifies the rejected alternatives: each either grows the wrong contract's surface to serve
+an internal concern, or treats an instance-discovery problem as a defensive-coding problem. The chosen
+seam is the only option that both discovers the instance in use and keeps the facade's contract unchanged.
+
+== References
+
+* `pm-dev-java:java-cdi` — constructor injection, producer, and `Instance<T>` lookup patterns this decision's resolution seam builds on.
+* `pm-dev-java-cui:cui-logging` — the `LogRecord` / `CuiLogger` pattern used to log resolution-outcome transitions without per-tick noise.

--- a/token-sheriff-quarkus-parent/doc/development/devui-implementation.adoc
+++ b/token-sheriff-quarkus-parent/doc/development/devui-implementation.adoc
@@ -53,7 +53,24 @@ CardPageBuildItem createJwtDevUICard() {
 }
 ----
 
-The JSON-RPC service is registered via `createJwtDevUIJsonRPCService()` in `TokenSheriffProcessor.java` and provided at runtime by `TokenSheriffDevUIRuntimeService.java` (`@ApplicationScoped`, injects `TokenValidator`, `List<IssuerConfig>`, and `ParserConfig`).
+The JSON-RPC service is registered via `createJwtDevUIJsonRPCService()` in `TokenSheriffProcessor.java` and provided at runtime by `TokenSheriffDevUIRuntimeService.java` (`@ApplicationScoped`, injects a single `ObservedValidatorResolver`).
+
+The resolver reports on the `TokenValidator` actually in use, so the panel stays functional when an
+application supplies its own `TokenValidator` and leaves the `sheriff.token.issuers.*` namespace
+empty. Its three outcomes map to three view states:
+
+* `PROPERTY_CONFIGURED` — the extension's own validator; every view renders as before.
+* `EXTERNAL_VALIDATOR` — an externally-produced validator is observed. Token validation works, but
+  its issuer configurations and parser limits are not exposed, so `getJwksStatus()` reports
+  `EXTERNAL_VALIDATOR` with an empty `issuers` array and `getConfiguration()` emits a
+  `{"status": "unavailable (external validator)"}` marker for the `parser` section and for
+  `httpJwksLoader.sizeLimit`.
+* `NOT_CONFIGURED` — nothing observable. Every method returns a well-formed response rather than
+  throwing; the same two surfaces carry the `unavailable (not configured)` marker, and
+  `getHealthInfo()` reports `configurationValid=false` and `healthStatus=DOWN`.
+
+The `qwc-jwt-status-config.js` web component renders an explicit notice for the unavailability
+marker instead of the underlying field values.
 
 == JSON-RPC Methods
 

--- a/token-sheriff-quarkus-parent/doc/integration/health-checks.adoc
+++ b/token-sheriff-quarkus-parent/doc/integration/health-checks.adoc
@@ -22,9 +22,26 @@ The token-sheriff-validation-quarkus extension provides MicroProfile Health chec
   "name": "jwks-endpoints",
   "data": {
     "checkedEndpoints": 3,
+    "readiness": "READY",
     "issuer.0.url": "https://keycloak.example.com/auth/realms/master",
     "issuer.0.jwksType": "HTTP",
     "issuer.0.status": "UP"
+  }
+}
+----
+
+When no issuer configuration is observable, the check reports `UP` with `checkedEndpoints` of `0`
+and a `readiness` marker naming the resolution outcome:
+
+[source,json]
+----
+{
+  "status": "UP",
+  "name": "jwks-endpoints",
+  "data": {
+    "checkedEndpoints": 0,
+    "readiness": "EXTERNAL_VALIDATOR",
+    "loading": "COMPLETE"
   }
 }
 ----
@@ -38,7 +55,19 @@ The token-sheriff-validation-quarkus extension provides MicroProfile Health chec
 {
   "status": "UP",
   "name": "jwt-validator",
-  "data": { "issuerCount": 3 }
+  "data": { "issuerCount": 3, "status": "configured" }
+}
+----
+
+When an externally-produced `TokenValidator` is in use, or nothing is configured at all, the check
+still reports `UP` and carries the real state in the `status` data key:
+
+[source,json]
+----
+{
+  "status": "UP",
+  "name": "jwt-validator",
+  "data": { "issuerCount": 0, "status": "observing external validator" }
 }
 ----
 
@@ -74,14 +103,28 @@ readinessProbe:
 
 == Health Check Behavior
 
+Both checks consult `ObservedValidatorResolver`, which reports on the `TokenValidator` actually in
+use. It probes the `sheriff.token.issuers.*` property namespace first and, when that namespace is
+empty, looks for an externally-produced `TokenValidator` bean without instantiating the extension's
+own producer. The three resolution outcomes are `PROPERTY_CONFIGURED`, `EXTERNAL_VALIDATOR` and
+`NOT_CONFIGURED`.
+
 === JWKS Endpoint Health Check
 
 * Caches results for 30 seconds to prevent excessive network calls
 * Reports per-issuer status including URL, JWKS type, and connectivity
-* Returns DOWN if any configured JWKS endpoint has a non-OK loader status (unreachable, still initializing, or in error state)
+* Returns DOWN if any observed JWKS endpoint has a non-OK loader status (unreachable, still initializing, or in error state)
+* Short-circuits to UP with `checkedEndpoints=0` and `readiness` set to `EXTERNAL_VALIDATOR` or
+  `NOT_CONFIGURED` when no issuer configuration is observable — an unconfigured optional extension is
+  no reason to hold the whole application out of the load balancer
 
 === Token Validator Health Check
 
-* Injects `List<IssuerConfig>` and checks whether the list is non-empty
-* Returns DOWN if no issuer configurations are found
-* Lightweight check focused on configuration availability (does not inject `TokenValidator`)
+* Consults `ObservedValidatorResolver` rather than injecting the extension's produced `List<IssuerConfig>`
+* Always returns UP — an unconfigured optional extension is not a dead application
+* Reports the real state in the `status` data key: `configured`, `observing external validator`, or
+  `not configured`, alongside the observable `issuerCount`
+
+NOTE: An externally-produced `TokenValidator` does not expose its issuer configurations or its parser
+limits, so the health checks can detect it but cannot enumerate its issuers or probe its JWKS
+loaders. They report the explicit markers above rather than fabricating a verdict.

--- a/token-sheriff-quarkus-parent/doc/integration/quarkus-integration.adoc
+++ b/token-sheriff-quarkus-parent/doc/integration/quarkus-integration.adoc
@@ -27,8 +27,8 @@ Handles build-time processing:
 
 === Health Checks
 
-* `JwksEndpointHealthCheck` (`@Readiness`): Monitors JWKS endpoint connectivity
-* `TokenValidatorHealthCheck` (`@Liveness`): Checks whether issuer configurations are present
+* `JwksEndpointHealthCheck` (`@Readiness`): Monitors JWKS endpoint connectivity, short-circuiting to UP with `checkedEndpoints=0` when no issuer configuration is observable
+* `TokenValidatorHealthCheck` (`@Liveness`): Consults `ObservedValidatorResolver` and always reports UP, carrying the real state in a `status` marker
 
 Automatically discovered by Quarkus -- no explicit registration needed. See xref:health-checks.adoc[Health Checks] for details.
 

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus-deployment/src/main/java/de/cuioss/sheriff/token/quarkus/deployment/TokenSheriffProcessor.java
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus-deployment/src/main/java/de/cuioss/sheriff/token/quarkus/deployment/TokenSheriffProcessor.java
@@ -23,6 +23,7 @@ import de.cuioss.sheriff.token.quarkus.mapper.DiscoverableClaimMapper;
 import de.cuioss.sheriff.token.quarkus.mapper.keycloak.KeycloakGroupsMapperBean;
 import de.cuioss.sheriff.token.quarkus.mapper.keycloak.KeycloakRolesMapperBean;
 import de.cuioss.sheriff.token.quarkus.metrics.JwtMetricsCollector;
+import de.cuioss.sheriff.token.quarkus.observability.ObservedValidatorResolver;
 import de.cuioss.sheriff.token.quarkus.producer.BearerTokenProducer;
 import de.cuioss.sheriff.token.quarkus.producer.JsonWebTokenAdapter;
 import de.cuioss.sheriff.token.quarkus.producer.TokenValidatorProducer;
@@ -157,6 +158,8 @@ public class TokenSheriffProcessor {
                         TokenValidatorProducer.class,
                         BearerTokenProducer.class,
                         VertxServletObjectsResolver.class,
+                        // Observation target resolution for the metrics, health and DevUI beans
+                        ObservedValidatorResolver.class,
                         JwtMetricsCollector.class,
                         // CDI-based claim mapper infrastructure
                         ClaimMapperRegistry.class,

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus-deployment/src/main/resources/dev-ui/qwc-jwt-status-config.js
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus-deployment/src/main/resources/dev-ui/qwc-jwt-status-config.js
@@ -482,8 +482,39 @@ export class QwcJwtStatusConfig extends LitElement {
     `;
   }
 
+  /**
+   * Reads the section-level unavailability marker the backend emits when no parser configuration is
+   * observable, and maps it to the notice rendered in place of the parser-derived values.
+   *
+   * Both parser-derived surfaces — the Parser Configuration grid and the HTTP JWKS Loader's size
+   * limit — consume this single predicate, so the symmetric peers cannot drift apart.
+   *
+   * @returns {string|null} the notice text, or `null` when the parser values are available
+   */
+  _parserUnavailableNotice() {
+    const marker = this._configuration?.parser?.status;
+    if (!marker) {
+      return null;
+    }
+    return marker.includes('external validator') ? 'Not available — an external validator is in use' : 'Not configured';
+  }
+
   _renderParserConfiguration() {
     const config = this._configuration;
+    const notice = this._parserUnavailableNotice();
+    if (notice) {
+      return html`
+        <div class="section" data-testid="status-config-parser-section">
+          <h4 class="section-title">Parser Configuration</h4>
+          <div class="config-grid">
+            <div class="config-item">
+              <div class="config-label">Parser Limits</div>
+              <div class="config-value null" data-testid="status-config-parser-unavailable">${notice}</div>
+            </div>
+          </div>
+        </div>
+      `;
+    }
     return html`
       <div class="section" data-testid="status-config-parser-section">
         <h4 class="section-title">Parser Configuration</h4>
@@ -521,6 +552,7 @@ export class QwcJwtStatusConfig extends LitElement {
 
   _renderHttpConfiguration() {
     const config = this._configuration;
+    const notice = this._parserUnavailableNotice();
     return html`
       <div class="section" data-testid="status-config-http-section">
         <h4 class="section-title">HTTP JWKS Loader</h4>
@@ -535,7 +567,9 @@ export class QwcJwtStatusConfig extends LitElement {
           </div>
           <div class="config-item">
             <div class="config-label">Size Limit</div>
-            <div class="config-value">${config.httpJwksLoader.sizeLimit} bytes</div>
+            <div class="config-value ${notice ? 'null' : ''}" data-testid="status-config-http-size-limit">
+              ${notice ? notice : html`${config.httpJwksLoader.sizeLimit} bytes`}
+            </div>
           </div>
           <div class="config-item">
             <div class="config-label">Cache TTL</div>

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus-deployment/src/main/resources/dev-ui/qwc-jwt-status-config.js
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus-deployment/src/main/resources/dev-ui/qwc-jwt-status-config.js
@@ -476,7 +476,11 @@ export class QwcJwtStatusConfig extends LitElement {
                   })}
                 </div>
               `
-            : html`<div class="no-issuers">No issuers configured. JWT validation will not be available.</div>`
+            : jwks.status === 'EXTERNAL_VALIDATOR'
+              ? html`<div class="no-issuers">
+                  No issuer configuration is exposed — an external validator is active and handling JWT validation.
+                </div>`
+              : html`<div class="no-issuers">No issuers configured. JWT validation will not be available.</div>`
         }
       </div>
     `;

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus-deployment/src/test/js/components/qwc-jwt-status-config.test.js
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus-deployment/src/test/js/components/qwc-jwt-status-config.test.js
@@ -5,6 +5,30 @@
 import { html, LitElement } from 'lit';
 import { devui, mockScenarios, resetDevUIMocks } from '../mocks/devui.js';
 
+/**
+ * Flattens a Lit TemplateResult into the string it would render, interpolating every value and
+ * recursing into nested templates. `undefined` and `null` values stringify verbatim, which is what
+ * makes "the panel must never render the literal `undefined`" an assertable negative control.
+ *
+ * @param {unknown} value a TemplateResult, an array of them, or a plain interpolated value
+ * @returns {string} the flattened markup
+ */
+const flattenTemplate = value => {
+  if (Array.isArray(value)) {
+    return value.map(entry => flattenTemplate(entry)).join('');
+  }
+  if (value && value.strings && value.values) {
+    return value.strings.reduce(
+      (accumulator, part, index) =>
+        accumulator +
+        part +
+        (index < value.values.length ? flattenTemplate(value.values[index]) : ''),
+      ''
+    );
+  }
+  return String(value);
+};
+
 // Simplified component class for testing (mirrors the real component's logic)
 class QwcJwtStatusConfig extends LitElement {
   static properties = {
@@ -87,7 +111,126 @@ class QwcJwtStatusConfig extends LitElement {
   render() {
     const result = this._doRender();
     this._lastRenderedResult = result.strings ? result.strings.join('') : result.toString();
+    this._lastRenderedHtml = flattenTemplate(result);
     return result;
+  }
+
+  /**
+   * Mirrors the real component's shared unavailability predicate: reads the section-level marker the
+   * backend emits when no parser configuration is observable and maps it to the notice text.
+   *
+   * @returns {string|null} the notice text, or `null` when the parser values are available
+   */
+  _parserUnavailableNotice() {
+    const marker = this._configuration?.parser?.status;
+    if (!marker) {
+      return null;
+    }
+    return marker.includes('external validator')
+      ? 'Not available — an external validator is in use'
+      : 'Not configured';
+  }
+
+  /**
+   * The real backend always emits both keys; the guards keep the mirror usable for the pre-existing
+   * tests that stub a bare `{ enabled: true }` configuration.
+   *
+   * @returns {Array<unknown>} the parser and HTTP sections that apply to the current configuration
+   */
+  _renderConfigSections() {
+    const config = this._configuration;
+    return [
+      config.parser ? this._renderParserConfiguration() : '',
+      config.httpJwksLoader ? this._renderHttpConfiguration() : '',
+    ];
+  }
+
+  _renderParserConfiguration() {
+    const config = this._configuration;
+    const notice = this._parserUnavailableNotice();
+    if (notice) {
+      return html`
+        <div class="section" data-testid="status-config-parser-section">
+          <h4 class="section-title">Parser Configuration</h4>
+          <div class="config-grid">
+            <div class="config-item">
+              <div class="config-label">Parser Limits</div>
+              <div class="config-value null" data-testid="status-config-parser-unavailable">
+                ${notice}
+              </div>
+            </div>
+          </div>
+        </div>
+      `;
+    }
+    return html`
+      <div class="section" data-testid="status-config-parser-section">
+        <h4 class="section-title">Parser Configuration</h4>
+        <div class="config-grid">
+          <div class="config-item">
+            <div class="config-label">Max Token Size</div>
+            <div class="config-value">${config.parser.maxTokenSize} bytes</div>
+          </div>
+          <div class="config-item">
+            <div class="config-label">Clock Skew</div>
+            <div class="config-value">${config.parser.clockSkewSeconds} seconds</div>
+          </div>
+          <div class="config-item">
+            <div class="config-label">Require Expiration Time</div>
+            <div
+              class="config-value ${this._formatValue(config.parser.requireExpirationTime).className}"
+            >
+              ${this._formatValue(config.parser.requireExpirationTime).text}
+            </div>
+          </div>
+          <div class="config-item">
+            <div class="config-label">Require Not Before Time</div>
+            <div
+              class="config-value ${this._formatValue(config.parser.requireNotBeforeTime).className}"
+            >
+              ${this._formatValue(config.parser.requireNotBeforeTime).text}
+            </div>
+          </div>
+          <div class="config-item">
+            <div class="config-label">Require Issued At Time</div>
+            <div
+              class="config-value ${this._formatValue(config.parser.requireIssuedAtTime).className}"
+            >
+              ${this._formatValue(config.parser.requireIssuedAtTime).text}
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  _renderHttpConfiguration() {
+    const config = this._configuration;
+    const notice = this._parserUnavailableNotice();
+    return html`
+      <div class="section" data-testid="status-config-http-section">
+        <h4 class="section-title">HTTP JWKS Loader</h4>
+        <div class="config-grid">
+          <div class="config-item">
+            <div class="config-label">Connect Timeout</div>
+            <div class="config-value">${config.httpJwksLoader.connectTimeoutSeconds} seconds</div>
+          </div>
+          <div class="config-item">
+            <div class="config-label">Read Timeout</div>
+            <div class="config-value">${config.httpJwksLoader.readTimeoutSeconds} seconds</div>
+          </div>
+          <div class="config-item">
+            <div class="config-label">Size Limit</div>
+            <div
+              class="config-value ${notice ? 'null' : ''}"
+              data-testid="status-config-http-size-limit"
+            >
+              ${notice ? notice : html`${config.httpJwksLoader.sizeLimit} bytes`}
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
   }
 
   _doRender() {
@@ -171,6 +314,7 @@ class QwcJwtStatusConfig extends LitElement {
               }
             </div>
           </div>
+          ${this._renderConfigSections()}
         </div>
       </div>
     `;
@@ -585,6 +729,93 @@ describe('QwcJwtStatusConfig', () => {
 
       expect(component).not.toHaveRenderedContent('Total Security Events');
       expect(component).not.toHaveRenderedContent('Error Events');
+    });
+  });
+
+  describe('Parser Configuration — PROPERTY_CONFIGURED', () => {
+    beforeEach(async () => {
+      resetDevUIMocks();
+      mockScenarios.configurationPropertyConfigured();
+      await component._loadAllData();
+      await waitForComponentUpdate(component);
+      component.render();
+    });
+
+    it('should render the full parser grid with the real values', () => {
+      expect(component._lastRenderedHtml).toContain('Max Token Size');
+      expect(component._lastRenderedHtml).toContain('8192 bytes');
+      expect(component._lastRenderedHtml).toContain('Clock Skew');
+      expect(component._lastRenderedHtml).toContain('60 seconds');
+    });
+
+    it('should render the HTTP size limit from the parser configuration', () => {
+      expect(component._lastRenderedHtml).toContain('Size Limit');
+      expect(component._lastRenderedHtml).toContain('8192 bytes');
+    });
+
+    it('should render no unavailability notice', () => {
+      expect(component._parserUnavailableNotice()).toBeNull();
+      expect(component._lastRenderedHtml).not.toContain('status-config-parser-unavailable');
+      expect(component._lastRenderedHtml).not.toContain('undefined');
+    });
+  });
+
+  describe('Parser Configuration — EXTERNAL_VALIDATOR', () => {
+    beforeEach(async () => {
+      resetDevUIMocks();
+      mockScenarios.configurationExternalValidator();
+      await component._loadAllData();
+      await waitForComponentUpdate(component);
+      component.render();
+    });
+
+    it('should render the external-validator notice in place of the parser grid', () => {
+      expect(component._parserUnavailableNotice()).toBe(
+        'Not available — an external validator is in use'
+      );
+      expect(component._lastRenderedHtml).toContain(
+        'Not available — an external validator is in use'
+      );
+      expect(component._lastRenderedHtml).not.toContain('Max Token Size');
+    });
+
+    it('should render the same notice for the symmetric sizeLimit peer', () => {
+      expect(component._lastRenderedHtml).toContain('status-config-http-size-limit');
+      expect(component._lastRenderedHtml).not.toContain('undefined bytes');
+    });
+
+    it('should keep emitting the parser and HTTP section containers', () => {
+      expect(component._lastRenderedHtml).toContain('data-testid="status-config-parser-section"');
+      expect(component._lastRenderedHtml).toContain('data-testid="status-config-http-section"');
+    });
+
+    it('should never render the literal undefined', () => {
+      expect(component._lastRenderedHtml).not.toContain('undefined');
+    });
+  });
+
+  describe('Parser Configuration — NOT_CONFIGURED', () => {
+    beforeEach(async () => {
+      resetDevUIMocks();
+      mockScenarios.configurationNotConfigured();
+      await component._loadAllData();
+      await waitForComponentUpdate(component);
+      component.render();
+    });
+
+    it('should render the not-configured notice in place of the parser grid', () => {
+      expect(component._parserUnavailableNotice()).toBe('Not configured');
+      expect(component._lastRenderedHtml).toContain('Not configured');
+      expect(component._lastRenderedHtml).not.toContain('Max Token Size');
+    });
+
+    it('should keep emitting the parser and HTTP section containers', () => {
+      expect(component._lastRenderedHtml).toContain('data-testid="status-config-parser-section"');
+      expect(component._lastRenderedHtml).toContain('data-testid="status-config-http-section"');
+    });
+
+    it('should never render the literal undefined', () => {
+      expect(component._lastRenderedHtml).not.toContain('undefined');
     });
   });
 

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus-deployment/src/test/js/components/qwc-jwt-status-config.test.js
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus-deployment/src/test/js/components/qwc-jwt-status-config.test.js
@@ -29,6 +29,13 @@ const flattenTemplate = value => {
   return String(value);
 };
 
+/** The Issuers-section message the real component renders when an external validator is active. */
+const EXTERNAL_VALIDATOR_ISSUERS_MESSAGE =
+  'No issuer configuration is exposed — an external validator is active and handling JWT validation.';
+
+/** The Issuers-section message the real component renders when nothing is configured. */
+const NO_ISSUERS_MESSAGE = 'No issuers configured. JWT validation will not be available.';
+
 // Simplified component class for testing (mirrors the real component's logic)
 class QwcJwtStatusConfig extends LitElement {
   static properties = {
@@ -143,6 +150,37 @@ class QwcJwtStatusConfig extends LitElement {
       config.parser ? this._renderParserConfiguration() : '',
       config.httpJwksLoader ? this._renderHttpConfiguration() : '',
     ];
+  }
+
+  /**
+   * Mirrors the real component's Issuers section. The empty-issuers message is branched on the
+   * backend's resolution outcome: `EXTERNAL_VALIDATOR` means JWT validation IS active through an
+   * externally-produced validator that merely exposes no issuer configuration, so the generic
+   * "will not be available" wording would contradict the reported state.
+   *
+   * @returns {unknown} the Issuers section template
+   */
+  _renderIssuers() {
+    const jwks = this._jwksStatus;
+    return html`
+      <div class="section" data-testid="status-config-issuers-section">
+        <h4 class="section-title">Issuers</h4>
+        ${
+          jwks?.issuers && jwks.issuers.length > 0
+            ? html`<div class="issuers-grid">
+                ${jwks.issuers.map(
+                  issuer =>
+                    html`<div class="issuer-card" data-testid="status-config-issuer-card">
+                      ${issuer.name}
+                    </div>`
+                )}
+              </div>`
+            : jwks?.status === 'EXTERNAL_VALIDATOR'
+              ? html`<div class="no-issuers">${EXTERNAL_VALIDATOR_ISSUERS_MESSAGE}</div>`
+              : html`<div class="no-issuers">${NO_ISSUERS_MESSAGE}</div>`
+        }
+      </div>
+    `;
   }
 
   _renderParserConfiguration() {
@@ -314,7 +352,7 @@ class QwcJwtStatusConfig extends LitElement {
               }
             </div>
           </div>
-          ${this._renderConfigSections()}
+          ${this._renderIssuers()} ${this._renderConfigSections()}
         </div>
       </div>
     `;
@@ -792,6 +830,11 @@ describe('QwcJwtStatusConfig', () => {
     it('should never render the literal undefined', () => {
       expect(component._lastRenderedHtml).not.toContain('undefined');
     });
+
+    it('should state that an external validator is handling validation instead of claiming it is unavailable', () => {
+      expect(component._lastRenderedHtml).toContain(EXTERNAL_VALIDATOR_ISSUERS_MESSAGE);
+      expect(component._lastRenderedHtml).not.toContain(NO_ISSUERS_MESSAGE);
+    });
   });
 
   describe('Parser Configuration — NOT_CONFIGURED', () => {
@@ -816,6 +859,11 @@ describe('QwcJwtStatusConfig', () => {
 
     it('should never render the literal undefined', () => {
       expect(component._lastRenderedHtml).not.toContain('undefined');
+    });
+
+    it('should keep the generic unavailable message when nothing is configured', () => {
+      expect(component._lastRenderedHtml).toContain(NO_ISSUERS_MESSAGE);
+      expect(component._lastRenderedHtml).not.toContain(EXTERNAL_VALIDATOR_ISSUERS_MESSAGE);
     });
   });
 

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus-deployment/src/test/js/mocks/devui.js
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus-deployment/src/test/js/mocks/devui.js
@@ -248,6 +248,97 @@ export const mockScenarios = {
     });
   },
 
+  // getConfiguration with a fully populated parser section (issuer namespace configured)
+  configurationPropertyConfigured: () => {
+    devui.jsonRPC.CuiJwtDevUI.getValidationStatus.mockResolvedValue({
+      enabled: true,
+      validatorPresent: true,
+      status: 'ACTIVE',
+      statusMessage: 'JWT validation is active and ready',
+    });
+
+    devui.jsonRPC.CuiJwtDevUI.getConfiguration.mockResolvedValue({
+      enabled: true,
+      logLevel: 'INFO',
+      parser: {
+        maxTokenSize: 8192,
+        maxPayloadSize: 16_384,
+        maxStringLength: 4096,
+        clockSkewSeconds: 60,
+        requireExpirationTime: true,
+        requireNotBeforeTime: false,
+        requireIssuedAtTime: true,
+      },
+      httpJwksLoader: {
+        connectTimeoutSeconds: 'per-issuer (default: ~10s, from HttpHandler)',
+        readTimeoutSeconds: 'per-issuer (default: ~10s, from HttpHandler)',
+        sizeLimit: 8192,
+      },
+      issuers: {
+        default: {
+          issuerUri: 'https://keycloak.example.com/auth/realms/master',
+          jwksUri: 'configured',
+          clockSkewSeconds: 60,
+        },
+      },
+    });
+  },
+
+  // getConfiguration when an externally-produced TokenValidator is observed: both
+  // parserConfig-derived surfaces carry the unavailability marker and no issuer is exposed
+  configurationExternalValidator: () => {
+    devui.jsonRPC.CuiJwtDevUI.getValidationStatus.mockResolvedValue({
+      enabled: true,
+      validatorPresent: true,
+      status: 'ACTIVE',
+      statusMessage: 'JWT validation is active and ready',
+    });
+
+    devui.jsonRPC.CuiJwtDevUI.getJwksStatus.mockResolvedValue({
+      status: 'EXTERNAL_VALIDATOR',
+      issuers: [],
+    });
+
+    devui.jsonRPC.CuiJwtDevUI.getConfiguration.mockResolvedValue({
+      enabled: true,
+      logLevel: 'INFO',
+      parser: { status: 'unavailable (external validator)' },
+      httpJwksLoader: {
+        connectTimeoutSeconds: 'per-issuer (default: ~10s, from HttpHandler)',
+        readTimeoutSeconds: 'per-issuer (default: ~10s, from HttpHandler)',
+        sizeLimit: 'unavailable (external validator)',
+      },
+      issuers: {},
+    });
+  },
+
+  // getConfiguration when nothing is observable at all
+  configurationNotConfigured: () => {
+    devui.jsonRPC.CuiJwtDevUI.getValidationStatus.mockResolvedValue({
+      enabled: true,
+      validatorPresent: false,
+      status: 'NOT_CONFIGURED',
+      statusMessage: 'No TokenValidator is configured',
+    });
+
+    devui.jsonRPC.CuiJwtDevUI.getJwksStatus.mockResolvedValue({
+      status: 'NOT_CONFIGURED',
+      issuers: [],
+    });
+
+    devui.jsonRPC.CuiJwtDevUI.getConfiguration.mockResolvedValue({
+      enabled: true,
+      logLevel: 'INFO',
+      parser: { status: 'unavailable (not configured)' },
+      httpJwksLoader: {
+        connectTimeoutSeconds: 'per-issuer (default: ~10s, from HttpHandler)',
+        readTimeoutSeconds: 'per-issuer (default: ~10s, from HttpHandler)',
+        sizeLimit: 'unavailable (not configured)',
+      },
+      issuers: {},
+    });
+  },
+
   // Network error scenario
   networkError: () => {
     const networkError = new Error('Network error');

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus-deployment/src/test/js/mocks/devui.js
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus-deployment/src/test/js/mocks/devui.js
@@ -257,6 +257,19 @@ export const mockScenarios = {
       statusMessage: 'JWT validation is active and ready',
     });
 
+    devui.jsonRPC.CuiJwtDevUI.getJwksStatus.mockResolvedValue({
+      status: 'CONFIGURED',
+      issuers: [
+        {
+          name: 'default',
+          issuerUri: 'https://keycloak.example.com/auth/realms/master',
+          jwksUri: 'configured',
+          loaderStatus: 'OK',
+          lastRefresh: 'N/A',
+        },
+      ],
+    });
+
     devui.jsonRPC.CuiJwtDevUI.getConfiguration.mockResolvedValue({
       enabled: true,
       logLevel: 'INFO',
@@ -299,6 +312,12 @@ export const mockScenarios = {
       issuers: [],
     });
 
+    devui.jsonRPC.CuiJwtDevUI.getHealthInfo.mockResolvedValue({
+      configurationValid: true,
+      message: 'All JWT components are healthy and operational (EXTERNAL_VALIDATOR)',
+      healthStatus: 'UP',
+    });
+
     devui.jsonRPC.CuiJwtDevUI.getConfiguration.mockResolvedValue({
       enabled: true,
       logLevel: 'INFO',
@@ -324,6 +343,12 @@ export const mockScenarios = {
     devui.jsonRPC.CuiJwtDevUI.getJwksStatus.mockResolvedValue({
       status: 'NOT_CONFIGURED',
       issuers: [],
+    });
+
+    devui.jsonRPC.CuiJwtDevUI.getHealthInfo.mockResolvedValue({
+      configurationValid: false,
+      message: 'No TokenValidator is configured (NOT_CONFIGURED)',
+      healthStatus: 'DOWN',
     });
 
     devui.jsonRPC.CuiJwtDevUI.getConfiguration.mockResolvedValue({

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/main/java/de/cuioss/sheriff/token/quarkus/TokenSheriffQuarkusLogMessages.java
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/main/java/de/cuioss/sheriff/token/quarkus/TokenSheriffQuarkusLogMessages.java
@@ -45,7 +45,7 @@ public final class TokenSheriffQuarkusLogMessages {
     public static final String PREFIX = "TokenSheriff_Q";
 
     /**
-     * INFO level log messages (001-024; identifiers 017 and 018 are retired and must not be reused).
+     * INFO level log messages (001-025; identifiers 017 and 018 are retired and must not be reused).
      */
     @UtilityClass
     public static final class INFO {
@@ -181,10 +181,16 @@ public final class TokenSheriffQuarkusLogMessages {
                 .prefix(PREFIX)
                 .identifier(24)
                 .build();
+
+        public static final LogRecord OBSERVED_VALIDATOR_RESOLUTION = LogRecordModel.builder()
+                .template("Observed TokenValidator resolution: %s")
+                .prefix(PREFIX)
+                .identifier(25)
+                .build();
     }
 
     /**
-     * WARN level log messages (100-103).
+     * WARN level log messages (100-104).
      */
     @UtilityClass
     public static final class WARN {
@@ -211,6 +217,12 @@ public final class TokenSheriffQuarkusLogMessages {
                 .template("No Micrometer counter found for event type %s, delta %s lost")
                 .prefix(PREFIX)
                 .identifier(103)
+                .build();
+
+        public static final LogRecord AMBIGUOUS_EXTERNAL_VALIDATORS = LogRecordModel.builder()
+                .template("Multiple external TokenValidator beans found (%s) - unable to select one, reporting NOT_CONFIGURED")
+                .prefix(PREFIX)
+                .identifier(104)
                 .build();
 
     }

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/main/java/de/cuioss/sheriff/token/quarkus/config/IssuerConfigResolver.java
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/main/java/de/cuioss/sheriff/token/quarkus/config/IssuerConfigResolver.java
@@ -101,7 +101,7 @@ public class IssuerConfigResolver {
     public List<IssuerConfig> resolveIssuerConfigs() {
         LOGGER.info(INFO.RESOLVING_ISSUER_CONFIGURATIONS);
 
-        Set<String> issuerNames = discoverIssuerNames();
+        Set<String> issuerNames = discoverIssuerNames(config);
         if (issuerNames.isEmpty()) {
             throw new IllegalStateException("No issuer configurations found in properties");
         }
@@ -109,7 +109,7 @@ public class IssuerConfigResolver {
         List<IssuerConfig> enabledIssuers = new ArrayList<>();
         for (String issuerName : issuerNames) {
             LOGGER.debug("Resolving issuer configuration for %s", issuerName);
-            if (isIssuerEnabled(issuerName)) {
+            if (isIssuerEnabled(config, issuerName)) {
                 IssuerConfig issuerConfig = createIssuerConfig(issuerName);
                 enabledIssuers.add(issuerConfig);
                 LOGGER.info(INFO.RESOLVED_ISSUER_CONFIGURATION, issuerName);
@@ -127,15 +127,32 @@ public class IssuerConfigResolver {
     }
 
     /**
+     * Probes whether the {@code sheriff.token.issuers.*} namespace yields at least one enabled issuer.
+     * <p>
+     * This reads only MicroProfile {@link Config} — it builds no {@link IssuerConfig} and touches no
+     * CDI bean, so callers can ask "is the extension configured at all?" without triggering the
+     * fail-fast behavior of {@link #resolveIssuerConfigs()}.
+     * </p>
+     *
+     * @param config the configuration instance to probe
+     * @return {@code true} if at least one discovered issuer is enabled, {@code false} otherwise
+     */
+    public static boolean hasEnabledIssuers(Config config) {
+        return discoverIssuerNames(config).stream()
+                .anyMatch(issuerName -> isIssuerEnabled(config, issuerName));
+    }
+
+    /**
      * Discovers all configured issuer names by scanning properties.
      * <p>
      * Scans all property names for the issuer template pattern and extracts
      * the issuer names from matching properties.
      * </p>
      *
+     * @param config the configuration instance to scan
      * @return set of discovered issuer names
      */
-    private Set<String> discoverIssuerNames() {
+    private static Set<String> discoverIssuerNames(Config config) {
         Set<String> issuerNames = ConfigValueParser.discoverNameSegments(
                 config, JwtPropertyKeys.PREFIX + ".issuers.");
         LOGGER.debug("Discovered issuer names: %s", issuerNames);
@@ -145,10 +162,11 @@ public class IssuerConfigResolver {
     /**
      * Checks if an issuer is enabled in the configuration.
      *
+     * @param config the configuration instance to read
      * @param issuerName the issuer name
      * @return true if the issuer is enabled, false otherwise
      */
-    private boolean isIssuerEnabled(String issuerName) {
+    private static boolean isIssuerEnabled(Config config, String issuerName) {
         return config.getOptionalValue(
                 JwtPropertyKeys.ISSUERS.ENABLED.formatted(issuerName),
                 Boolean.class

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/main/java/de/cuioss/sheriff/token/quarkus/health/JwksEndpointHealthCheck.java
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/main/java/de/cuioss/sheriff/token/quarkus/health/JwksEndpointHealthCheck.java
@@ -17,6 +17,7 @@ package de.cuioss.sheriff.token.quarkus.health;
 
 import de.cuioss.sheriff.token.commons.transport.LoaderStatus;
 import de.cuioss.sheriff.token.quarkus.config.JwtPropertyKeys;
+import de.cuioss.sheriff.token.quarkus.observability.ObservedValidatorResolver;
 import de.cuioss.sheriff.token.validation.IssuerConfig;
 import de.cuioss.sheriff.token.validation.jwks.JwksLoader;
 import de.cuioss.tools.logging.CuiLogger;
@@ -38,8 +39,15 @@ import static de.cuioss.sheriff.token.quarkus.TokenSheriffQuarkusLogMessages.WAR
  * Health check for JWKS endpoint connectivity.
  * <p>
  * This class implements the SmallRye Health check interface to provide
- * readiness status for JWT validation JWKS endpoints. It only needs access
- * to the issuer configurations to check the health of their JWKS loaders.
+ * readiness status for JWT validation JWKS endpoints. It consults
+ * {@link ObservedValidatorResolver} for the issuer configurations of the validator actually in use
+ * and checks the health of their JWKS loaders.
+ * </p>
+ * <p>
+ * When no issuer configuration is observable — an externally-produced validator is in use, or
+ * nothing is configured at all — the check short-circuits to {@code UP} with
+ * {@code checkedEndpoints=0}: an unconfigured optional extension is no reason to hold the whole
+ * application out of the load balancer. The {@code readiness} data key carries the real state.
  * </p>
  *
  * @since 1.0
@@ -54,14 +62,14 @@ public class JwksEndpointHealthCheck implements HealthCheck {
     private static final String STATUS_UP = "UP";
     private static final String STATUS_DOWN = "DOWN";
 
-    private final List<IssuerConfig> issuerConfigs;
+    private final ObservedValidatorResolver resolver;
     private final ConcurrentHashMap<String, CachedResponse> healthCheckCache = new ConcurrentHashMap<>();
     private final long cacheTimeoutMillis;
 
     @Inject
-    public JwksEndpointHealthCheck(List<IssuerConfig> issuerConfigs,
+    public JwksEndpointHealthCheck(ObservedValidatorResolver resolver,
             @ConfigProperty(name = JwtPropertyKeys.HEALTH.JWKS.CACHE_SECONDS, defaultValue = DEFAULT_CACHE_SECONDS) int cacheSeconds) {
-        this.issuerConfigs = issuerConfigs;
+        this.resolver = resolver;
         this.cacheTimeoutMillis = TimeUnit.SECONDS.toMillis(cacheSeconds);
     }
 
@@ -84,9 +92,16 @@ public class JwksEndpointHealthCheck implements HealthCheck {
      * @return the health check response
      */
     private HealthCheckResponse performHealthCheck() {
-        // The produced issuer config list is guaranteed non-empty: TokenValidatorProducer
-        // fails application startup when no enabled issuer is configured.
         var responseBuilder = HealthCheckResponse.named(HEALTHCHECK_NAME).up();
+
+        List<IssuerConfig> issuerConfigs = resolver.observedIssuerConfigs();
+        if (issuerConfigs.isEmpty()) {
+            return responseBuilder
+                    .withData("checkedEndpoints", 0)
+                    .withData("readiness", resolver.outcome().name())
+                    .withData("loading", "COMPLETE")
+                    .build();
+        }
 
         var results = issuerConfigs.stream()
                 .map(issuerConfig -> EndpointResult.fromIssuerConfig(issuerConfig.getIssuerIdentifier(), issuerConfig))

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/main/java/de/cuioss/sheriff/token/quarkus/health/TokenValidatorHealthCheck.java
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/main/java/de/cuioss/sheriff/token/quarkus/health/TokenValidatorHealthCheck.java
@@ -15,21 +15,24 @@
  */
 package de.cuioss.sheriff.token.quarkus.health;
 
-import de.cuioss.sheriff.token.validation.IssuerConfig;
+import de.cuioss.sheriff.token.quarkus.observability.ObservedValidatorResolver;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.Liveness;
 
-import java.util.List;
-
 /**
  * Health check for JWT validation configuration.
  * <p>
  * This class implements the SmallRye Health check interface to provide
- * liveness status for the JWT validation component. It only needs access
- * to the issuer configurations to verify they are properly loaded.
+ * liveness status for the JWT validation component. It consults
+ * {@link ObservedValidatorResolver} to report on the validator actually in use, which may be an
+ * externally-produced one rather than the extension's own.
+ * </p>
+ * <p>
+ * Liveness is always {@code UP}: an unconfigured optional extension is not a dead application. The
+ * {@code status} data key carries the real state.
  * </p>
  *
  * @since 1.0
@@ -39,21 +42,31 @@ import java.util.List;
 public class TokenValidatorHealthCheck implements HealthCheck {
 
     private static final String HEALTHCHECK_NAME = "jwt-validator";
+    private static final String STATUS_EXTERNAL_VALIDATOR = "observing external validator";
+    private static final String STATUS_NOT_CONFIGURED = "not configured";
+    private static final String STATUS_CONFIGURED = "configured";
 
-    private final List<IssuerConfig> issuerConfigs;
+    private final ObservedValidatorResolver resolver;
 
     @Inject
-    public TokenValidatorHealthCheck(List<IssuerConfig> issuerConfigs) {
-        this.issuerConfigs = issuerConfigs;
+    public TokenValidatorHealthCheck(ObservedValidatorResolver resolver) {
+        this.resolver = resolver;
     }
 
     @Override
     public HealthCheckResponse call() {
-        // The produced issuer config list is guaranteed non-empty: TokenValidatorProducer
-        // fails application startup when no enabled issuer is configured.
         return HealthCheckResponse.named(HEALTHCHECK_NAME)
                 .up()
-                .withData("issuerCount", issuerConfigs.size())
+                .withData("issuerCount", resolver.observedIssuerConfigs().size())
+                .withData("status", statusFor(resolver.outcome()))
                 .build();
+    }
+
+    private static String statusFor(ObservedValidatorResolver.Outcome outcome) {
+        return switch (outcome) {
+            case PROPERTY_CONFIGURED -> STATUS_CONFIGURED;
+            case EXTERNAL_VALIDATOR -> STATUS_EXTERNAL_VALIDATOR;
+            case NOT_CONFIGURED -> STATUS_NOT_CONFIGURED;
+        };
     }
 }

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/main/java/de/cuioss/sheriff/token/quarkus/metrics/JwtMetricsCollector.java
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/main/java/de/cuioss/sheriff/token/quarkus/metrics/JwtMetricsCollector.java
@@ -40,6 +40,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import static de.cuioss.sheriff.token.quarkus.TokenSheriffQuarkusLogMessages.INFO;
 import static de.cuioss.sheriff.token.quarkus.TokenSheriffQuarkusLogMessages.WARN;
+import static io.quarkus.scheduler.Scheduled.ConcurrentExecution.SKIP;
 
 /**
  * Collects JWT validation metrics from {@link SecurityEventCounter} and exposes them as Micrometer metrics.
@@ -174,8 +175,14 @@ public class JwtMetricsCollector {
      * <p>
      * The interval can be configured via the property: sheriff.token.metrics.collection.interval
      * Default: 10s (production), can be set to 2s for faster integration testing.
+     * <p>
+     * Overlapping executions are skipped: the delta bookkeeping reads and writes
+     * {@code lastKnownCounts} and {@code baselinedValidator} without synchronization, so a
+     * concurrent second run could export duplicate or lost deltas.
      */
-    @Scheduled(every = "${" + JwtPropertyKeys.METRICS_COLLECTION_INTERVAL + ":10s}")
+    @Scheduled(
+            every = "${" + JwtPropertyKeys.METRICS_COLLECTION_INTERVAL + ":10s}",
+            concurrentExecution = SKIP)
     public void updateCounters() {
         updateSecurityEventCounters();
     }
@@ -201,15 +208,7 @@ public class JwtMetricsCollector {
         // Get current counts for all event types
         Map<SecurityEventCounter.EventType, Long> currentCounts = securityEventCounter.getCounters();
 
-        // Debug: Log current state for success events
-        for (SecurityEventCounter.EventType eventType : SecurityEventCounter.EventType.values()) {
-            if (eventType.getCategory() == null) {
-                long count = securityEventCounter.getCount(eventType);
-                if (count > 0) {
-                    LOGGER.debug("Success event %s has count %s", eventType.name(), count);
-                }
-            }
-        }
+        logSuccessEventCounts(securityEventCounter);
 
         // Update counters based on current counts. Iterate the union of current and
         // baseline keys: after an external reset, event types disappear from the
@@ -218,35 +217,61 @@ public class JwtMetricsCollector {
         eventTypes.addAll(lastKnownCounts.keySet());
 
         for (SecurityEventCounter.EventType eventType : eventTypes) {
-            long currentCount = currentCounts.getOrDefault(eventType, 0L);
+            applyDelta(eventType, currentCounts.getOrDefault(eventType, 0L));
+        }
+    }
 
-            // Get the last known count for this event type
-            long lastCount = lastKnownCounts.getOrDefault(eventType, 0L);
-
-            // Calculate the delta
-            long delta = currentCount - lastCount;
-
-            // Only update if there's a change
-            if (delta > 0) {
-                // Get the counter for this event type
-                Counter counter = counters.get(eventType.name());
-                if (counter != null) {
-                    // Increment the counter by the delta
-                    counter.increment(delta);
-                    LOGGER.debug("Updated counter for event type %s by %s (total: %s)", eventType.name(), delta, counter.count());
-                } else {
-                    LOGGER.warn(WARN.NO_MICROMETER_COUNTER_FOUND, eventType.name(), delta);
+    /**
+     * Logs the current count of every success-classified event type that has been recorded at least
+     * once.
+     *
+     * @param securityEventCounter the counter the observed validator exposes
+     */
+    private void logSuccessEventCounts(SecurityEventCounter securityEventCounter) {
+        for (SecurityEventCounter.EventType eventType : SecurityEventCounter.EventType.values()) {
+            if (eventType.getCategory() == null) {
+                long count = securityEventCounter.getCount(eventType);
+                if (count > 0) {
+                    LOGGER.debug("Success event %s has count %s", eventType.name(), count);
                 }
-
-                // Update the last known count
-                lastKnownCounts.put(eventType, currentCount);
-            } else if (delta < 0) {
-                // The underlying counter was reset externally — re-baseline to the current
-                // count so subsequent events are exported correctly instead of being ignored
-                LOGGER.debug("Detected external reset for event type %s (delta %s), re-baselining to %s",
-                        eventType.name(), delta, currentCount);
-                lastKnownCounts.put(eventType, currentCount);
             }
+        }
+    }
+
+    /**
+     * Exports the delta between the current and the baselined count for a single event type and
+     * updates the baseline.
+     *
+     * @param eventType    the event type to export
+     * @param currentCount the count the observed validator currently reports for that event type
+     */
+    private void applyDelta(SecurityEventCounter.EventType eventType, long currentCount) {
+        // Get the last known count for this event type
+        long lastCount = lastKnownCounts.getOrDefault(eventType, 0L);
+
+        // Calculate the delta
+        long delta = currentCount - lastCount;
+
+        // Only update if there's a change
+        if (delta > 0) {
+            // Get the counter for this event type
+            Counter counter = counters.get(eventType.name());
+            if (counter != null) {
+                // Increment the counter by the delta
+                counter.increment(delta);
+                LOGGER.debug("Updated counter for event type %s by %s (total: %s)", eventType.name(), delta, counter.count());
+            } else {
+                LOGGER.warn(WARN.NO_MICROMETER_COUNTER_FOUND, eventType.name(), delta);
+            }
+
+            // Update the last known count
+            lastKnownCounts.put(eventType, currentCount);
+        } else if (delta < 0) {
+            // The underlying counter was reset externally — re-baseline to the current
+            // count so subsequent events are exported correctly instead of being ignored
+            LOGGER.debug("Detected external reset for event type %s (delta %s), re-baselining to %s",
+                    eventType.name(), delta, currentCount);
+            lastKnownCounts.put(eventType, currentCount);
         }
     }
 

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/main/java/de/cuioss/sheriff/token/quarkus/metrics/JwtMetricsCollector.java
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/main/java/de/cuioss/sheriff/token/quarkus/metrics/JwtMetricsCollector.java
@@ -19,6 +19,8 @@ import de.cuioss.sheriff.token.commons.events.EventCategory;
 import de.cuioss.sheriff.token.commons.events.SecurityEventCounter;
 import de.cuioss.sheriff.token.commons.metrics.MetricIdentifier;
 import de.cuioss.sheriff.token.quarkus.config.JwtPropertyKeys;
+import de.cuioss.sheriff.token.quarkus.observability.ObservedValidatorResolver;
+import de.cuioss.sheriff.token.validation.TokenValidator;
 import de.cuioss.tools.logging.CuiLogger;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -29,6 +31,7 @@ import io.quarkus.scheduler.Scheduled;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import org.jspecify.annotations.Nullable;
 
 import java.util.HashSet;
 import java.util.Map;
@@ -76,7 +79,7 @@ public class JwtMetricsCollector {
     private static final String RESULT_SUCCESS = "success";
 
     private final MeterRegistry registry;
-    private final SecurityEventCounter securityEventCounter;
+    private final ObservedValidatorResolver resolver;
 
     // Caching of counters to avoid lookups
     private final Map<String, Counter> counters = new ConcurrentHashMap<>();
@@ -84,17 +87,20 @@ public class JwtMetricsCollector {
     // Track last known counts to calculate deltas
     private final Map<SecurityEventCounter.EventType, Long> lastKnownCounts = new ConcurrentHashMap<>();
 
+    // The validator whose counter the current baselines belong to; deltas are re-baselined when it changes
+    private @Nullable TokenValidator baselinedValidator;
+
     /**
-     * Creates a new JwtMetricsCollector with the given MeterRegistry and SecurityEventCounter.
+     * Creates a new JwtMetricsCollector with the given MeterRegistry and validator resolver.
      *
      * @param registry the Micrometer registry
-     * @param securityEventCounter the security event counter for monitoring validation events
+     * @param resolver resolves the validator whose security events are exported
      */
     @Inject
     public JwtMetricsCollector(MeterRegistry registry,
-            SecurityEventCounter securityEventCounter) {
+            ObservedValidatorResolver resolver) {
         this.registry = registry;
-        this.securityEventCounter = securityEventCounter;
+        this.resolver = resolver;
     }
 
     /**
@@ -175,9 +181,23 @@ public class JwtMetricsCollector {
     }
 
     /**
-     * Updates security event counters from the SecurityEventCounter state.
+     * Updates security event counters from the observed validator's SecurityEventCounter state.
+     * <p>
+     * Goes idle without throwing when no validator is observable, and re-baselines the deltas when
+     * the observed validator changes so two validators' histories are never mixed.
+     * </p>
      */
     private void updateSecurityEventCounters() {
+        TokenValidator validator = resolver.observedValidator().orElse(null);
+        if (validator == null) {
+            return;
+        }
+        if (validator != baselinedValidator) {
+            lastKnownCounts.clear();
+            baselinedValidator = validator;
+        }
+        SecurityEventCounter securityEventCounter = validator.getSecurityEventCounter();
+
         // Get current counts for all event types
         Map<SecurityEventCounter.EventType, Long> currentCounts = securityEventCounter.getCounters();
 

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/main/java/de/cuioss/sheriff/token/quarkus/observability/ObservedValidatorResolver.java
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/main/java/de/cuioss/sheriff/token/quarkus/observability/ObservedValidatorResolver.java
@@ -31,6 +31,7 @@ import org.jspecify.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static de.cuioss.sheriff.token.quarkus.TokenSheriffQuarkusLogMessages.INFO;
 import static de.cuioss.sheriff.token.quarkus.TokenSheriffQuarkusLogMessages.WARN;
@@ -112,13 +113,14 @@ public class ObservedValidatorResolver {
     Instance<ParserConfig> parserConfig) {
     }
 
-    private final @Nullable CdiHandles cdi;
-
-    private volatile Resolution resolution;
-    private volatile @Nullable Outcome lastLoggedOutcome;
-
     private static final Resolution UNRESOLVED =
             new Resolution(Outcome.NOT_CONFIGURED, null, List.of(), null);
+
+    private final @Nullable CdiHandles cdi;
+
+    private final AtomicReference<Resolution> resolution = new AtomicReference<>(UNRESOLVED);
+    private volatile @Nullable Outcome lastLoggedOutcome;
+    private final AtomicReference<List<String>> lastWarnedCandidates = new AtomicReference<>(List.of());
 
     /**
      * CDI constructor. Every producer-sourced dependency is a lazy {@link Instance} handle, so
@@ -133,7 +135,6 @@ public class ObservedValidatorResolver {
     public ObservedValidatorResolver(Config config, @Any Instance<TokenValidator> tokenValidators,
             Instance<List<IssuerConfig>> issuerConfigsHandle, Instance<ParserConfig> parserConfigHandle) {
         this.cdi = new CdiHandles(config, tokenValidators, issuerConfigsHandle, parserConfigHandle);
-        this.resolution = UNRESOLVED;
     }
 
     /**
@@ -148,7 +149,7 @@ public class ObservedValidatorResolver {
     public ObservedValidatorResolver(Outcome outcome, @Nullable TokenValidator validator,
             List<IssuerConfig> issuerConfigs, @Nullable ParserConfig parserConfig) {
         this.cdi = null;
-        this.resolution = new Resolution(outcome, validator, List.copyOf(issuerConfigs), parserConfig);
+        this.resolution.set(new Resolution(outcome, validator, List.copyOf(issuerConfigs), parserConfig));
     }
 
     /**
@@ -184,14 +185,14 @@ public class ObservedValidatorResolver {
     private Resolution resolve() {
         CdiHandles handles = cdi;
         if (handles == null) {
-            return resolution;
+            return resolution.get();
         }
-        Resolution current = resolution;
+        Resolution current = resolution.get();
         if (current.outcome() != Outcome.NOT_CONFIGURED) {
             return current;
         }
         Resolution resolved = doResolve(handles);
-        resolution = resolved;
+        resolution.set(resolved);
         return resolved;
     }
 
@@ -224,12 +225,19 @@ public class ObservedValidatorResolver {
 
     /**
      * Emits the resolution transition once per distinct outcome rather than on every probe.
+     * <p>
+     * The ambiguity warning is gated separately, on the candidate set rather than on the outcome
+     * transition: {@link Outcome#NOT_CONFIGURED} is re-resolved on every call, so an outcome-gated
+     * warning would stay silent for an ambiguity that only appears after an earlier zero-candidate
+     * probe already logged {@code NOT_CONFIGURED}.
+     * </p>
      */
     private Resolution logged(Resolution resolved, List<String> ambiguousCandidates) {
+        if (ambiguousCandidates.size() > 1 && !ambiguousCandidates.equals(lastWarnedCandidates.get())) {
+            LOGGER.warn(WARN.AMBIGUOUS_EXTERNAL_VALIDATORS, String.join(", ", ambiguousCandidates));
+            lastWarnedCandidates.set(ambiguousCandidates);
+        }
         if (resolved.outcome() != lastLoggedOutcome) {
-            if (ambiguousCandidates.size() > 1) {
-                LOGGER.warn(WARN.AMBIGUOUS_EXTERNAL_VALIDATORS, String.join(", ", ambiguousCandidates));
-            }
             LOGGER.info(INFO.OBSERVED_VALIDATOR_RESOLUTION, resolved.outcome());
             lastLoggedOutcome = resolved.outcome();
         }

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/main/java/de/cuioss/sheriff/token/quarkus/observability/ObservedValidatorResolver.java
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/main/java/de/cuioss/sheriff/token/quarkus/observability/ObservedValidatorResolver.java
@@ -92,16 +92,24 @@ public class ObservedValidatorResolver {
         NOT_CONFIGURED
     }
 
-    private record Resolution(Outcome outcome, @Nullable TokenValidator validator,
-            List<IssuerConfig> issuerConfigs, @Nullable ParserConfig parserConfig) {
+    private record Resolution(
+    Outcome outcome,
+    @Nullable
+    TokenValidator validator,
+    List<IssuerConfig> issuerConfigs,
+    @Nullable
+    ParserConfig parserConfig) {
     }
 
     /**
      * The lazily-consulted CDI dependencies. {@code null} when this resolver was constructed with an
      * already-resolved outcome, in which case no resolution ever runs.
      */
-    private record CdiHandles(Config config, Instance<TokenValidator> tokenValidators,
-            Instance<List<IssuerConfig>> issuerConfigs, Instance<ParserConfig> parserConfig) {
+    private record CdiHandles(
+    Config config,
+    Instance<TokenValidator> tokenValidators,
+    Instance<List<IssuerConfig>> issuerConfigs,
+    Instance<ParserConfig> parserConfig) {
     }
 
     private final @Nullable CdiHandles cdi;

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/main/java/de/cuioss/sheriff/token/quarkus/observability/ObservedValidatorResolver.java
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/main/java/de/cuioss/sheriff/token/quarkus/observability/ObservedValidatorResolver.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.token.quarkus.observability;
+
+import de.cuioss.sheriff.token.commons.transport.ParserConfig;
+import de.cuioss.sheriff.token.quarkus.config.IssuerConfigResolver;
+import de.cuioss.sheriff.token.quarkus.producer.TokenValidatorProducer;
+import de.cuioss.sheriff.token.validation.IssuerConfig;
+import de.cuioss.sheriff.token.validation.TokenValidator;
+import de.cuioss.tools.logging.CuiLogger;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.Config;
+import org.jspecify.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static de.cuioss.sheriff.token.quarkus.TokenSheriffQuarkusLogMessages.INFO;
+import static de.cuioss.sheriff.token.quarkus.TokenSheriffQuarkusLogMessages.WARN;
+
+/**
+ * Resolves which {@link TokenValidator} the extension's observability beans should report against.
+ * <p>
+ * The extension's own {@link TokenValidatorProducer} initializes from the
+ * {@code sheriff.token.issuers.*} property namespace and fails fast when that namespace yields no
+ * enabled issuer. Observability beans must therefore not bind to that producer's by-products:
+ * an embedder that supplies its own qualified {@code TokenValidator} and leaves the namespace
+ * unpopulated would otherwise trigger the producer's failure on every health probe, metrics tick
+ * and DevUI call.
+ * </p>
+ * <p>
+ * This resolver answers "which validator is in use, and is anything configured at all?" without
+ * eagerly instantiating the extension's producer:
+ * </p>
+ * <ol>
+ *   <li>Probe {@link IssuerConfigResolver#hasEnabledIssuers(Config)} — a pure {@link Config} read
+ *       that touches no CDI bean.</li>
+ *   <li>Namespace populated &rarr; {@link Outcome#PROPERTY_CONFIGURED}: the extension's own
+ *       produced validator, issuer configurations and parser configuration are the observation
+ *       target.</li>
+ *   <li>Namespace unpopulated &rarr; enumerate {@code @Any Instance<TokenValidator>} handles and
+ *       skip the handle whose bean class is {@link TokenValidatorProducer}. Reading a handle's bean
+ *       metadata does not instantiate it, so the failing producer is never initialized. Exactly one
+ *       surviving handle &rarr; {@link Outcome#EXTERNAL_VALIDATOR}; several &rarr; a warning naming
+ *       the candidates and {@link Outcome#NOT_CONFIGURED}.</li>
+ *   <li>Nothing found &rarr; {@link Outcome#NOT_CONFIGURED}.</li>
+ * </ol>
+ * <p>
+ * On the {@link Outcome#EXTERNAL_VALIDATOR} and {@link Outcome#NOT_CONFIGURED} outcomes
+ * {@link #observedIssuerConfigs()} is empty and {@link #observedParserConfig()} is
+ * {@link Optional#empty()}: the core {@code TokenValidator} exposes neither its issuer
+ * configurations nor its parser configuration.
+ * </p>
+ * <p>
+ * The resolution is memoized, but a {@link Outcome#NOT_CONFIGURED} outcome is re-resolved on every
+ * call so a validator that becomes available later is still picked up.
+ * </p>
+ *
+ * @since 1.0
+ */
+@ApplicationScoped
+public class ObservedValidatorResolver {
+
+    private static final CuiLogger LOGGER = new CuiLogger(ObservedValidatorResolver.class);
+
+    /**
+     * The resolution outcome.
+     */
+    public enum Outcome {
+        /** The {@code sheriff.token.issuers.*} namespace is populated; the extension's own producer is observed. */
+        PROPERTY_CONFIGURED,
+        /** The namespace is empty and exactly one foreign {@link TokenValidator} bean is observable. */
+        EXTERNAL_VALIDATOR,
+        /** Neither a configured namespace nor an unambiguous foreign validator exists. */
+        NOT_CONFIGURED
+    }
+
+    private record Resolution(Outcome outcome, @Nullable TokenValidator validator,
+            List<IssuerConfig> issuerConfigs, @Nullable ParserConfig parserConfig) {
+    }
+
+    /**
+     * The lazily-consulted CDI dependencies. {@code null} when this resolver was constructed with an
+     * already-resolved outcome, in which case no resolution ever runs.
+     */
+    private record CdiHandles(Config config, Instance<TokenValidator> tokenValidators,
+            Instance<List<IssuerConfig>> issuerConfigs, Instance<ParserConfig> parserConfig) {
+    }
+
+    private final @Nullable CdiHandles cdi;
+
+    private volatile Resolution resolution;
+    private volatile @Nullable Outcome lastLoggedOutcome;
+
+    private static final Resolution UNRESOLVED =
+            new Resolution(Outcome.NOT_CONFIGURED, null, List.of(), null);
+
+    /**
+     * CDI constructor. Every producer-sourced dependency is a lazy {@link Instance} handle, so
+     * constructing this bean instantiates nothing.
+     *
+     * @param config              the MicroProfile configuration used for the property probe
+     * @param tokenValidators     all {@link TokenValidator} beans, regardless of qualifier
+     * @param issuerConfigsHandle lazy handle to the produced issuer configurations
+     * @param parserConfigHandle  lazy handle to the produced parser configuration
+     */
+    @Inject
+    public ObservedValidatorResolver(Config config, @Any Instance<TokenValidator> tokenValidators,
+            Instance<List<IssuerConfig>> issuerConfigsHandle, Instance<ParserConfig> parserConfigHandle) {
+        this.cdi = new CdiHandles(config, tokenValidators, issuerConfigsHandle, parserConfigHandle);
+        this.resolution = UNRESOLVED;
+    }
+
+    /**
+     * Creates a resolver pinned to an already-resolved outcome, so this bean and its consumers can be
+     * exercised without a CDI container.
+     *
+     * @param outcome       the fixed resolution outcome
+     * @param validator     the observed validator, or {@code null} when nothing is observable
+     * @param issuerConfigs the observed issuer configurations
+     * @param parserConfig  the observed parser configuration, or {@code null} when unavailable
+     */
+    public ObservedValidatorResolver(Outcome outcome, @Nullable TokenValidator validator,
+            List<IssuerConfig> issuerConfigs, @Nullable ParserConfig parserConfig) {
+        this.cdi = null;
+        this.resolution = new Resolution(outcome, validator, List.copyOf(issuerConfigs), parserConfig);
+    }
+
+    /**
+     * @return the current resolution outcome
+     */
+    public Outcome outcome() {
+        return resolve().outcome();
+    }
+
+    /**
+     * @return the observed validator, or {@link Optional#empty()} when nothing is observable
+     */
+    public Optional<TokenValidator> observedValidator() {
+        return Optional.ofNullable(resolve().validator());
+    }
+
+    /**
+     * @return the observed issuer configurations; empty unless the outcome is
+     *         {@link Outcome#PROPERTY_CONFIGURED}
+     */
+    public List<IssuerConfig> observedIssuerConfigs() {
+        return resolve().issuerConfigs();
+    }
+
+    /**
+     * @return the observed parser configuration; empty unless the outcome is
+     *         {@link Outcome#PROPERTY_CONFIGURED}
+     */
+    public Optional<ParserConfig> observedParserConfig() {
+        return Optional.ofNullable(resolve().parserConfig());
+    }
+
+    private Resolution resolve() {
+        CdiHandles handles = cdi;
+        if (handles == null) {
+            return resolution;
+        }
+        Resolution current = resolution;
+        if (current.outcome() != Outcome.NOT_CONFIGURED) {
+            return current;
+        }
+        Resolution resolved = doResolve(handles);
+        resolution = resolved;
+        return resolved;
+    }
+
+    private Resolution doResolve(CdiHandles handles) {
+        Instance.Handle<TokenValidator> producerHandle = null;
+        List<Instance.Handle<TokenValidator>> foreignHandles = new ArrayList<>();
+        for (Instance.Handle<TokenValidator> handle : handles.tokenValidators().handles()) {
+            if (TokenValidatorProducer.class.equals(handle.getBean().getBeanClass())) {
+                producerHandle = handle;
+            } else {
+                foreignHandles.add(handle);
+            }
+        }
+
+        if (producerHandle != null && IssuerConfigResolver.hasEnabledIssuers(handles.config())) {
+            return logged(new Resolution(Outcome.PROPERTY_CONFIGURED, producerHandle.get(),
+                    handles.issuerConfigs().get(), handles.parserConfig().get()), List.of());
+        }
+
+        if (foreignHandles.size() == 1) {
+            return logged(new Resolution(Outcome.EXTERNAL_VALIDATOR, foreignHandles.getFirst().get(),
+                    List.of(), null), List.of());
+        }
+
+        List<String> candidates = foreignHandles.stream()
+                .map(handle -> handle.getBean().getBeanClass().getName())
+                .toList();
+        return logged(UNRESOLVED, candidates);
+    }
+
+    /**
+     * Emits the resolution transition once per distinct outcome rather than on every probe.
+     */
+    private Resolution logged(Resolution resolved, List<String> ambiguousCandidates) {
+        if (resolved.outcome() != lastLoggedOutcome) {
+            if (ambiguousCandidates.size() > 1) {
+                LOGGER.warn(WARN.AMBIGUOUS_EXTERNAL_VALIDATORS, String.join(", ", ambiguousCandidates));
+            }
+            LOGGER.info(INFO.OBSERVED_VALIDATOR_RESOLUTION, resolved.outcome());
+            lastLoggedOutcome = resolved.outcome();
+        }
+        return resolved;
+    }
+}

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/main/java/de/cuioss/sheriff/token/quarkus/runtime/TokenSheriffDevUIRuntimeService.java
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/main/java/de/cuioss/sheriff/token/quarkus/runtime/TokenSheriffDevUIRuntimeService.java
@@ -16,6 +16,7 @@
 package de.cuioss.sheriff.token.quarkus.runtime;
 
 import de.cuioss.sheriff.token.commons.transport.ParserConfig;
+import de.cuioss.sheriff.token.quarkus.observability.ObservedValidatorResolver;
 import de.cuioss.sheriff.token.validation.IssuerConfig;
 import de.cuioss.sheriff.token.validation.TokenValidator;
 import de.cuioss.sheriff.token.validation.domain.context.AccessTokenRequest;
@@ -48,24 +49,22 @@ public class TokenSheriffDevUIRuntimeService {
     private static final String CLAIMS = "claims";
     private static final String ISSUER = "issuer";
     private static final String HEALTH_STATUS = "healthStatus";
+    private static final String STATUS = "status";
+    private static final String NOT_CONFIGURED = "NOT_CONFIGURED";
+    private static final String UNAVAILABLE_EXTERNAL_VALIDATOR = "unavailable (external validator)";
+    private static final String UNAVAILABLE_NOT_CONFIGURED = "unavailable (not configured)";
 
-    private final TokenValidator tokenValidator;
-    private final List<IssuerConfig> issuerConfigs;
-    private final ParserConfig parserConfig;
+    private final ObservedValidatorResolver resolver;
 
     /**
      * Constructor for dependency injection.
      *
-     * @param tokenValidator the token validator
-     * @param issuerConfigs  the issuer configurations from TokenValidatorProducer
-     * @param parserConfig   the parser configuration from TokenValidatorProducer
+     * @param resolver resolves the validator, issuer configurations and parser configuration
+     *                 actually in use — which may belong to an externally-produced validator
      */
     @Inject
-    public TokenSheriffDevUIRuntimeService(TokenValidator tokenValidator, List<IssuerConfig> issuerConfigs,
-            ParserConfig parserConfig) {
-        this.tokenValidator = tokenValidator;
-        this.issuerConfigs = issuerConfigs;
-        this.parserConfig = parserConfig;
+    public TokenSheriffDevUIRuntimeService(ObservedValidatorResolver resolver) {
+        this.resolver = resolver;
     }
 
     /**
@@ -73,15 +72,16 @@ public class TokenSheriffDevUIRuntimeService {
      *
      * @return A map containing runtime validation status information
      */
-   
+
     public Map<String, Object> getValidationStatus() {
-        // JWT validation is always active when this service exists: TokenValidatorProducer
-        // fails application startup when no enabled issuer is configured.
+        boolean validatorPresent = resolver.observedValidator().isPresent();
         Map<String, Object> status = new HashMap<>();
         status.put("enabled", true);
-        status.put("validatorPresent", tokenValidator != null);
-        status.put("status", "ACTIVE");
-        status.put("statusMessage", "JWT validation is active and ready");
+        status.put("validatorPresent", validatorPresent);
+        status.put(STATUS, validatorPresent ? "ACTIVE" : NOT_CONFIGURED);
+        status.put("statusMessage", validatorPresent
+                ? "JWT validation is active and ready"
+                : "No TokenValidator is configured");
         return status;
     }
 
@@ -94,8 +94,8 @@ public class TokenSheriffDevUIRuntimeService {
     public Map<String, Object> getJwksStatus() {
         Map<String, Object> jwksInfo = new HashMap<>();
 
-        // The produced issuer config list is guaranteed non-empty (startup fails otherwise)
-        jwksInfo.put("status", "CONFIGURED");
+        List<IssuerConfig> issuerConfigs = resolver.observedIssuerConfigs();
+        jwksInfo.put(STATUS, issuerConfigs.isEmpty() ? resolver.outcome().name() : "CONFIGURED");
 
         // Build issuers array with details for each configured issuer
         List<Map<String, Object>> issuers = new ArrayList<>();
@@ -126,21 +126,34 @@ public class TokenSheriffDevUIRuntimeService {
         configMap.put("enabled", true);
         configMap.put("logLevel", "INFO");
 
-        // Parser configuration section — values from actual runtime config
+        List<IssuerConfig> issuerConfigs = resolver.observedIssuerConfigs();
+        ParserConfig parserConfig = resolver.observedParserConfig().orElse(null);
+        String unavailableMarker = resolver.outcome() == ObservedValidatorResolver.Outcome.EXTERNAL_VALIDATOR
+                ? UNAVAILABLE_EXTERNAL_VALIDATOR
+                : UNAVAILABLE_NOT_CONFIGURED;
+
+        // Parser configuration section — values from actual runtime config. Both this section and
+        // httpJwksLoader.sizeLimit below are parserConfig-derived, so they carry the same
+        // unavailability marker when no parser configuration is observable.
         Map<String, Object> parser = new HashMap<>();
-        parser.put("maxTokenSize", parserConfig.getMaxTokenSize());
-        parser.put("maxPayloadSize", parserConfig.getMaxPayloadSize());
-        parser.put("maxStringLength", parserConfig.getMaxStringLength());
-        // Clock skew is per-issuer; show the first issuer's value
-        // (the produced issuer config list is guaranteed non-empty)
-        parser.put("clockSkewSeconds", issuerConfigs.getFirst().getClockSkewSeconds());
+        if (parserConfig == null) {
+            parser.put(STATUS, unavailableMarker);
+        } else {
+            parser.put("maxTokenSize", parserConfig.getMaxTokenSize());
+            parser.put("maxPayloadSize", parserConfig.getMaxPayloadSize());
+            parser.put("maxStringLength", parserConfig.getMaxStringLength());
+            // Clock skew is per-issuer; show the first issuer's value when one is observable
+            if (!issuerConfigs.isEmpty()) {
+                parser.put("clockSkewSeconds", issuerConfigs.getFirst().getClockSkewSeconds());
+            }
+        }
         configMap.put("parser", parser);
 
         // HTTP JWKS loader configuration section — approximate defaults from HttpHandler (external library)
         Map<String, Object> httpJwksLoader = new HashMap<>();
         httpJwksLoader.put("connectTimeoutSeconds", "per-issuer (default: ~10s, from HttpHandler)");
         httpJwksLoader.put("readTimeoutSeconds", "per-issuer (default: ~10s, from HttpHandler)");
-        httpJwksLoader.put("sizeLimit", parserConfig.getMaxTokenSize());
+        httpJwksLoader.put("sizeLimit", parserConfig == null ? unavailableMarker : parserConfig.getMaxTokenSize());
         configMap.put("httpJwksLoader", httpJwksLoader);
 
         // Issuers configuration section
@@ -179,6 +192,13 @@ public class TokenSheriffDevUIRuntimeService {
 
         if (token == null || token.trim().isEmpty()) {
             result.put(ERROR, "Token is empty or null");
+            return result;
+        }
+
+        TokenValidator tokenValidator = resolver.observedValidator().orElse(null);
+        if (tokenValidator == null) {
+            result.put(ERROR, "No validator configured");
+            result.put("details", "No TokenValidator is configured");
             return result;
         }
 
@@ -221,12 +241,14 @@ public class TokenSheriffDevUIRuntimeService {
      */
    
     public Map<String, Object> getHealthInfo() {
-        // Configuration is always valid when this service exists: TokenValidatorProducer
-        // fails application startup when no enabled issuer is configured.
+        ObservedValidatorResolver.Outcome outcome = resolver.outcome();
+        boolean configurationValid = outcome != ObservedValidatorResolver.Outcome.NOT_CONFIGURED;
         Map<String, Object> health = new HashMap<>();
-        health.put("configurationValid", true);
-        health.put(MESSAGE, "All JWT components are healthy and operational");
-        health.put(HEALTH_STATUS, "UP");
+        health.put("configurationValid", configurationValid);
+        health.put(MESSAGE, configurationValid
+                ? "All JWT components are healthy and operational (%s)".formatted(outcome.name())
+                : "No TokenValidator is configured (%s)".formatted(outcome.name()));
+        health.put(HEALTH_STATUS, configurationValid ? "UP" : "DOWN");
         return health;
     }
 

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/main/java/de/cuioss/sheriff/token/quarkus/runtime/TokenSheriffDevUIRuntimeService.java
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/main/java/de/cuioss/sheriff/token/quarkus/runtime/TokenSheriffDevUIRuntimeService.java
@@ -50,6 +50,7 @@ public class TokenSheriffDevUIRuntimeService {
     private static final String ISSUER = "issuer";
     private static final String HEALTH_STATUS = "healthStatus";
     private static final String STATUS = "status";
+    private static final String DETAILS = "details";
     private static final String NOT_CONFIGURED = "NOT_CONFIGURED";
     private static final String UNAVAILABLE_EXTERNAL_VALIDATOR = "unavailable (external validator)";
     private static final String UNAVAILABLE_NOT_CONFIGURED = "unavailable (not configured)";
@@ -198,7 +199,7 @@ public class TokenSheriffDevUIRuntimeService {
         TokenValidator tokenValidator = resolver.observedValidator().orElse(null);
         if (tokenValidator == null) {
             result.put(ERROR, "No validator configured");
-            result.put("details", "No TokenValidator is configured");
+            result.put(DETAILS, "No TokenValidator is configured");
             return result;
         }
 
@@ -224,11 +225,11 @@ public class TokenSheriffDevUIRuntimeService {
         } catch (TokenValidationException e) {
             // Token remains invalid (default state)
             result.put(ERROR, e.getMessage());
-            result.put("details", "Access token validation failed");
+            result.put(DETAILS, "Access token validation failed");
         } catch (JsonException | IllegalArgumentException e) {
             // Handle JSON parsing errors and other token format issues
             result.put(ERROR, "Invalid token format: " + e.getMessage());
-            result.put("details", "Token format is invalid");
+            result.put(DETAILS, "Token format is invalid");
         }
 
         return result;

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/test/java/de/cuioss/sheriff/token/quarkus/config/IssuerConfigResolverTest.java
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/test/java/de/cuioss/sheriff/token/quarkus/config/IssuerConfigResolverTest.java
@@ -224,7 +224,7 @@ class IssuerConfigResolverTest {
 
             // resolveIssuerConfigs would reject the cleartext http JWKS URL; the probe must not care
             assertTrue(assertDoesNotThrow(() -> IssuerConfigResolver.hasEnabledIssuers(config),
-                            "The probe must not run builder validation"),
+                    "The probe must not run builder validation"),
                     "The enabled issuer must still be detected");
         }
     }

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/test/java/de/cuioss/sheriff/token/quarkus/config/IssuerConfigResolverTest.java
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/test/java/de/cuioss/sheriff/token/quarkus/config/IssuerConfigResolverTest.java
@@ -168,6 +168,68 @@ class IssuerConfigResolverTest {
     }
 
     @Nested
+    @DisplayName("hasEnabledIssuers Probe")
+    class HasEnabledIssuersProbe {
+
+        @Test
+        @DisplayName("should report false when no issuer names are discovered")
+        void shouldReportFalseWithoutIssuerNames() {
+            assertFalse(IssuerConfigResolver.hasEnabledIssuers(new TestConfig(Map.of())),
+                    "An empty namespace must not report enabled issuers");
+        }
+
+        @Test
+        @DisplayName("should report false when every discovered issuer is disabled")
+        void shouldReportFalseWhenAllIssuersDisabled() {
+            TestConfig config = new TestConfig(Map.of(
+                    JwtPropertyKeys.ISSUERS.ENABLED.formatted(TEST_ISSUER), "false",
+                    JwtPropertyKeys.ISSUERS.ENABLED.formatted(ANOTHER_ISSUER), "false"
+            ));
+
+            assertFalse(IssuerConfigResolver.hasEnabledIssuers(config),
+                    "A namespace whose issuers are all disabled must not report enabled issuers");
+        }
+
+        @Test
+        @DisplayName("should report false when the enabled flag is absent (default is disabled)")
+        void shouldReportFalseWhenEnabledFlagAbsent() {
+            TestConfig config = new TestConfig(Map.of(
+                    JwtPropertyKeys.ISSUERS.ISSUER_IDENTIFIER.formatted(TEST_ISSUER), "https://example.com"
+            ));
+
+            assertFalse(IssuerConfigResolver.hasEnabledIssuers(config),
+                    "An issuer without an explicit enabled=true must not count as enabled");
+        }
+
+        @Test
+        @DisplayName("should report true when at least one discovered issuer is enabled")
+        void shouldReportTrueWithOneEnabledIssuer() {
+            TestConfig config = new TestConfig(Map.of(
+                    JwtPropertyKeys.ISSUERS.ENABLED.formatted(TEST_ISSUER), "false",
+                    JwtPropertyKeys.ISSUERS.ENABLED.formatted(ANOTHER_ISSUER), "true"
+            ));
+
+            assertTrue(IssuerConfigResolver.hasEnabledIssuers(config),
+                    "A single enabled issuer must be enough to report enabled issuers");
+        }
+
+        @Test
+        @DisplayName("should not build any issuer configuration while probing")
+        void shouldNotBuildIssuerConfigsWhileProbing() {
+            TestConfig config = new TestConfig(Map.of(
+                    JwtPropertyKeys.ISSUERS.ENABLED.formatted(TEST_ISSUER), "true",
+                    JwtPropertyKeys.ISSUERS.ISSUER_IDENTIFIER.formatted(TEST_ISSUER), "http://localhost:8080/realms/test",
+                    JwtPropertyKeys.ISSUERS.JWKS_URL.formatted(TEST_ISSUER), "http://localhost:8080/jwks"
+            ));
+
+            // resolveIssuerConfigs would reject the cleartext http JWKS URL; the probe must not care
+            assertTrue(assertDoesNotThrow(() -> IssuerConfigResolver.hasEnabledIssuers(config),
+                            "The probe must not run builder validation"),
+                    "The enabled issuer must still be detected");
+        }
+    }
+
+    @Nested
     @DisplayName("Enabled Property Handling")
     @EnableTestLogger(debug = IssuerConfigResolver.class)
     class EnabledProperty {

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/test/java/de/cuioss/sheriff/token/quarkus/health/JwksEndpointHealthCheckTest.java
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/test/java/de/cuioss/sheriff/token/quarkus/health/JwksEndpointHealthCheckTest.java
@@ -19,7 +19,9 @@ import de.cuioss.sheriff.token.commons.events.SecurityEventCounter;
 import de.cuioss.sheriff.token.commons.transport.JwksType;
 import de.cuioss.sheriff.token.commons.transport.LoaderStatus;
 import de.cuioss.sheriff.token.quarkus.config.JwtTestProfile;
+import de.cuioss.sheriff.token.quarkus.observability.ObservedValidatorResolver;
 import de.cuioss.sheriff.token.validation.IssuerConfig;
+import de.cuioss.sheriff.token.validation.TokenValidator;
 import de.cuioss.sheriff.token.validation.jwks.JwksLoader;
 import de.cuioss.sheriff.token.validation.jwks.key.KeyInfo;
 import de.cuioss.test.juli.junit5.EnableTestLogger;
@@ -39,6 +41,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import static org.awaitility.Awaitility.await;
+import static org.easymock.EasyMock.createNiceMock;
 import static org.junit.jupiter.api.Assertions.*;
 
 @QuarkusTest
@@ -187,7 +190,7 @@ class JwksEndpointHealthCheckTest {
 
         // Create a health check with the error issuer config
         JwksEndpointHealthCheck errorHealthCheck = new JwksEndpointHealthCheck(
-                List.of(errorIssuerConfig), 30);
+                observing(errorIssuerConfig), 30);
 
         // Call the health check
         HealthCheckResponse response = errorHealthCheck.call();
@@ -240,7 +243,7 @@ class JwksEndpointHealthCheckTest {
 
         // Create a health check with both issuer configs
         JwksEndpointHealthCheck mixedHealthCheck = new JwksEndpointHealthCheck(
-                List.of(healthyIssuerConfig, unhealthyIssuerConfig), 30);
+                observing(healthyIssuerConfig, unhealthyIssuerConfig), 30);
 
         // Call the health check
         HealthCheckResponse response = mixedHealthCheck.call();
@@ -293,7 +296,7 @@ class JwksEndpointHealthCheckTest {
     void healthCheckCacheExpiration() {
         // Create a health check with a very short cache timeout (1 millisecond)
         JwksEndpointHealthCheck shortCacheHealthCheck = new JwksEndpointHealthCheck(
-                List.of(IssuerConfig.builder()
+                observing(IssuerConfig.builder()
                         .issuerIdentifier("cache-test-issuer")
                         .jwksLoader(new HealthyJwksLoader())
                         .audienceValidationDisabled(true)
@@ -360,7 +363,7 @@ class JwksEndpointHealthCheckTest {
 
         // Create health check with fail-fast loader
         JwksEndpointHealthCheck failFastHealthCheck = new JwksEndpointHealthCheck(
-                List.of(failFastIssuerConfig), 30);
+                observing(failFastIssuerConfig), 30);
 
         // Measure execution time to ensure it's fail-fast
         long startTime = System.currentTimeMillis();
@@ -391,6 +394,56 @@ class JwksEndpointHealthCheckTest {
         // Overall status should be DOWN due to UNDEFINED loader status
         assertEquals(HealthCheckResponse.Status.DOWN, response.getStatus(),
                 "Health check status should be DOWN with UNDEFINED loader status");
+    }
+
+    @Test
+    @DisplayName("Health check should report UP with zero endpoints when an external validator is observed")
+    void healthCheckExternalValidator() {
+        JwksEndpointHealthCheck externalHealthCheck = new JwksEndpointHealthCheck(
+                new ObservedValidatorResolver(ObservedValidatorResolver.Outcome.EXTERNAL_VALIDATOR,
+                        createNiceMock(TokenValidator.class), List.of(), null),
+                30);
+
+        HealthCheckResponse response = externalHealthCheck.call();
+
+        Map<String, Object> data = response.getData().orElseThrow();
+        assertAll("external validator readiness",
+                () -> assertEquals(HealthCheckResponse.Status.UP, response.getStatus(),
+                        "Readiness must stay UP when an external validator is in use"),
+                () -> assertEquals(0, ((Number) data.get("checkedEndpoints")).intValue(),
+                        "A foreign validator exposes no JWKS endpoints to probe"),
+                () -> assertEquals("EXTERNAL_VALIDATOR", data.get("readiness"),
+                        "readiness must name the external-validator outcome"),
+                () -> assertFalse(data.containsKey("issuer.0.url"),
+                        "No per-issuer data may be emitted without observable issuers"));
+    }
+
+    @Test
+    @DisplayName("Health check should report UP with zero endpoints when nothing is configured")
+    void healthCheckNotConfigured() {
+        JwksEndpointHealthCheck unconfiguredHealthCheck = new JwksEndpointHealthCheck(
+                new ObservedValidatorResolver(ObservedValidatorResolver.Outcome.NOT_CONFIGURED,
+                        null, List.of(), null),
+                30);
+
+        HealthCheckResponse response = unconfiguredHealthCheck.call();
+
+        Map<String, Object> data = response.getData().orElseThrow();
+        assertAll("unconfigured readiness",
+                () -> assertEquals(HealthCheckResponse.Status.UP, response.getStatus(),
+                        "An unconfigured optional extension must not hold the application out of the load balancer"),
+                () -> assertEquals(0, ((Number) data.get("checkedEndpoints")).intValue(),
+                        "Nothing is observable, so nothing is probed"),
+                () -> assertEquals("NOT_CONFIGURED", data.get("readiness"),
+                        "readiness must name the not-configured outcome"));
+    }
+
+    /**
+     * Pins a resolver to the property-configured outcome over the supplied issuer configurations.
+     */
+    private static ObservedValidatorResolver observing(IssuerConfig... issuerConfigs) {
+        return new ObservedValidatorResolver(ObservedValidatorResolver.Outcome.PROPERTY_CONFIGURED,
+                createNiceMock(TokenValidator.class), List.of(issuerConfigs), null);
     }
 
     // Mock JwksLoader implementations for testing

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/test/java/de/cuioss/sheriff/token/quarkus/health/TokenValidatorHealthCheckTest.java
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/test/java/de/cuioss/sheriff/token/quarkus/health/TokenValidatorHealthCheckTest.java
@@ -16,6 +16,8 @@
 package de.cuioss.sheriff.token.quarkus.health;
 
 import de.cuioss.sheriff.token.quarkus.config.JwtTestProfile;
+import de.cuioss.sheriff.token.quarkus.observability.ObservedValidatorResolver;
+import de.cuioss.sheriff.token.validation.TokenValidator;
 import de.cuioss.test.juli.junit5.EnableTestLogger;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
@@ -26,8 +28,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Map;
 
+import static org.easymock.EasyMock.createNiceMock;
 import static org.junit.jupiter.api.Assertions.*;
 
 @QuarkusTest
@@ -86,6 +90,9 @@ class TokenValidatorHealthCheckTest {
             int issuerCount = ((Number) issuerCountValue).intValue();
             assertTrue(issuerCount > 0,
                     "issuerCount should be greater than 0 when UP, but was: " + issuerCount);
+
+            assertEquals("configured", data.get("status"),
+                    "status should report the property-configured outcome");
         }
 
         @Test
@@ -127,6 +134,48 @@ class TokenValidatorHealthCheckTest {
 
             assertEquals(response1.getStatus(), response2.getStatus(),
                     "Response status should be consistent between calls");
+        }
+    }
+
+    @Nested
+    @DisplayName("Resolution Outcome Matrix")
+    class ResolutionOutcomeMatrix {
+
+        @Test
+        @DisplayName("should report UP with the external-validator marker when a foreign validator is observed")
+        void shouldReportExternalValidator() {
+            TokenValidatorHealthCheck check = new TokenValidatorHealthCheck(new ObservedValidatorResolver(
+                    ObservedValidatorResolver.Outcome.EXTERNAL_VALIDATOR,
+                    createNiceMock(TokenValidator.class), List.of(), null));
+
+            HealthCheckResponse response = check.call();
+
+            Map<String, Object> data = response.getData().orElseThrow();
+            assertAll("external validator liveness",
+                    () -> assertEquals(HealthCheckResponse.Status.UP, response.getStatus(),
+                            "Liveness must stay UP when an external validator is in use"),
+                    () -> assertEquals("observing external validator", data.get("status"),
+                            "status must name the external-validator outcome"),
+                    () -> assertEquals(0, ((Number) data.get("issuerCount")).intValue(),
+                            "A foreign validator exposes no issuer configurations"));
+        }
+
+        @Test
+        @DisplayName("should report UP with the not-configured marker when nothing is observable")
+        void shouldReportNotConfigured() {
+            TokenValidatorHealthCheck check = new TokenValidatorHealthCheck(new ObservedValidatorResolver(
+                    ObservedValidatorResolver.Outcome.NOT_CONFIGURED, null, List.of(), null));
+
+            HealthCheckResponse response = check.call();
+
+            Map<String, Object> data = response.getData().orElseThrow();
+            assertAll("unconfigured liveness",
+                    () -> assertEquals(HealthCheckResponse.Status.UP, response.getStatus(),
+                            "An unconfigured optional extension is not a dead application"),
+                    () -> assertEquals("not configured", data.get("status"),
+                            "status must name the not-configured outcome"),
+                    () -> assertEquals(0, ((Number) data.get("issuerCount")).intValue(),
+                            "No issuer configuration is observable"));
         }
     }
 }

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/test/java/de/cuioss/sheriff/token/quarkus/metrics/JwtMetricsCollectorRebaselineTest.java
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/test/java/de/cuioss/sheriff/token/quarkus/metrics/JwtMetricsCollectorRebaselineTest.java
@@ -17,6 +17,8 @@ package de.cuioss.sheriff.token.quarkus.metrics;
 
 import de.cuioss.sheriff.token.commons.events.SecurityEventCounter;
 import de.cuioss.sheriff.token.commons.metrics.MetricIdentifier;
+import de.cuioss.sheriff.token.quarkus.observability.ObservedValidatorResolver;
+import de.cuioss.sheriff.token.validation.TokenValidator;
 import de.cuioss.test.juli.LogAsserts;
 import de.cuioss.test.juli.TestLogLevel;
 import de.cuioss.test.juli.junit5.EnableTestLogger;
@@ -25,6 +27,11 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
+import static org.easymock.EasyMock.createNiceMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
@@ -38,6 +45,17 @@ class JwtMetricsCollectorRebaselineTest {
 
     private static final SecurityEventCounter.EventType EVENT =
             SecurityEventCounter.EventType.ACCESS_TOKEN_CREATED;
+
+    /**
+     * Pins a resolver to a validator exposing the supplied security event counter.
+     */
+    private static ObservedValidatorResolver observing(SecurityEventCounter counter) {
+        TokenValidator validator = createNiceMock(TokenValidator.class);
+        expect(validator.getSecurityEventCounter()).andStubReturn(counter);
+        replay(validator);
+        return new ObservedValidatorResolver(ObservedValidatorResolver.Outcome.PROPERTY_CONFIGURED,
+                validator, List.of(), null);
+    }
 
     private double counterValue(SimpleMeterRegistry registry) {
         return registry.find(MetricIdentifier.VALIDATION.SUCCESS)
@@ -55,7 +73,7 @@ class JwtMetricsCollectorRebaselineTest {
         securityEventCounter.increment(EVENT);
         securityEventCounter.increment(EVENT);
 
-        JwtMetricsCollector collector = new JwtMetricsCollector(registry, securityEventCounter);
+        JwtMetricsCollector collector = new JwtMetricsCollector(registry, observing(securityEventCounter));
         collector.initialize();
 
         assertEquals(2.0, counterValue(registry),
@@ -67,7 +85,7 @@ class JwtMetricsCollectorRebaselineTest {
     void rebaselinesAfterExternalReset() {
         SimpleMeterRegistry registry = new SimpleMeterRegistry();
         SecurityEventCounter securityEventCounter = new SecurityEventCounter();
-        JwtMetricsCollector collector = new JwtMetricsCollector(registry, securityEventCounter);
+        JwtMetricsCollector collector = new JwtMetricsCollector(registry, observing(securityEventCounter));
         collector.initialize();
 
         // Normal export: positive delta
@@ -94,7 +112,7 @@ class JwtMetricsCollectorRebaselineTest {
     void updateWithoutNewEventsIsNoop() {
         SimpleMeterRegistry registry = new SimpleMeterRegistry();
         SecurityEventCounter securityEventCounter = new SecurityEventCounter();
-        JwtMetricsCollector collector = new JwtMetricsCollector(registry, securityEventCounter);
+        JwtMetricsCollector collector = new JwtMetricsCollector(registry, observing(securityEventCounter));
         collector.initialize();
 
         securityEventCounter.increment(EVENT);
@@ -111,7 +129,7 @@ class JwtMetricsCollectorRebaselineTest {
     void warnsWhenNoMicrometerCounterRegistered() {
         SimpleMeterRegistry registry = new SimpleMeterRegistry();
         SecurityEventCounter securityEventCounter = new SecurityEventCounter();
-        JwtMetricsCollector collector = new JwtMetricsCollector(registry, securityEventCounter);
+        JwtMetricsCollector collector = new JwtMetricsCollector(registry, observing(securityEventCounter));
 
         // initialize() is deliberately not called: no Micrometer counters are registered
         securityEventCounter.increment(EVENT);

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/test/java/de/cuioss/sheriff/token/quarkus/metrics/JwtMetricsCollectorRebaselineTest.java
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/test/java/de/cuioss/sheriff/token/quarkus/metrics/JwtMetricsCollectorRebaselineTest.java
@@ -29,9 +29,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.easymock.EasyMock.createNiceMock;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/test/java/de/cuioss/sheriff/token/quarkus/metrics/JwtMetricsCollectorTest.java
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/test/java/de/cuioss/sheriff/token/quarkus/metrics/JwtMetricsCollectorTest.java
@@ -36,9 +36,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import static org.easymock.EasyMock.createNiceMock;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/test/java/de/cuioss/sheriff/token/quarkus/metrics/JwtMetricsCollectorTest.java
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/test/java/de/cuioss/sheriff/token/quarkus/metrics/JwtMetricsCollectorTest.java
@@ -19,6 +19,7 @@ import de.cuioss.sheriff.token.commons.events.SecurityEventCounter;
 import de.cuioss.sheriff.token.commons.events.SecurityEventCounter.EventType;
 import de.cuioss.sheriff.token.commons.metrics.MetricIdentifier;
 import de.cuioss.sheriff.token.quarkus.config.JwtTestProfile;
+import de.cuioss.sheriff.token.quarkus.observability.ObservedValidatorResolver;
 import de.cuioss.sheriff.token.validation.TokenValidator;
 import de.cuioss.test.juli.junit5.EnableTestLogger;
 import io.micrometer.core.instrument.Counter;
@@ -31,8 +32,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
+import static org.easymock.EasyMock.createNiceMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -128,7 +134,7 @@ class JwtMetricsCollectorTest {
         // composite and the scheduled update would interfere with delta assertions)
         SecurityEventCounter securityEventCounter = new SecurityEventCounter();
         SimpleMeterRegistry localRegistry = new SimpleMeterRegistry();
-        JwtMetricsCollector localCollector = new JwtMetricsCollector(localRegistry, securityEventCounter);
+        JwtMetricsCollector localCollector = new JwtMetricsCollector(localRegistry, observing(securityEventCounter));
         localCollector.initialize();
 
         // Record some events and export them
@@ -169,7 +175,7 @@ class JwtMetricsCollectorTest {
         preInitCounter.increment(testEventType);
 
         SimpleMeterRegistry localRegistry = new SimpleMeterRegistry();
-        JwtMetricsCollector localCollector = new JwtMetricsCollector(localRegistry, preInitCounter);
+        JwtMetricsCollector localCollector = new JwtMetricsCollector(localRegistry, observing(preInitCounter));
         localCollector.initialize();
 
         Counter metricCounter = localRegistry.find(MetricIdentifier.VALIDATION.ERRORS)
@@ -178,5 +184,92 @@ class JwtMetricsCollectorTest {
         assertNotNull(metricCounter, "Counter should exist");
         assertEquals(2.0, metricCounter.count(),
                 "Pre-initialization events must be exported as deltas, not silently dropped");
+    }
+
+    @Test
+    @DisplayName("Should go idle without throwing when no validator is observable")
+    void shouldBeSilentNoOpWhenNothingObservable() {
+        SimpleMeterRegistry localRegistry = new SimpleMeterRegistry();
+        JwtMetricsCollector localCollector = new JwtMetricsCollector(localRegistry,
+                new ObservedValidatorResolver(ObservedValidatorResolver.Outcome.NOT_CONFIGURED,
+                        null, List.of(), null));
+
+        assertDoesNotThrow(localCollector::initialize,
+                "Initialization must register counters without touching a validator");
+        assertDoesNotThrow(localCollector::updateCounters,
+                "A scheduled tick must go idle instead of throwing when nothing is observable");
+
+        Counter metricCounter = localRegistry.find(MetricIdentifier.VALIDATION.ERRORS)
+                .tag("event_type", EventType.SIGNATURE_VALIDATION_FAILED.name())
+                .counter();
+        assertNotNull(metricCounter, "Counters are registered regardless of the resolution outcome");
+        assertEquals(0.0, metricCounter.count(), "No event may be exported when nothing is observable");
+    }
+
+    @Test
+    @DisplayName("Should re-baseline when the observed validator changes between ticks")
+    void shouldRebaselineWhenObservedValidatorChanges() {
+        EventType testEventType = EventType.SIGNATURE_VALIDATION_FAILED;
+        SecurityEventCounter firstCounter = new SecurityEventCounter();
+        firstCounter.increment(testEventType);
+
+        SimpleMeterRegistry localRegistry = new SimpleMeterRegistry();
+        SwitchableResolver resolver = new SwitchableResolver(observing(firstCounter));
+        JwtMetricsCollector localCollector = new JwtMetricsCollector(localRegistry, resolver);
+        localCollector.initialize();
+
+        Counter metricCounter = localRegistry.find(MetricIdentifier.VALIDATION.ERRORS)
+                .tag("event_type", testEventType.name())
+                .counter();
+        assertNotNull(metricCounter, "Counter should exist");
+        assertEquals(1.0, metricCounter.count(), "The first validator's single event should be exported");
+
+        // A different validator carrying a lower count must not be read against the old baseline
+        SecurityEventCounter secondCounter = new SecurityEventCounter();
+        secondCounter.increment(testEventType);
+        resolver.switchTo(observing(secondCounter));
+        localCollector.updateCounters();
+
+        assertEquals(2.0, metricCounter.count(),
+                "The new validator's event must be exported against a fresh baseline");
+    }
+
+    /**
+     * A resolver whose delegate can be swapped, standing in for a validator that changes between
+     * scheduled ticks.
+     */
+    private static final class SwitchableResolver extends ObservedValidatorResolver {
+
+        private ObservedValidatorResolver delegate;
+
+        SwitchableResolver(ObservedValidatorResolver delegate) {
+            super(Outcome.NOT_CONFIGURED, null, List.of(), null);
+            this.delegate = delegate;
+        }
+
+        void switchTo(ObservedValidatorResolver next) {
+            this.delegate = next;
+        }
+
+        @Override
+        public Outcome outcome() {
+            return delegate.outcome();
+        }
+
+        @Override
+        public Optional<TokenValidator> observedValidator() {
+            return delegate.observedValidator();
+        }
+    }
+
+    /**
+     * Pins a resolver to a validator exposing the supplied security event counter.
+     */
+    private static ObservedValidatorResolver observing(SecurityEventCounter counter) {
+        TokenValidator validator = createNiceMock(TokenValidator.class);
+        expect(validator.getSecurityEventCounter()).andStubReturn(counter);
+        replay(validator);
+        return new ObservedValidatorResolver(ObservedValidatorResolver.Outcome.PROPERTY_CONFIGURED,
+                validator, List.of(), null);
     }
 }

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/test/java/de/cuioss/sheriff/token/quarkus/observability/ForeignValidatorObservabilityTest.java
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/test/java/de/cuioss/sheriff/token/quarkus/observability/ForeignValidatorObservabilityTest.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.token.quarkus.observability;
+
+import de.cuioss.sheriff.token.commons.events.SecurityEventCounter;
+import de.cuioss.sheriff.token.commons.transport.ParserConfig;
+import de.cuioss.sheriff.token.quarkus.health.JwksEndpointHealthCheck;
+import de.cuioss.sheriff.token.quarkus.health.TokenValidatorHealthCheck;
+import de.cuioss.sheriff.token.quarkus.metrics.JwtMetricsCollector;
+import de.cuioss.sheriff.token.quarkus.runtime.TokenSheriffDevUIRuntimeService;
+import de.cuioss.sheriff.token.validation.TokenType;
+import de.cuioss.sheriff.token.validation.TokenValidator;
+import de.cuioss.sheriff.token.validation.test.TestTokenHolder;
+import de.cuioss.sheriff.token.validation.test.generator.ClaimControlParameter;
+import de.cuioss.test.juli.junit5.EnableTestLogger;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+import jakarta.inject.Qualifier;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Liveness;
+import org.eclipse.microprofile.health.Readiness;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Container-level regression test for the embedder scenario reported in issue #641: the
+ * {@code sheriff.token.issuers.*} namespace is empty and the application supplies its own
+ * differently-qualified {@link TokenValidator}.
+ * <p>
+ * Before the fix every observability bean injected {@code TokenValidatorProducer}'s by-products,
+ * which forced that producer's {@code @PostConstruct init()} to run and throw
+ * {@code IllegalStateException("No issuer configurations found in properties")} — liveness and
+ * readiness reported {@code DOWN}, the scheduled metrics collector threw on every tick, and every
+ * DevUI JSON-RPC call threw.
+ * <p>
+ * The assertions here run against the container's own wiring rather than hand-constructed beans, so
+ * they exercise the real injection points. The resolver reporting
+ * {@link ObservedValidatorResolver.Outcome#EXTERNAL_VALIDATOR} is the structural evidence that the
+ * extension's own producer was never instantiated: had it been, the resolution would have failed
+ * with that {@code IllegalStateException} instead of degrading honestly.
+ */
+@QuarkusTest
+@TestProfile(ForeignValidatorObservabilityTest.ForeignValidatorProfile.class)
+@EnableTestLogger
+@DisplayName("Foreign TokenValidator observability")
+class ForeignValidatorObservabilityTest {
+
+    /**
+     * Mirrors an embedder's own qualifier (e.g. API Sheriff's {@code @GatewayValidator}).
+     */
+    @Qualifier
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface GatewayValidator {
+    }
+
+    /**
+     * Test-only producer of a differently-qualified {@link TokenValidator}. It carries no
+     * {@code @Priority}: a prioritized alternative is enabled GLOBALLY, which would leak this second
+     * validator bean into every other test's application. Enabling it solely through
+     * {@link ForeignValidatorProfile#getEnabledAlternatives()} keeps it scoped to this profile.
+     */
+    @Alternative
+    @ApplicationScoped
+    public static class ForeignValidatorProducer {
+
+        @Produces
+        @ApplicationScoped
+        @GatewayValidator
+        TokenValidator gatewayValidator() {
+            TestTokenHolder tokenHolder = new TestTokenHolder(TokenType.ACCESS_TOKEN,
+                    ClaimControlParameter.defaultForTokenType(TokenType.ACCESS_TOKEN));
+            return TokenValidator.builder()
+                    .parserConfig(ParserConfig.builder().build())
+                    .issuerConfig(tokenHolder.getIssuerConfig())
+                    .build();
+        }
+    }
+
+    /**
+     * Supplies no {@code sheriff.token.issuers.*} property at all and enables the foreign producer.
+     */
+    public static class ForeignValidatorProfile implements QuarkusTestProfile {
+
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of();
+        }
+
+        @Override
+        public Set<Class<?>> getEnabledAlternatives() {
+            return Set.of(ForeignValidatorProducer.class);
+        }
+    }
+
+    @Inject
+    ObservedValidatorResolver resolver;
+
+    @Inject
+    @GatewayValidator
+    TokenValidator foreignValidator;
+
+    @Inject
+    @Liveness
+    TokenValidatorHealthCheck livenessCheck;
+
+    @Inject
+    @Readiness
+    JwksEndpointHealthCheck readinessCheck;
+
+    @Inject
+    JwtMetricsCollector metricsCollector;
+
+    @Inject
+    TokenSheriffDevUIRuntimeService devUiService;
+
+    @Test
+    @DisplayName("resolves the foreign validator without instantiating the extension's producer")
+    void resolvesForeignValidator() {
+        assertAll("foreign validator resolution",
+                () -> assertEquals(ObservedValidatorResolver.Outcome.EXTERNAL_VALIDATOR, resolver.outcome(),
+                        "An empty namespace plus one foreign validator must resolve to EXTERNAL_VALIDATOR"),
+                () -> assertSame(foreignValidator, resolver.observedValidator().orElseThrow(),
+                        "The foreign validator must be the observation target"),
+                () -> assertTrue(resolver.observedIssuerConfigs().isEmpty(),
+                        "A foreign validator exposes no issuer configurations"),
+                () -> assertTrue(resolver.observedParserConfig().isEmpty(),
+                        "A foreign validator exposes no parser configuration"));
+    }
+
+    @Test
+    @DisplayName("liveness reports UP with the external-validator marker instead of DOWN")
+    void livenessReportsUp() {
+        HealthCheckResponse response = livenessCheck.call();
+
+        assertAll("liveness",
+                () -> assertEquals(HealthCheckResponse.Status.UP, response.getStatus(),
+                        "Liveness must not report DOWN for an embedder-supplied validator"),
+                () -> assertEquals("observing external validator",
+                        response.getData().orElseThrow().get("status"),
+                        "status must name the external-validator outcome"));
+    }
+
+    @Test
+    @DisplayName("readiness reports UP with zero checked endpoints instead of DOWN")
+    void readinessReportsUp() {
+        HealthCheckResponse response = readinessCheck.call();
+
+        Map<String, Object> data = response.getData().orElseThrow();
+        assertAll("readiness",
+                () -> assertEquals(HealthCheckResponse.Status.UP, response.getStatus(),
+                        "Readiness must not hold the application out of the load balancer"),
+                () -> assertEquals(0, ((Number) data.get("checkedEndpoints")).intValue(),
+                        "A foreign validator exposes no JWKS endpoints to probe"),
+                () -> assertEquals("EXTERNAL_VALIDATOR", data.get("readiness"),
+                        "readiness must name the external-validator outcome"));
+    }
+
+    @Test
+    @DisplayName("the scheduled metrics tick runs without throwing when an external validator is in use")
+    void metricsTickDoesNotThrow() {
+        assertDoesNotThrow(metricsCollector::updateCounters,
+                "The scheduled tick threw on every interval before the fix");
+    }
+
+    @Test
+    @DisplayName("the collector's counter source is the foreign validator's SecurityEventCounter")
+    void collectorObservesForeignCounters() {
+        // The collector reads getSecurityEventCounter() off the resolver's observed validator, so
+        // establishing that this container's resolution points at the foreign validator's own counter
+        // is what proves the collector exports the validator in use. The Micrometer delta/export
+        // mechanics on top of that counter are asserted deterministically in JwtMetricsCollectorTest
+        // against a local SimpleMeterRegistry — the injected registry is a composite with no child
+        // registry in this module's test scope, so its counters are permanent no-ops.
+        SecurityEventCounter observedCounter = resolver.observedValidator().orElseThrow()
+                .getSecurityEventCounter();
+        SecurityEventCounter.EventType eventType = SecurityEventCounter.EventType.SIGNATURE_VALIDATION_FAILED;
+        long before = observedCounter.getCount(eventType);
+
+        foreignValidator.getSecurityEventCounter().increment(eventType);
+
+        assertAll("observed counter",
+                () -> assertSame(foreignValidator.getSecurityEventCounter(), observedCounter,
+                        "The collector must read the foreign validator's own SecurityEventCounter"),
+                () -> assertEquals(before + 1, observedCounter.getCount(eventType),
+                        "An event recorded on the foreign validator must be visible to the collector"));
+    }
+
+    @Test
+    @DisplayName("every DevUI JSON-RPC method returns the external-validator view state without throwing")
+    void devUiReportsExternalValidatorViewState() {
+        Map<String, Object> validationStatus = assertDoesNotThrow(devUiService::getValidationStatus);
+        Map<String, Object> jwksStatus = assertDoesNotThrow(devUiService::getJwksStatus);
+        Map<String, Object> configuration = assertDoesNotThrow(devUiService::getConfiguration);
+        Map<String, Object> health = assertDoesNotThrow(devUiService::getHealthInfo);
+        Map<String, Object> validation = assertDoesNotThrow(() -> devUiService.validateToken("not-a-jwt"));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> parser = (Map<String, Object>) configuration.get("parser");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> httpJwksLoader = (Map<String, Object>) configuration.get("httpJwksLoader");
+
+        assertAll("DevUI view state",
+                () -> assertEquals("ACTIVE", validationStatus.get("status"),
+                        "A foreign validator is still an active validator"),
+                () -> assertEquals("EXTERNAL_VALIDATOR", jwksStatus.get("status"),
+                        "JWKS status must name the external-validator outcome"),
+                () -> assertEquals("unavailable (external validator)", parser.get("status"),
+                        "The parser section must carry the unavailability marker"),
+                () -> assertEquals("unavailable (external validator)", httpJwksLoader.get("sizeLimit"),
+                        "sizeLimit is the symmetric peer and carries the same marker"),
+                () -> assertEquals("UP", health.get("healthStatus"),
+                        "Health stays UP while a validator is observable"),
+                () -> assertEquals(false, validation.get("valid"),
+                        "A malformed token is rejected rather than throwing"));
+    }
+}

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/test/java/de/cuioss/sheriff/token/quarkus/observability/ObservedValidatorResolverTest.java
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/test/java/de/cuioss/sheriff/token/quarkus/observability/ObservedValidatorResolverTest.java
@@ -35,9 +35,7 @@ import java.util.List;
 import java.util.Map;
 
 import static de.cuioss.test.juli.LogAsserts.assertLogMessagePresentContaining;
-import static org.easymock.EasyMock.createNiceMock;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/test/java/de/cuioss/sheriff/token/quarkus/observability/ObservedValidatorResolverTest.java
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/test/java/de/cuioss/sheriff/token/quarkus/observability/ObservedValidatorResolverTest.java
@@ -141,6 +141,29 @@ class ObservedValidatorResolverTest {
         }
 
         @Test
+        @DisplayName("should warn about an ambiguity that only appears after an earlier zero-candidate probe")
+        void shouldWarnOnAmbiguityAfterEarlierNotConfiguredProbe() {
+            List<Instance.Handle<TokenValidator>> handles = new ArrayList<>();
+            handles.add(new RecordingHandle(TokenValidatorProducer.class, createNiceMock(TokenValidator.class)));
+            ObservedValidatorResolver resolver = new ObservedValidatorResolver(
+                    new TestConfig(Map.of()),
+                    validatorInstance(handles),
+                    valueInstance(new ArrayList<>()),
+                    valueInstance(ParserConfig.builder().build()));
+
+            assertEquals(ObservedValidatorResolver.Outcome.NOT_CONFIGURED, resolver.outcome(),
+                    "Nothing is observable on the first probe");
+            handles.add(new RecordingHandle(ForeignValidatorAlpha.class, createNiceMock(TokenValidator.class)));
+            handles.add(new RecordingHandle(ForeignValidatorBeta.class, createNiceMock(TokenValidator.class)));
+
+            assertEquals(ObservedValidatorResolver.Outcome.NOT_CONFIGURED, resolver.outcome(),
+                    "Ambiguous foreign validators must still resolve to NOT_CONFIGURED");
+            // The outcome never transitioned, so an outcome-gated warning would stay silent here
+            assertLogMessagePresentContaining(TestLogLevel.WARN, ForeignValidatorAlpha.class.getName());
+            assertLogMessagePresentContaining(TestLogLevel.WARN, ForeignValidatorBeta.class.getName());
+        }
+
+        @Test
         @DisplayName("should report NOT_CONFIGURED when no validator exists at all")
         void shouldReportNotConfiguredWithoutAnyValidator() {
             RecordingHandle producerHandle = new RecordingHandle(TokenValidatorProducer.class,

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/test/java/de/cuioss/sheriff/token/quarkus/observability/ObservedValidatorResolverTest.java
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/test/java/de/cuioss/sheriff/token/quarkus/observability/ObservedValidatorResolverTest.java
@@ -1,0 +1,307 @@
+/*
+ * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.token.quarkus.observability;
+
+import de.cuioss.sheriff.token.commons.transport.ParserConfig;
+import de.cuioss.sheriff.token.quarkus.config.JwtPropertyKeys;
+import de.cuioss.sheriff.token.quarkus.producer.TokenValidatorProducer;
+import de.cuioss.sheriff.token.quarkus.test.TestConfig;
+import de.cuioss.sheriff.token.validation.IssuerConfig;
+import de.cuioss.sheriff.token.validation.TokenValidator;
+import de.cuioss.test.juli.TestLogLevel;
+import de.cuioss.test.juli.junit5.EnableTestLogger;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.spi.Bean;
+import org.eclipse.microprofile.config.Config;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static de.cuioss.test.juli.LogAsserts.assertLogMessagePresentContaining;
+import static org.easymock.EasyMock.createNiceMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link ObservedValidatorResolver}, covering all four resolution branches without a
+ * CDI container.
+ */
+@DisplayName("ObservedValidatorResolver")
+@EnableTestLogger
+class ObservedValidatorResolverTest {
+
+    private static final String TEST_ISSUER = "test";
+
+    /** Stand-in bean classes for embedder-supplied validators. */
+    private static final class ForeignValidatorAlpha {
+    }
+
+    private static final class ForeignValidatorBeta {
+    }
+
+    @Nested
+    @DisplayName("Populated issuer namespace")
+    class PropertyConfigured {
+
+        @Test
+        @DisplayName("should observe the extension's own produced validator, issuer configs and parser config")
+        void shouldObserveProducedValidator() {
+            TokenValidator produced = createNiceMock(TokenValidator.class);
+            RecordingHandle producerHandle = new RecordingHandle(TokenValidatorProducer.class, produced);
+            List<IssuerConfig> producedIssuerConfigs = new ArrayList<>();
+            ParserConfig producedParserConfig = ParserConfig.builder().build();
+            ObservedValidatorResolver resolver = new ObservedValidatorResolver(
+                    configWithEnabledIssuer(),
+                    validatorInstance(producerHandle),
+                    valueInstance(producedIssuerConfigs),
+                    valueInstance(producedParserConfig));
+
+            assertAll("property-configured resolution",
+                    () -> assertEquals(ObservedValidatorResolver.Outcome.PROPERTY_CONFIGURED, resolver.outcome(),
+                            "Populated namespace must resolve to PROPERTY_CONFIGURED"),
+                    () -> assertSame(produced, resolver.observedValidator().orElseThrow(),
+                            "Observed validator must be the produced one"),
+                    () -> assertSame(producedIssuerConfigs, resolver.observedIssuerConfigs(),
+                            "Observed issuer configs must be the produced list"),
+                    () -> assertSame(producedParserConfig, resolver.observedParserConfig().orElseThrow(),
+                            "Observed parser config must be the produced one"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Empty issuer namespace")
+    class EmptyNamespace {
+
+        @Test
+        @DisplayName("should observe the single foreign validator without instantiating the extension's producer")
+        void shouldObserveSingleForeignValidator() {
+            TokenValidator foreign = createNiceMock(TokenValidator.class);
+            RecordingHandle producerHandle = new RecordingHandle(TokenValidatorProducer.class,
+                    createNiceMock(TokenValidator.class));
+            RecordingHandle foreignHandle = new RecordingHandle(ForeignValidatorAlpha.class, foreign);
+            ObservedValidatorResolver resolver = resolverOver(producerHandle, foreignHandle);
+
+            assertAll("external-validator resolution",
+                    () -> assertEquals(ObservedValidatorResolver.Outcome.EXTERNAL_VALIDATOR, resolver.outcome(),
+                            "A single foreign validator must resolve to EXTERNAL_VALIDATOR"),
+                    () -> assertSame(foreign, resolver.observedValidator().orElseThrow(),
+                            "Observed validator must be the foreign one"),
+                    () -> assertTrue(resolver.observedIssuerConfigs().isEmpty(),
+                            "A foreign validator exposes no issuer configurations"),
+                    () -> assertTrue(resolver.observedParserConfig().isEmpty(),
+                            "A foreign validator exposes no parser configuration"),
+                    () -> assertTrue(foreignHandle.wasGetInvoked(),
+                            "Positive control: the foreign handle must be resolved"),
+                    () -> assertFalse(producerHandle.wasGetInvoked(),
+                            "Negative control: the TokenValidatorProducer handle must never be get()-ed"));
+        }
+
+        @Test
+        @DisplayName("should report NOT_CONFIGURED and warn when several foreign validators exist")
+        void shouldRefuseToGuessBetweenForeignValidators() {
+            RecordingHandle producerHandle = new RecordingHandle(TokenValidatorProducer.class,
+                    createNiceMock(TokenValidator.class));
+            RecordingHandle alpha = new RecordingHandle(ForeignValidatorAlpha.class,
+                    createNiceMock(TokenValidator.class));
+            RecordingHandle beta = new RecordingHandle(ForeignValidatorBeta.class,
+                    createNiceMock(TokenValidator.class));
+            ObservedValidatorResolver resolver = resolverOver(producerHandle, alpha, beta);
+
+            ObservedValidatorResolver.Outcome outcome = resolver.outcome();
+
+            assertAll("ambiguous resolution",
+                    () -> assertEquals(ObservedValidatorResolver.Outcome.NOT_CONFIGURED, outcome,
+                            "Ambiguous foreign validators must resolve to NOT_CONFIGURED"),
+                    () -> assertTrue(resolver.observedValidator().isEmpty(),
+                            "No validator may be observed when the choice is ambiguous"),
+                    () -> assertFalse(producerHandle.wasGetInvoked(),
+                            "Negative control: the TokenValidatorProducer handle must never be get()-ed"),
+                    () -> assertFalse(alpha.wasGetInvoked(),
+                            "No candidate may be instantiated when the choice is ambiguous"),
+                    () -> assertFalse(beta.wasGetInvoked(),
+                            "No candidate may be instantiated when the choice is ambiguous"));
+            assertLogMessagePresentContaining(TestLogLevel.WARN, ForeignValidatorAlpha.class.getName());
+            assertLogMessagePresentContaining(TestLogLevel.WARN, ForeignValidatorBeta.class.getName());
+        }
+
+        @Test
+        @DisplayName("should report NOT_CONFIGURED when no validator exists at all")
+        void shouldReportNotConfiguredWithoutAnyValidator() {
+            RecordingHandle producerHandle = new RecordingHandle(TokenValidatorProducer.class,
+                    createNiceMock(TokenValidator.class));
+            ObservedValidatorResolver resolver = resolverOver(producerHandle);
+
+            assertAll("unconfigured resolution",
+                    () -> assertEquals(ObservedValidatorResolver.Outcome.NOT_CONFIGURED, resolver.outcome(),
+                            "An empty namespace with no foreign validator must resolve to NOT_CONFIGURED"),
+                    () -> assertTrue(resolver.observedValidator().isEmpty(),
+                            "No validator may be observed"),
+                    () -> assertTrue(resolver.observedIssuerConfigs().isEmpty(),
+                            "No issuer configuration may be observed"),
+                    () -> assertTrue(resolver.observedParserConfig().isEmpty(),
+                            "No parser configuration may be observed"),
+                    () -> assertFalse(producerHandle.wasGetInvoked(),
+                            "Negative control: the TokenValidatorProducer handle must never be get()-ed"));
+        }
+
+        @Test
+        @DisplayName("should pick up a validator that only becomes available after the first probe")
+        void shouldReResolveWhileNotConfigured() {
+            TokenValidator lateArrival = createNiceMock(TokenValidator.class);
+            List<Instance.Handle<TokenValidator>> handles = new ArrayList<>();
+            handles.add(new RecordingHandle(TokenValidatorProducer.class, createNiceMock(TokenValidator.class)));
+            ObservedValidatorResolver resolver = new ObservedValidatorResolver(
+                    new TestConfig(Map.of()),
+                    validatorInstance(handles),
+                    valueInstance(new ArrayList<>()),
+                    valueInstance(ParserConfig.builder().build()));
+
+            assertEquals(ObservedValidatorResolver.Outcome.NOT_CONFIGURED, resolver.outcome(),
+                    "Nothing is observable on the first probe");
+            handles.add(new RecordingHandle(ForeignValidatorAlpha.class, lateArrival));
+
+            assertAll("late-arriving validator",
+                    () -> assertEquals(ObservedValidatorResolver.Outcome.EXTERNAL_VALIDATOR, resolver.outcome(),
+                            "NOT_CONFIGURED must be re-resolved so a later validator is picked up"),
+                    () -> assertSame(lateArrival, resolver.observedValidator().orElseThrow(),
+                            "The late-arriving validator must become the observation target"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Pinned resolution")
+    class PinnedResolution {
+
+        @Test
+        @DisplayName("should report the pinned outcome without consulting CDI")
+        void shouldReportPinnedOutcome() {
+            TokenValidator validator = createNiceMock(TokenValidator.class);
+            ObservedValidatorResolver resolver = new ObservedValidatorResolver(
+                    ObservedValidatorResolver.Outcome.EXTERNAL_VALIDATOR, validator, List.of(), null);
+
+            assertAll("pinned resolution",
+                    () -> assertEquals(ObservedValidatorResolver.Outcome.EXTERNAL_VALIDATOR, resolver.outcome(),
+                            "Pinned outcome must be reported verbatim"),
+                    () -> assertSame(validator, resolver.observedValidator().orElseThrow(),
+                            "Pinned validator must be reported verbatim"),
+                    () -> assertTrue(resolver.observedIssuerConfigs().isEmpty(),
+                            "Pinned issuer configs must be reported verbatim"),
+                    () -> assertTrue(resolver.observedParserConfig().isEmpty(),
+                            "Pinned parser config must be reported verbatim"));
+        }
+
+        @Test
+        @DisplayName("should keep reporting NOT_CONFIGURED when pinned to it")
+        void shouldNotReResolvePinnedNotConfigured() {
+            ObservedValidatorResolver resolver = new ObservedValidatorResolver(
+                    ObservedValidatorResolver.Outcome.NOT_CONFIGURED, null, List.of(), null);
+
+            assertEquals(ObservedValidatorResolver.Outcome.NOT_CONFIGURED, resolver.outcome(),
+                    "A pinned NOT_CONFIGURED must never trigger a CDI lookup");
+            assertTrue(resolver.observedValidator().isEmpty(), "No validator may be observed");
+        }
+    }
+
+    private static ObservedValidatorResolver resolverOver(RecordingHandle... handles) {
+        return new ObservedValidatorResolver(
+                new TestConfig(Map.of()),
+                validatorInstance(List.of(handles)),
+                valueInstance(new ArrayList<>()),
+                valueInstance(ParserConfig.builder().build()));
+    }
+
+    private static Config configWithEnabledIssuer() {
+        return new TestConfig(Map.of(
+                JwtPropertyKeys.ISSUERS.ENABLED.formatted(TEST_ISSUER), "true",
+                JwtPropertyKeys.ISSUERS.ISSUER_IDENTIFIER.formatted(TEST_ISSUER), "https://example.com"));
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static Instance<TokenValidator> validatorInstance(List<? extends Instance.Handle<TokenValidator>> handles) {
+        Instance<TokenValidator> instance = createNiceMock(Instance.class);
+        // The raw cast side-steps the wildcard capture on Instance#handles(); the recorded call is unaffected
+        expect((Iterable) instance.handles()).andStubReturn(handles);
+        replay(instance);
+        return instance;
+    }
+
+    private static Instance<TokenValidator> validatorInstance(RecordingHandle handle) {
+        return validatorInstance(List.of(handle));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> Instance<T> valueInstance(T value) {
+        Instance<T> instance = createNiceMock(Instance.class);
+        expect(instance.get()).andStubReturn(value);
+        replay(instance);
+        return instance;
+    }
+
+    /**
+     * A {@link Instance.Handle} test double that records whether {@link #get()} was ever invoked, so
+     * the "the producer handle is never instantiated" invariant can be asserted directly.
+     */
+    private static final class RecordingHandle implements Instance.Handle<TokenValidator> {
+
+        private final Bean<TokenValidator> bean;
+        private final TokenValidator value;
+        private boolean getInvoked;
+
+        RecordingHandle(Class<?> beanClass, TokenValidator value) {
+            this.bean = beanOf(beanClass);
+            this.value = value;
+        }
+
+        @Override
+        public TokenValidator get() {
+            getInvoked = true;
+            return value;
+        }
+
+        @Override
+        public Bean<TokenValidator> getBean() {
+            return bean;
+        }
+
+        @Override
+        public void destroy() {
+            // no-op: the double owns no contextual instance
+        }
+
+        @Override
+        public void close() {
+            // no-op: the double owns no contextual instance
+        }
+
+        boolean wasGetInvoked() {
+            return getInvoked;
+        }
+
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        private static Bean<TokenValidator> beanOf(Class<?> beanClass) {
+            Bean<TokenValidator> bean = createNiceMock(Bean.class);
+            // The raw cast side-steps the wildcard capture on Bean#getBeanClass()
+            expect((Class) bean.getBeanClass()).andStubReturn(beanClass);
+            replay(bean);
+            return bean;
+        }
+    }
+}

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/test/java/de/cuioss/sheriff/token/quarkus/runtime/TokenSheriffDevUIRuntimeServiceTest.java
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/test/java/de/cuioss/sheriff/token/quarkus/runtime/TokenSheriffDevUIRuntimeServiceTest.java
@@ -18,6 +18,7 @@ package de.cuioss.sheriff.token.quarkus.runtime;
 import de.cuioss.sheriff.token.commons.transport.ParserConfig;
 import de.cuioss.sheriff.token.quarkus.config.JwtPropertyKeys;
 import de.cuioss.sheriff.token.quarkus.config.JwtTestProfile;
+import de.cuioss.sheriff.token.quarkus.observability.ObservedValidatorResolver;
 import de.cuioss.sheriff.token.quarkus.test.TestConfig;
 import de.cuioss.sheriff.token.quarkus.test.TestConfigurations;
 import de.cuioss.sheriff.token.validation.IssuerConfig;
@@ -63,6 +64,16 @@ class TokenSheriffDevUIRuntimeServiceTest {
 
     @Inject
     List<IssuerConfig> issuerConfigs;
+
+    /**
+     * Pins a resolver to the property-configured outcome over the supplied dependencies, mirroring
+     * what the CDI-wired resolver reports when the issuer namespace is populated.
+     */
+    private static ObservedValidatorResolver propertyConfigured(TokenValidator validator,
+            List<IssuerConfig> issuerConfigs) {
+        return new ObservedValidatorResolver(ObservedValidatorResolver.Outcome.PROPERTY_CONFIGURED,
+                validator, issuerConfigs, ParserConfig.builder().build());
+    }
 
 
     @Nested
@@ -251,7 +262,7 @@ class TokenSheriffDevUIRuntimeServiceTest {
         @DisplayName("Should attempt access token validation when JWT is enabled")
         void shouldAttemptAccessTokenValidationWhenJwtIsEnabled() {
             // Create a service with enabled JWT configuration to test the validation logic
-            TokenSheriffDevUIRuntimeService enabledService = new TokenSheriffDevUIRuntimeService(tokenValidator, issuerConfigs, ParserConfig.builder().build());
+            TokenSheriffDevUIRuntimeService enabledService = new TokenSheriffDevUIRuntimeService(propertyConfigured(tokenValidator, issuerConfigs));
 
             // Test with an invalid access token to see the validation attempt behavior
             // This tests that validation is attempted (not just disabled)
@@ -334,7 +345,7 @@ class TokenSheriffDevUIRuntimeServiceTest {
         @DisplayName("Should handle service with enabled issuer configuration")
         void shouldHandleServiceWithEnabledIssuerConfiguration() {
             // Create a service with enabled issuer configuration
-            TokenSheriffDevUIRuntimeService testService = new TokenSheriffDevUIRuntimeService(tokenValidator, issuerConfigs, ParserConfig.builder().build());
+            TokenSheriffDevUIRuntimeService testService = new TokenSheriffDevUIRuntimeService(propertyConfigured(tokenValidator, issuerConfigs));
 
             Map<String, Object> validationStatus = testService.getValidationStatus();
             Map<String, Object> configuration = testService.getConfiguration();
@@ -355,7 +366,7 @@ class TokenSheriffDevUIRuntimeServiceTest {
             List<IssuerConfig> issuerConfigsList = new ArrayList<>(issuerConfigs);
             // Duplicate, but we only test the size here
             issuerConfigsList.addAll(issuerConfigs);
-            TokenSheriffDevUIRuntimeService testService = new TokenSheriffDevUIRuntimeService(tokenValidator, issuerConfigsList, ParserConfig.builder().build());
+            TokenSheriffDevUIRuntimeService testService = new TokenSheriffDevUIRuntimeService(propertyConfigured(tokenValidator, issuerConfigsList));
 
             Map<String, Object> jwksStatus = testService.getJwksStatus();
 
@@ -367,9 +378,8 @@ class TokenSheriffDevUIRuntimeServiceTest {
         @Test
         @DisplayName("Should report healthy state for enabled configuration")
         void shouldDetermineHealthBasedOnDifferentConfigurations() {
-            // With a produced (guaranteed non-empty) issuer list, health is always UP —
-            // startup fails before this service exists when no enabled issuer is configured
-            TokenSheriffDevUIRuntimeService enabledService = new TokenSheriffDevUIRuntimeService(tokenValidator, issuerConfigs, ParserConfig.builder().build());
+            // A property-configured resolution keeps the configurationValid => UP contract
+            TokenSheriffDevUIRuntimeService enabledService = new TokenSheriffDevUIRuntimeService(propertyConfigured(tokenValidator, issuerConfigs));
 
             Map<String, Object> enabledHealth = enabledService.getHealthInfo();
             Boolean configurationValid = (Boolean) enabledHealth.get("configurationValid");
@@ -383,18 +393,23 @@ class TokenSheriffDevUIRuntimeServiceTest {
     class ConstructorTests {
 
         @Test
-        @DisplayName("Should create service with minimal dependencies")
-        void shouldCreateServiceWithMinimalDependencies() {
-            // The constructor performs no validation — it only stores its dependencies
-            assertDoesNotThrow(() -> new TokenSheriffDevUIRuntimeService(null, issuerConfigs, ParserConfig.builder().build()),
-                    "Constructor should not throw exception with null tokenValidator");
+        @DisplayName("Should create service over a resolver reporting NOT_CONFIGURED")
+        void shouldCreateServiceWithUnconfiguredResolver() {
+            // The constructor performs no validation — it only stores its dependency
+            TokenSheriffDevUIRuntimeService unconfiguredService = assertDoesNotThrow(
+                    () -> new TokenSheriffDevUIRuntimeService(new ObservedValidatorResolver(
+                            ObservedValidatorResolver.Outcome.NOT_CONFIGURED, null, List.of(), null)),
+                    "Constructor should not throw when nothing is observable");
+
+            assertEquals("NOT_CONFIGURED", unconfiguredService.getValidationStatus().get("status"),
+                    "An unconfigured resolver must surface as NOT_CONFIGURED rather than throwing");
         }
 
         @Test
         @DisplayName("Should create service with valid dependencies")
         void shouldCreateServiceWithValidDependencies() {
             // Test constructor with actual dependencies
-            TokenSheriffDevUIRuntimeService testService = new TokenSheriffDevUIRuntimeService(tokenValidator, issuerConfigs, ParserConfig.builder().build());
+            TokenSheriffDevUIRuntimeService testService = new TokenSheriffDevUIRuntimeService(propertyConfigured(tokenValidator, issuerConfigs));
             assertNotNull(testService, "Service should be created successfully with valid dependencies");
 
             // Verify the service can perform basic operations

--- a/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/test/java/de/cuioss/sheriff/token/quarkus/runtime/TokenSheriffDevUIRuntimeServiceUnitTest.java
+++ b/token-sheriff-quarkus-parent/token-sheriff-validation-quarkus/src/test/java/de/cuioss/sheriff/token/quarkus/runtime/TokenSheriffDevUIRuntimeServiceUnitTest.java
@@ -17,6 +17,7 @@ package de.cuioss.sheriff.token.quarkus.runtime;
 
 import de.cuioss.sheriff.token.commons.transport.LoaderStatus;
 import de.cuioss.sheriff.token.commons.transport.ParserConfig;
+import de.cuioss.sheriff.token.quarkus.observability.ObservedValidatorResolver;
 import de.cuioss.sheriff.token.validation.IssuerConfig;
 import de.cuioss.sheriff.token.validation.TokenType;
 import de.cuioss.sheriff.token.validation.TokenValidator;
@@ -42,6 +43,8 @@ import static org.junit.jupiter.api.Assertions.*;
 class TokenSheriffDevUIRuntimeServiceUnitTest {
 
     private static final String DISABLED_ISSUER = "https://disabled-issuer.example.com";
+    private static final String UNAVAILABLE_EXTERNAL_VALIDATOR = "unavailable (external validator)";
+    private static final String UNAVAILABLE_NOT_CONFIGURED = "unavailable (not configured)";
 
     private TestTokenHolder tokenHolder;
     private IssuerConfig issuerConfig;
@@ -65,8 +68,9 @@ class TokenSheriffDevUIRuntimeServiceUnitTest {
                 .parserConfig(ParserConfig.builder().build())
                 .issuerConfig(issuerConfig)
                 .build();
-        service = new TokenSheriffDevUIRuntimeService(tokenValidator,
-                List.of(issuerConfig, disabledIssuerConfig), ParserConfig.builder().build());
+        service = new TokenSheriffDevUIRuntimeService(new ObservedValidatorResolver(
+                ObservedValidatorResolver.Outcome.PROPERTY_CONFIGURED, tokenValidator,
+                List.of(issuerConfig, disabledIssuerConfig), ParserConfig.builder().build()));
     }
 
     @Test
@@ -83,14 +87,11 @@ class TokenSheriffDevUIRuntimeServiceUnitTest {
     @Test
     @DisplayName("getValidationStatus reports missing validator")
     void validationStatusWithoutValidator() {
-        TokenSheriffDevUIRuntimeService withoutValidator =
-                new TokenSheriffDevUIRuntimeService(null, List.of(issuerConfig), ParserConfig.builder().build());
-
-        Map<String, Object> status = withoutValidator.getValidationStatus();
+        Map<String, Object> status = unconfiguredService().getValidationStatus();
 
         assertEquals(true, status.get("enabled"));
         assertEquals(false, status.get("validatorPresent"));
-        assertEquals("ACTIVE", status.get("status"));
+        assertEquals("NOT_CONFIGURED", status.get("status"));
     }
 
     @Test
@@ -199,6 +200,94 @@ class TokenSheriffDevUIRuntimeServiceUnitTest {
 
         assertEquals(true, health.get("configurationValid"));
         assertEquals("UP", health.get("healthStatus"));
-        assertEquals("All JWT components are healthy and operational", health.get("message"));
+        assertEquals("All JWT components are healthy and operational (PROPERTY_CONFIGURED)",
+                health.get("message"));
+    }
+
+    @Test
+    @DisplayName("EXTERNAL_VALIDATOR marks both parserConfig-derived surfaces as unavailable")
+    void externalValidatorMarksParserSurfacesUnavailable() {
+        Map<String, Object> configuration = externalValidatorService().getConfiguration();
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> parser = (Map<String, Object>) configuration.get("parser");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> httpJwksLoader = (Map<String, Object>) configuration.get("httpJwksLoader");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> issuers = (Map<String, Object>) configuration.get("issuers");
+
+        assertAll("external validator configuration",
+                () -> assertEquals(UNAVAILABLE_EXTERNAL_VALIDATOR, parser.get("status"),
+                        "The parser section must carry the external-validator unavailability marker"),
+                () -> assertFalse(parser.containsKey("maxTokenSize"),
+                        "No parser field may be emitted without a parser configuration"),
+                () -> assertEquals(UNAVAILABLE_EXTERNAL_VALIDATOR, httpJwksLoader.get("sizeLimit"),
+                        "sizeLimit is the symmetric peer of the parser fields and carries the same marker"),
+                () -> assertTrue(issuers.isEmpty(), "A foreign validator exposes no issuer configurations"));
+    }
+
+    @Test
+    @DisplayName("EXTERNAL_VALIDATOR reports the external view state without throwing")
+    void externalValidatorReportsViewState() {
+        TokenSheriffDevUIRuntimeService externalService = externalValidatorService();
+
+        Map<String, Object> validationStatus = externalService.getValidationStatus();
+        Map<String, Object> jwksStatus = externalService.getJwksStatus();
+        Map<String, Object> health = externalService.getHealthInfo();
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> issuers = (List<Map<String, Object>>) jwksStatus.get("issuers");
+
+        assertAll("external validator view state",
+                () -> assertEquals("ACTIVE", validationStatus.get("status"),
+                        "A foreign validator is still an active validator"),
+                () -> assertEquals(true, validationStatus.get("validatorPresent"),
+                        "The foreign validator must be reported as present"),
+                () -> assertEquals("EXTERNAL_VALIDATOR", jwksStatus.get("status"),
+                        "JWKS status must name the external-validator outcome"),
+                () -> assertTrue(issuers.isEmpty(), "No issuer may be listed for a foreign validator"),
+                () -> assertEquals(true, health.get("configurationValid"),
+                        "An observable validator is a valid configuration"),
+                () -> assertEquals("UP", health.get("healthStatus"), "Health must stay UP"));
+    }
+
+    @Test
+    @DisplayName("NOT_CONFIGURED returns well-formed responses instead of throwing")
+    void notConfiguredReturnsWellFormedResponses() {
+        TokenSheriffDevUIRuntimeService unconfigured = unconfiguredService();
+
+        Map<String, Object> configuration = assertDoesNotThrow(unconfigured::getConfiguration,
+                "getConfiguration must not throw on an empty issuer list");
+        Map<String, Object> jwksStatus = unconfigured.getJwksStatus();
+        Map<String, Object> health = unconfigured.getHealthInfo();
+        Map<String, Object> validation = unconfigured.validateToken("any-token");
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> parser = (Map<String, Object>) configuration.get("parser");
+
+        assertAll("unconfigured view state",
+                () -> assertEquals(UNAVAILABLE_NOT_CONFIGURED, parser.get("status"),
+                        "The parser section must carry the not-configured unavailability marker"),
+                () -> assertFalse(parser.containsKey("clockSkewSeconds"),
+                        "The clock-skew read must be guarded against an empty issuer list"),
+                () -> assertEquals("NOT_CONFIGURED", jwksStatus.get("status"),
+                        "JWKS status must name the not-configured outcome"),
+                () -> assertEquals(false, health.get("configurationValid"),
+                        "Nothing observable is not a valid configuration"),
+                () -> assertEquals("DOWN", health.get("healthStatus"),
+                        "The DevUI service keeps its configurationValid => UP, else DOWN contract"),
+                () -> assertEquals(false, validation.get("valid"), "No token can be validated"),
+                () -> assertEquals("No validator configured", validation.get("error"),
+                        "validateToken must report the missing validator rather than throwing"));
+    }
+
+    private TokenSheriffDevUIRuntimeService externalValidatorService() {
+        return new TokenSheriffDevUIRuntimeService(new ObservedValidatorResolver(
+                ObservedValidatorResolver.Outcome.EXTERNAL_VALIDATOR, tokenValidator, List.of(), null));
+    }
+
+    private static TokenSheriffDevUIRuntimeService unconfiguredService() {
+        return new TokenSheriffDevUIRuntimeService(new ObservedValidatorResolver(
+                ObservedValidatorResolver.Outcome.NOT_CONFIGURED, null, List.of(), null));
     }
 }


### PR DESCRIPTION
## Summary

The Quarkus validation extension's observability beans — `TokenValidatorHealthCheck`,
`JwksEndpointHealthCheck`, `JwtMetricsCollector`, and the DevUI `TokenSheriffDevUIRuntimeService` —
now observe whichever `TokenValidator` is actually in use, instead of independently re-deriving
issuer state from `sheriff.token.issuers.*` properties via `IssuerConfigResolver`. An embedder that
produces its own differently-qualified `TokenValidator` (e.g. API Sheriff's `@GatewayValidator`
bean) no longer sees the extension's health probes go `DOWN` or its scheduled metrics collector
throw on every tick merely because the extension's own property namespace is unpopulated.

## Changes

- Added `ObservedValidatorResolver` (`de.cuioss.sheriff.token.quarkus.observability`), a new
  `@ApplicationScoped` bean that resolves which `TokenValidator` to observe — property-configured,
  foreign/external, or not-configured — without eagerly instantiating the extension's own producer.
- Extracted `IssuerConfigResolver.hasEnabledIssuers()` for a cheap, non-instantiating property
  probe reused by both the resolver and `resolveIssuerConfigs()`.
- Rewired `TokenValidatorHealthCheck`, `JwksEndpointHealthCheck`, `JwtMetricsCollector`, and
  `TokenSheriffDevUIRuntimeService` to consult `ObservedValidatorResolver` instead of injecting
  `TokenValidatorProducer`'s by-products; all four now degrade honestly (`EXTERNAL_VALIDATOR` /
  `NOT_CONFIGURED`) instead of throwing or reporting `DOWN`.
- Updated `qwc-jwt-status-config.js` (DevUI web component) and its jest mirrors/mocks
  (`qwc-jwt-status-config.test.js`, `mocks/devui.js`) to render explicit "unavailable" /
  "not configured" notices for the new `getConfiguration()` response shapes instead of
  `undefined bytes` / `undefined seconds`.
- Added `ForeignValidatorObservabilityTest`, a `@QuarkusTest` reproducing the embedder scenario
  end-to-end against the container's own wiring (empty property namespace, foreign qualified
  `TokenValidator`).
- Updated `health-checks.adoc`, `devui-implementation.adoc`, and `quarkus-integration.adoc` to
  describe the resolver-based behavior and the new `status` / `readiness` markers.

## Test Plan

- [ ] Verification command passed (`test -pl token-sheriff-quarkus-parent/token-sheriff-validation-quarkus -am`)
- [ ] Verification command passed (`npm run test --prefix=token-sheriff-quarkus-parent/token-sheriff-validation-quarkus-deployment`)
- [ ] Verification command passed (`npm run lint --prefix=token-sheriff-quarkus-parent/token-sheriff-validation-quarkus-deployment`)
- [ ] Manual testing completed (if applicable)

## Related Issues

Closes #641

---
Generated by plan-finalize skill

## Intent

**Problem**: The four observability beans injected `TokenValidatorProducer`'s by-products
(`List<IssuerConfig>`, `ParserConfig`, `SecurityEventCounter`, `TokenValidator`), which forced that
producer's `@PostConstruct init()` to run and throw whenever `sheriff.token.issuers.*` was
unpopulated — even when a perfectly good, differently-qualified `TokenValidator` was already
available from the embedder. That made the extension's optional observability surface a hard
dependency on its own property namespace.

**Approach**: introduce a single new seam, `ObservedValidatorResolver`, that answers "which
validator should be reported on, and is anything configured at all?" without instantiating the
extension's own producer. It probes the property namespace cheaply first (no instantiation), falls
back to enumerating CDI-visible `TokenValidator` producers (skipping its own), and reports an
explicit outcome (`PROPERTY_CONFIGURED` / `EXTERNAL_VALIDATOR` / `NOT_CONFIGURED`). All four
consumers rewire to this resolver and degrade honestly instead of failing.

**Non-goals**: this change does not touch `TokenValidator`'s builder or public API in the core
module — the health checks intentionally cannot enumerate a foreign validator's issuers or JWKS
loaders (an accepted, operator-confirmed limitation), reporting `status="observing external
validator"` rather than fabricating a verdict. It does

_[Intent truncated — 1396 of 1605 characters shown; full outline in the plan workspace]_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for observing externally supplied token validators.
  * Dev UI now identifies external-validator and unconfigured states with clear notices.
  * Health checks report validator status and issuer counts, including zero-configuration scenarios.
  * Token validation returns a clear response when no validator is available.

* **Bug Fixes**
  * Improved metrics handling when the active validator changes.
  * Prevented unavailable configuration values from being displayed misleadingly.
  * JWKS readiness remains healthy when no issuer configuration is observable.

* **Documentation**
  * Updated Dev UI, health-check, and integration documentation for all validator states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->